### PR TITLE
Remove `var text` as p5 shows a warning.

### DIFF
--- a/src/data/examples/en/09_Simulate/03_Flocking.js
+++ b/src/data/examples/en/09_Simulate/03_Flocking.js
@@ -10,8 +10,6 @@
 
 var flock;
 
-var text;
-
 function setup() {
   createCanvas(640,360);
   createP("Drag the mouse to generate new boids.");


### PR DESCRIPTION
FF: p5 had problems creating the global function "text", possibly because your code is already using that name as a variable. You may want to rename your variable to something else.