### PR TITLE
replace flash slideshow, fix  community header collapse

### DIFF
--- a/dist/community/index.html
+++ b/dist/community/index.html
@@ -165,8 +165,7 @@
       <p>In 2015, p5.js held its first-ever <a href="/contributors-conference">contributors conference</a>. Artists, designers, developers, educators, and more joined forces at <a href="http://studioforcreativeinquiry.org/">CMU's Studio for Creative Inquiry</a> to make p5.js awesome.
       </p>
 
-      <object width="720" height="480" classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"  codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=6,0,40,0"> <param name="flashvars" value="offsite=true&amp;lang=en-us&amp;page_show_url=%2Fphotos%2F80913365%40N04%2Fsets%2F72157653238862069%2Fshow&amp;page_show_back_url=%2Fphotos%2F80913365%40N04%2Fsets%2F72157653238862069%2F&amp;user_id=80913365@N04&amp;set_id=72157653238862069" /> <param name="allowFullScreen" value="true" /> <param name="src" value="https://www.flickr.com/apps/slideshow/show.swf?v=71649" /> <embed width="720" height="480" type="application/x-shockwave-flash" src="https://www.flickr.com/apps/slideshow/show.swf?v=71649" flashvars="offsite=true&amp;lang=en-us&amp;page_show_url=%2Fphotos%2F80913365%40N04%2Fsets%2F72157653238862069%2Fshow&amp;page_show_back_url=%2Fphotos%2F80913365%40N04%2Fsets%2F72157653238862069%2F&amp;user_id=80913365@N04&amp;set_id=72157653238862069" allowFullScreen="true" /> </object>
-
+      <a data-flickr-embed="true"  href="https://www.flickr.com/photos/80913365@N04/albums/72157653238862069" title="p5.js conference"><img class="slideshow-image" src="https://farm8.staticflickr.com/7758/18210867280_9a2bc946c9_z.jpg" width="720" height="480" alt="p5.js conference"></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
 
       <h2>Mailing list</h2>
       <div class="email-octopus-form-wrapper">
@@ -188,6 +187,7 @@
       </div>
       <script src="https://emailoctopus.com/bundles/emailoctopuslist/js/formEmbed.js"></script>
       <style>
