### PR TITLE
Update link on community page

### DIFF
--- a/dist/community/index.html
+++ b/dist/community/index.html
@@ -152,7 +152,7 @@
 
       <p><b>Develop.</b> <a href="https://github.com/processing/p5.js" target="blank_">GitHub</a> is the main place where code is collected, issues are documented, and discussions about code are had. Check out the  <a href="https://github.com/processing/p5.js/wiki/Development" target="blank_"> development tutorial </a>  to get started, or  <a href="../libraries/#create-your-own"> create your own library. </a></p>
 
-      <p><b>Document.</b> Everyone loves documentation. Help is needed <a href="https://github.com/lmccart/p5js.org/wiki/Adding-examples" target="blank_">porting examples</a>, and<a href="https://github.com/processing/p5.js/wiki/Inline-documentation" target="blank_"> adding documentation</a>, and creating tutorials.</p>
+      <p><b>Document.</b> Everyone loves documentation. Help is needed <a href="https://github.com/processing/p5.js-website/wiki/Adding-examples" target="blank_">porting examples</a>, and<a href="https://github.com/processing/p5.js/wiki/Inline-documentation" target="blank_"> adding documentation</a>, and creating tutorials.</p>
 
       <p><b>Teach.</b> Check out the <a href="https://github.com/processing/p5.js/wiki/Education" target="blank_">education page</a> on the wiki to view resources from past classes, workshops, and events. Add your own links!</p>
 

--- a/dist/es/community/index.html
+++ b/dist/es/community/index.html
@@ -152,7 +152,7 @@
 
       <p><b>Desarrolla.</b> <a href="https://github.com/processing/p5.js" target="blank_">GitHub</a> es el principal lugar donde se almacena el código, se documentan los problemas y se discute sobre el código. Revisa el  <a href="https://github.com/processing/p5.js/wiki/Development" target="blank_"> tutorial de desarrollo </a>  para introducirte al tema, o  <a href="../libraries/#create-your-own"> crea tu propia librería. </a></p>
 
-      <p><b>Documenta.</b> Todos amamos la documentación. Se necesita ayuda <a href="https://github.com/lmccart/p5js.org/wiki/Adding-examples" target="blank_">portando ejemplos</a>, <a href="https://github.com/processing/p5.js/wiki/Inline-documentation" target="blank_"> añadiendo documentación</a> y creando tutoriales.</p>
+      <p><b>Documenta.</b> Todos amamos la documentación. Se necesita ayuda <a href="https://github.com/processing/p5.js-website/wiki/Adding-examples" target="blank_">portando ejemplos</a>, <a href="https://github.com/processing/p5.js/wiki/Inline-documentation" target="blank_"> añadiendo documentación</a> y creando tutoriales.</p>
 
       <p><b>Enseña.</b> Revisa la <a href="https://github.com/processing/p5.js/wiki/Education" target="blank_">página de educación</a> en la wiki para encontrar recursos de clases pasadas, talleres y eventos. ¡Agrega tus propios enlaces!</p>
 

--- a/src/templates/pages/community/index.hbs
+++ b/src/templates/pages/community/index.hbs
@@ -55,7 +55,7 @@ slug: community/
 
       <p><b>{{#i18n "develop-title"}}{{/i18n}}</b> <a href="https://github.com/processing/p5.js" target="blank_">{{#i18n "develop1"}}{{/i18n}}</a>{{#i18n "develop2"}}{{/i18n}} <a href="https://github.com/processing/p5.js/wiki/Development" target="blank_">{{#i18n "develop3"}}{{/i18n}} </a> {{#i18n "develop4"}}{{/i18n}} <a href="../libraries/#create-your-own"> {{#i18n "develop5"}}{{/i18n}} </a></p>
 
-      <p><b>{{#i18n "document-title"}}{{/i18n}}</b>{{#i18n "document1"}}{{/i18n}}<a href="https://github.com/lmccart/p5js.org/wiki/Adding-examples" target="blank_">{{#i18n "document2"}}{{/i18n}}</a>{{#i18n "document3"}}{{/i18n}}<a href="https://github.com/processing/p5.js/wiki/Inline-documentation" target="blank_">{{#i18n "document4"}}{{/i18n}}</a>{{#i18n "document5"}}{{/i18n}}</p>
+      <p><b>{{#i18n "document-title"}}{{/i18n}}</b>{{#i18n "document1"}}{{/i18n}}<a href="https://github.com/processing/p5.js-website/wiki/Adding-examples" target="blank_">{{#i18n "document2"}}{{/i18n}}</a>{{#i18n "document3"}}{{/i18n}}<a href="https://github.com/processing/p5.js/wiki/Inline-documentation" target="blank_">{{#i18n "document4"}}{{/i18n}}</a>{{#i18n "document5"}}{{/i18n}}</p>
 
       <p><b>{{#i18n "teach-title"}}{{/i18n}}</b>{{#i18n "teach1"}}{{/i18n}}<a href="https://github.com/processing/p5.js/wiki/Education" target="blank_">{{#i18n "teach2"}}{{/i18n}}</a>{{#i18n "teach3"}}{{/i18n}}</p>
 


### PR DESCRIPTION
I updated the "porting examples" link so it points to the new repo instead of the archived version. 