### PR TITLE
fix #104: speed up grunt imagemin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,7 +35,7 @@ module.exports = function(grunt) {
         ]
       },
       imagemin: {
-        files: '<%= config.dist %>/assets/img/*.{png,jpg,jpeg,gif,svg}',
+        files: '<%= config.src %>/assets/img/*.{png,jpg,jpeg,gif,svg}',
         tasks: ['newer:imagemin']
       },
       livereload: {
@@ -125,7 +125,7 @@ module.exports = function(grunt) {
     imagemin: {
       images: {
         options: {
-          optimizationLevel: 7
+          optimizationLevel: 2
         },
         files: [{
           expand: true,

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-connect": "^0.8.0",
     "grunt-contrib-copy": "^0.5.0",
-    "grunt-contrib-imagemin": "^1.0.1",
+    "grunt-contrib-imagemin": "^2.0.1",
     "grunt-contrib-uglify": "^2.0.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-exec": "^1.0.0",


### PR DESCRIPTION
I hadn't built the new p5 website since it migrated from the PHP version. It's great! But the imagemin task took a long time (9 min) to complete and this was a confusing initial developer experience. I looked into it a bit after filing https://github.com/processing/p5.js-website/issues/104 and it seems that we can do less optimization and still get the same benefits.

- Decrease imagemin optimization level from 7 (240 trials, ~9 min) to 2 (8 trials, ~10 seconds). Optimization level 2 says "you saved 2.17 MB - 16.8%" and that's about the best we can do, plus it's much faster than level 7.
- Point imagemin watch task to `src` directory
- Update imagemin dependency to version 2.0.1
- Resize a particularly large image that was making imagemin run slowly (in the future, resizing images makes a big difference)