+
         .email-octopus-email-address {
           color:#ED225D;
           text-decoration: none;
@@ -197,7 +197,7 @@
           border-bottom: 0.11em dashed;
           border-bottom-color: #ED225D;
           transition: border-bottom 30ms linear;
-          width: 20em;
+          width: 13em;
         }
         .email-octopus-form-row-subscribe button, .email-octopus-form-row-hp {
           position: absolute;
@@ -207,6 +207,14 @@
         .email-octopus-email-address::-moz-placeholder { color:#ABABAB; }
         .email-octopus-email-address:-moz-placeholder { color:#ABABAB; }
         .email-octopus-email-address:-ms-input-placeholder { color:#ABABAB; }
+
+        @media (min-width: 720px) {
+          .email-octopus-email-address {
+            width: 20em;
+          }
+
+        }
+
       </style>
       <br><br>
     </section>

--- a/dist/es/community/index.html
+++ b/dist/es/community/index.html
@@ -165,8 +165,7 @@
       <p>En 2015, p5.js organizó su primera <a href="/es/contributors-conference">conferencia de colaboradores</a>. Artistas, diseñadores, programadores, educadores y más unieron fuerzas en el <a href="http://studioforcreativeinquiry.org/">CMU's Studio for Creative Inquiry</a> para mejorar p5.js.
       </p>
 
-      <object width="720" height="480" classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"  codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=6,0,40,0"> <param name="flashvars" value="offsite=true&amp;lang=en-us&amp;page_show_url=%2Fphotos%2F80913365%40N04%2Fsets%2F72157653238862069%2Fshow&amp;page_show_back_url=%2Fphotos%2F80913365%40N04%2Fsets%2F72157653238862069%2F&amp;user_id=80913365@N04&amp;set_id=72157653238862069" /> <param name="allowFullScreen" value="true" /> <param name="src" value="https://www.flickr.com/apps/slideshow/show.swf?v=71649" /> <embed width="720" height="480" type="application/x-shockwave-flash" src="https://www.flickr.com/apps/slideshow/show.swf?v=71649" flashvars="offsite=true&amp;lang=en-us&amp;page_show_url=%2Fphotos%2F80913365%40N04%2Fsets%2F72157653238862069%2Fshow&amp;page_show_back_url=%2Fphotos%2F80913365%40N04%2Fsets%2F72157653238862069%2F&amp;user_id=80913365@N04&amp;set_id=72157653238862069" allowFullScreen="true" /> </object>
-
+      <a data-flickr-embed="true"  href="https://www.flickr.com/photos/80913365@N04/albums/72157653238862069" title="p5.js conference"><img class="slideshow-image" src="https://farm8.staticflickr.com/7758/18210867280_9a2bc946c9_z.jpg" width="720" height="480" alt="p5.js conference"></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
 
       <h2>Boletín</h2>
       <div class="email-octopus-form-wrapper">
@@ -188,6 +187,7 @@
       </div>
       <script src="https://emailoctopus.com/bundles/emailoctopuslist/js/formEmbed.js"></script>
       <style>
+
         .email-octopus-email-address {
           color:#ED225D;
           text-decoration: none;
@@ -197,7 +197,7 @@
           border-bottom: 0.11em dashed;
           border-bottom-color: #ED225D;
           transition: border-bottom 30ms linear;
-          width: 20em;
+          width: 13em;
         }
         .email-octopus-form-row-subscribe button, .email-octopus-form-row-hp {
           position: absolute;
@@ -207,6 +207,14 @@
         .email-octopus-email-address::-moz-placeholder { color:#ABABAB; }
         .email-octopus-email-address:-moz-placeholder { color:#ABABAB; }
         .email-octopus-email-address:-ms-input-placeholder { color:#ABABAB; }
+
+        @media (min-width: 720px) {
+          .email-octopus-email-address {
+            width: 20em;
+          }
+
+        }
+
       </style>
       <br><br>
     </section>

--- a/src/templates/pages/community/index.hbs
+++ b/src/templates/pages/community/index.hbs
@@ -68,8 +68,7 @@ slug: community/
       <p>{{#i18n "contributors-conference1"}}{{/i18n}}<a href="{{root}}/contributors-conference">{{#i18n "contributors-conference2"}}{{/i18n}}</a>{{#i18n "contributors-conference3"}}{{/i18n}}<a href="http://studioforcreativeinquiry.org/">{{#i18n "contributors-conference4"}}{{/i18n}}</a>{{#i18n "contributors-conference5"}}{{/i18n}}
       </p>
 
-      <object width="720" height="480" classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000"  codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=6,0,40,0"> <param name="flashvars" value="offsite=true&amp;lang=en-us&amp;page_show_url=%2Fphotos%2F80913365%40N04%2Fsets%2F72157653238862069%2Fshow&amp;page_show_back_url=%2Fphotos%2F80913365%40N04%2Fsets%2F72157653238862069%2F&amp;user_id=80913365@N04&amp;set_id=72157653238862069" /> <param name="allowFullScreen" value="true" /> <param name="src" value="https://www.flickr.com/apps/slideshow/show.swf?v=71649" /> <embed width="720" height="480" type="application/x-shockwave-flash" src="https://www.flickr.com/apps/slideshow/show.swf?v=71649" flashvars="offsite=true&amp;lang=en-us&amp;page_show_url=%2Fphotos%2F80913365%40N04%2Fsets%2F72157653238862069%2Fshow&amp;page_show_back_url=%2Fphotos%2F80913365%40N04%2Fsets%2F72157653238862069%2F&amp;user_id=80913365@N04&amp;set_id=72157653238862069" allowFullScreen="true" /> </object>
-
+      <a data-flickr-embed="true"  href="https://www.flickr.com/photos/80913365@N04/albums/72157653238862069" title="p5.js conference"><img class="slideshow-image" src="https://farm8.staticflickr.com/7758/18210867280_9a2bc946c9_z.jpg" width="720" height="480" alt="p5.js conference"></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
 
       <h2>{{#i18n "mailing-list-title"}}{{/i18n}}</h2>
       <div class="email-octopus-form-wrapper">
@@ -91,6 +90,7 @@ slug: community/
       </div>
       <script src="https://emailoctopus.com/bundles/emailoctopuslist/js/formEmbed.js"></script>
       <style>
+
         .email-octopus-email-address {
           color:#ED225D;
           text-decoration: none;
@@ -100,7 +100,7 @@ slug: community/
           border-bottom: 0.11em dashed;
           border-bottom-color: #ED225D;
           transition: border-bottom 30ms linear;
-          width: 20em;
+          width: 13em;
         }
         .email-octopus-form-row-subscribe button, .email-octopus-form-row-hp {
           position: absolute;
@@ -110,6 +110,14 @@ slug: community/
         .email-octopus-email-address::-moz-placeholder { color:#ABABAB; }
         .email-octopus-email-address:-moz-placeholder { color:#ABABAB; }
         .email-octopus-email-address:-ms-input-placeholder { color:#ABABAB; }
+
+        @media (min-width: 720px) {
+          .email-octopus-email-address {
+            width: 20em;
+          }
+
+        }
+
       </style>
       <br><br>
     </section>


### PR DESCRIPTION
Flickr flash slideshow prompted users to enable flash on desktop, and it did not load on mobile. To fix, I replaced this with Flickr's embed slideshow feature (code can be found on album's [Flickr page](https://www.flickr.com/photos/80913365@N04/sets/72157653238862069/), and selecting "share album").

Reduced the size of the email input box for mobile, as it was wider than the page on some devices and causing the header to collapse.