### PR TITLE
Add version-sample.json as discussed in issue #185

### DIFF
--- a/dist/download/version-sample.json
+++ b/dist/download/version-sample.json
@@ -1,0 +1,1 @@
+{"version":"0.6.0","date":"January 19, 2018","editor_version":"0.6.2"}


### PR DESCRIPTION
Following instructions in README.md, it references a file /dist/download/version-sample.json, which has been deleted from the repository at some point. 

I've guessed the values of `version` and `date` based on the current website. The `editor_version` I've left at 0.6.2, which is the last version of the deprecated desktop editor. I assume that this will be removed at some point as all the code that references it seems to be commented out currently. 

The site will build without this file but the version information will not be included in the download box. There is also an earlier issue (#64) in which not having it seemed to cause problems internationalisation, but I didn't reproduce this.  