### PR TITLE
Fixed link to issue site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a rebuild of the original p5.js website [p5js.org](https://p5js.org) using Grunt, YAML, and Assemble. The goals are to implement internationalization (i18n) and to improve site accessibility.
 
-**If you're looking for the current version of the website, it is here: https://github.com/processing/p5.js-website. You can report issues with that [here](https://github.com/processing/p5.js-website/issues]).**
+**If you're looking for the current version of the website, it is here: https://github.com/processing/p5.js-website. You can report issues with that [here](https://github.com/processing/p5.js-website/issues).**
 
 ## Setup
 


### PR DESCRIPTION
Quick fix of link to [p5.js-website issue site](https://github.com/processing/p5.js-website/issues) (goes to 404 page currently). Mostly as an excuse to finally get a p5.js dev environment set up. 😉 