### PR TITLE
Make particle system example more idiomatic

### DIFF
--- a/src/data/examples/en/09_Simulate/02_ParticleSystem.js
+++ b/src/data/examples/en/09_Simulate/02_ParticleSystem.js
@@ -21,7 +21,7 @@ var Particle = function(position) {
   this.acceleration = createVector(0, 0.05);
   this.velocity = createVector(random(-1, 1), random(-1, 0));
   this.position = position.copy();
-  this.lifespan = 255.0;
+  this.lifespan = 255;
 };
 
 Particle.prototype.run = function() {
@@ -46,11 +46,7 @@ Particle.prototype.display = function() {
 
 // Is the particle still useful?
 Particle.prototype.isDead = function(){
-  if (this.lifespan < 0) {
-    return true;
-  } else {
-    return false;
-  }
+  return this.lifespan < 0;
 };
 
 var ParticleSystem = function(position) {


### PR DESCRIPTION
This PR includes two things:

In one case, 255 was written as `255.0`. Though both are valid, I fear that doing examples with a 255.0 in them - which have other numbers, like the ellipse size, as `12` (without a decimal part) might lead some people astray in thinking that 255 is not the same thing as 255.0.

The other thing is the

```
if (expression) {
  return true;
} else {
  return false;
}
```

My thinking with that one is that, like the `.0`, the `(expr) ? true : false` can delay the learning of the fact that, well - the `true` or `false` that's generated by that `this.lifespan < 0` expression is just as real and usable as a true or false you write out as a literal.

Both of these are, of course, pretty opinionated, so if what I'm seeing doesn't match up with the p5.js ethos, no worries if it doesn't fit.