### PR TITLE
Set the title of the reference page based on topic

### DIFF
--- a/dist/reference/assets/js/reference.js
+++ b/dist/reference/assets/js/reference.js
@@ -4212,6 +4212,9 @@ define('itemView',[
 
         renderCode();
 
+        // Set the document title
+        App.pageView.appendToDocumentTitle(item.name);
+
         // Hook up alt-text for examples
         setTimeout(function() {
           var alts = $('.example-content')[0];
@@ -4498,6 +4501,9 @@ define('pageView',[
   'libraryView'
 ], function(App, searchView, listView, itemView, menuView, libraryView) {
 
+  // Store the original title so we can append different names later on.
+  var _originalDocumentTitle = window.document.title;
+
   var pageView = Backbone.View.extend({
     el: 'body',
     /**
@@ -4561,6 +4567,17 @@ define('pageView',[
       });
 
       return this;
+    },
+    /**
+     * Append the supplied name to the original document title.
+     * If no name is supplied, the title will reset to the original one.
+     */
+    appendToDocumentTitle: function(name){
+      if(name){
+        window.document.title = _originalDocumentTitle + " | " + name;
+      } else {
+        window.document.title = _originalDocumentTitle;
+      }
     }
   });
 


### PR DESCRIPTION
This pull request is in response to issue #38.

This pull request adds a function to reference.js, App.pageView.appendToDocumentTitle, which will append the name you give it to the title of the document. This is called from the itemView when it loads, with the name of the item (if it has one) as an argument. This means that when browsing topics in the reference pages, you will more easily be able to see which tab has which topic. 

![image](https://user-images.githubusercontent.com/92529/38766817-0fae9d8c-401b-11e8-99cb-975d19468639.png)

The discussion of the issue raises SEO as a disincentive for using javascript to change the title, but I can't see any other way to do it considering the way the reference is currently generated and loaded. I have tested that this works on Chrome and also with the English and Spanish versions of the reference docs. It seems to work, but more testing is probably a good idea :). 

I am not committing /dist/es/reference/assets/js/reference.js, because it will be copied from this file by grunt when the assembling task is run.

**Note:** this does not add the function for the offline-reference, because the grunt task for that copies over reference.js with a slightly different version from /offline-reference/extra/js/reference.js. I wanted to keep this pull request as minimal as possible, so I didn't want to update the other file as well and it seems like it might be a mistake that this file is getting copied over... 

If you would prefer that I replicate the changes in /offline-reference/extra/js/reference.js, let me know and I will amend the pull request. 