### PR TITLE
Make get-started work from the get-started page

### DIFF
--- a/src/templates/pages/get-started/index.hbs
+++ b/src/templates/pages/get-started/index.hbs
@@ -43,7 +43,7 @@ slug: get-started/
 &lt;html&gt;
   &lt;head&gt;
     &lt;meta charset=&quot;UTF-8&quot;&gt;
-    &lt;script src=&quot;//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.5/p5.min.js&quot;&gt;&lt;/script&gt;
+    &lt;script src=&quot;//cdnjs.cloudflare.com/ajax/libs/p5.js/[p5_version]/p5.min.js&quot;&gt;&lt;/script&gt;
     &lt;script language=&quot;javascript&quot; type=&quot;text/javascript&quot; src=&quot;sketch.js&quot;&gt;&lt;/script&gt;
     &lt;style&gt; body {padding: 0; margin: 0;} &lt;/style&gt;
   &lt;/head&gt;

--- a/src/templates/pages/get-started/index.hbs
+++ b/src/templates/pages/get-started/index.hbs
@@ -39,7 +39,18 @@ slug: get-started/
             p5.js CDN</a>{{#i18n "download6"}}{{/i18n}}
         </p>
 
-        <pre><code class="language-markup">&lt;script src="//cdnjs.cloudflare.com/ajax/libs/p5.js/0.0.0/p5.js">&lt;/script></code></pre>
+        <pre><code class="language-markup">
+&lt;html&gt;
+  &lt;head&gt;
+    &lt;meta charset=&quot;UTF-8&quot;&gt;
+    &lt;script src=&quot;//cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.5/p5.min.js&quot;&gt;&lt;/script&gt;
+    &lt;script language=&quot;javascript&quot; type=&quot;text/javascript&quot; src=&quot;sketch.js&quot;&gt;&lt;/script&gt;
+    &lt;style&gt; body {padding: 0; margin: 0;} &lt;/style&gt;
+  &lt;/head&gt;
+  &lt;body&gt;
+  &lt;/body&gt;
+&lt;/html&gt;
+        </code></pre>
       </div>
 
       <a name="environment" class="anchor">


### PR DESCRIPTION
I want to teach 10-12 year old kids but they need a quick start without downloading stuff and making mistakes. This will work when they can copy paste the CDN variant.

The CDN is currently https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.5/p5.min.js as checked on https://cdnjs.com/libraries/p5.js