### PR TITLE
Fix broken links in tutorial-guide.hbs

### DIFF
--- a/src/templates/pages/tutorials/tutorial-guide.hbs
+++ b/src/templates/pages/tutorials/tutorial-guide.hbs
@@ -32,10 +32,10 @@ slug: tutorials/
 <p>Prepare the content of your tutorial as a tutorial-name.hbs file with this <a href="https://github.com/mayaman/p5js-website/blob/master/src/templates/pages/tutorials/test-tutorial.hbs">this basic structure</a>. As is shown in this file, it must contain a header as shown below:</p>
 <img src="{{assets}}/tutorials/tutorial-guide/images/screenshot-1.png" alt="Screenshot">
 
-<p>The folder containing your tutorial will be placed in the 'tutorials' folder of the p5js site.The file called index.hbs is the <a href=”http://p5js.org/tutorials/ “>p5js tutorials landing page,</a> and the test-tutorial.hbs file is the test tutorial. </p>
+<p>The folder containing your tutorial will be placed in the 'tutorials' folder of the p5js site.The file called index.hbs is the <a href="http://p5js.org/tutorials/">p5js tutorials landing page,</a> and the test-tutorial.hbs file is the test tutorial. </p>
 <p>All content should go in the:</br>
   &lt;section role="region" label="main content"&gt; &lt;/section&gt; </br>
-  tags on the page, with formatting defined by the &lt;h1&gt; and &lt;h2&gt; tags, the &lt;p&gt; paragraph tags as is done shown on the <a href=”https://github.com/processing/p5.js-website/blob/master/src/templates/pages/tutorials/test-tutorial.hbs”>test tutorial page.</a></p>
+  tags on the page, with formatting defined by the &lt;h1&gt; and &lt;h2&gt; tags, the &lt;p&gt; paragraph tags as is done shown on the <a href="https://github.com/processing/p5.js-website/blob/master/src/templates/pages/tutorials/test-tutorial.hbs">test tutorial page.</a></p>
 <p>If your tutorial contains images, they are to be placed in the assets folder of the p5 site, in the location src/assets/tutorials/test-tutorial/images as shown below.</p>
 <img src="{{assets}}/tutorials/tutorial-guide/images/screenshot-2.png" alt="Screenshot">
 <p>To correctly format code in the html of the page use the tag:</br>
@@ -52,7 +52,7 @@ Your code here!</br>
 <p>Using p5js means you can illustrate your tutorial with animated, interactive or editable code examples to demonstrate programming concepts. Your examples should be prepared as p5.js sketches and can be embedded into the tutorial in two ways.  </p>
 
 <p><ol>
-<li>If the example is to be editable like in <a href="http://p5js.org/reference/#/p5/ellipse">the reference pages</a> of the p5js site, the p5 sketch should be embedded into the html page using the p5js widget. Follow <a href=”https://toolness.github.io/p5.js-widget/”>this guide </a>on how to embed p5js sketches using the widgit written by <a href="https://github.com/toolness">Toolness</a>. You can also see this in action on the<a href=”https://github.com/processing/p5.js-website/blob/master/src/templates/pages/tutorials/test-tutorial.hbs”> test tutorial page.</a></li>
+<li>If the example is to be editable like in <a href="http://p5js.org/reference/#/p5/ellipse">the reference pages</a> of the p5js site, the p5 sketch should be embedded into the html page using the p5js widget. Follow <a href="https://toolness.github.io/p5.js-widget/">this guide </a>on how to embed p5js sketches using the widgit written by <a href="https://github.com/toolness">Toolness</a>. You can also see this in action on the<a href="https://github.com/processing/p5.js-website/blob/master/src/templates/pages/tutorials/test-tutorial.hbs"> test tutorial page.</a></li>
 <li>If the example is to be animated and/or interactive but not editable. The p5.js sketch should be embedded into the page as an iframe as described below.</li>
 </ol>
 <h2>Embed a p5 sketch using an iframe</h2>
@@ -90,7 +90,7 @@ Your code here!</br>
 
 <p>Also note that the links to the p5.js library files do not happen from the .eps page with all the tutorial content. Instead they will be located in the html page that is rendering your sketch (in this case, called embed.html). </p>
 
-<p>More information on embedding p5js sketches can be found <a href=”https://github.com/processing/p5.js/wiki/Embedding-p5.js“>here.</a></p>
+<p>More information on embedding p5js sketches can be found <a href="https://github.com/processing/p5.js/wiki/Embedding-p5.js">here.</a></p>
 <h2>Finishing Up</h2>
 <p>Once your have finished writing your tutorial and your content has been given the thumbs up. Fork the p5js website repository, prepare your content as described above and then issue a pull request to the p5js website repository so we can publish your contribution!</p>
 


### PR DESCRIPTION
Fix broken links in ```tutorial-guide.hbs```

A few links were broken in ```src/templates/pages/tutorials/tutorial-guide.hbs``` due to quotation marks. 

Example:

from (broken)

```”http://p5js.org/tutorials/ “```

to (working)

```"http://p5js.org/tutorials/"```