### PR TITLE
Add note to README.md on contributing to the reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ Once you've setup the site, to run again in the future:
 
 * For english version, the site will follow the same top-level hierarchy as the original site. When you switch to a different language, the permalink and file structure will include a two letter abbreviation immediately following the root url. (ex: `https://p5js.org/es/get-started/`)
 
+## Updating the reference
 
+The documentation for p5.js is handled inline in the source code. 
+
+See [Inline documentation](https://github.com/processing/p5.js/wiki/Inline-documentation) in the p5.js repo for information on how to contribute.
 ## Notes about Examples
 
 The examples are handled a bit differently from other pages.


### PR DESCRIPTION
I recently fixed a formatting error in the p5.js docs and one of the issues I encountered was not knowing how to regenerate the docs from the p5 source code. My first instinct was to look through this repo, but I wasn't able to figure it out. Nobody in the coding train slack seemed to know how it was done either. I happened to stumble upon the inline documentation wiki page and figured it out.

Having this in the README.md would help others like me that want to contribute, but don't know how.

Have a great day!