### PR TITLE
Update 00_Load_and_Display_Image.js

### DIFF
--- a/src/data/examples/en/05_Image/00_Load_and_Display_Image.js
+++ b/src/data/examples/en/05_Image/00_Load_and_Display_Image.js
@@ -18,5 +18,6 @@ function draw() {
   // Displays the image at its actual size at point (0,0)
   image(img, 0, 0);
   // Displays the image at point (0, height/2) at half size
+  // TODO fix this
   image(img, 0, height/2, img.width/2, img.height/2);
 }


### PR DESCRIPTION
this example doesn't seem to run as expected. i would hope to see 2 images of different sizes, but i see 1 image. tested on Chrome latest on Windows 8.1

remove my `// TODO` when fixed