### PR TITLE
Append reference topic to shortened document title

### DIFF
--- a/dist/reference/assets/js/reference.js
+++ b/dist/reference/assets/js/reference.js
@@ -4212,6 +4212,9 @@ define('itemView',[
 
         renderCode();
 
+        // Set the document title
+        App.pageView.appendToDocumentTitle(item.name);
+
         // Hook up alt-text for examples
         setTimeout(function() {
           var alts = $('.example-content')[0];
@@ -4498,6 +4501,9 @@ define('pageView',[
   'libraryView'
 ], function(App, searchView, listView, itemView, menuView, libraryView) {
 
+  // Store the original title so we can append different names later on.
+  var _originalDocumentTitle = window.document.title;
+
   var pageView = Backbone.View.extend({
     el: 'body',
     /**
@@ -4561,6 +4567,17 @@ define('pageView',[
       });
 
       return this;
+    },
+    /**
+     * Append the supplied name to the original document title.
+     * If no name is supplied, the title will reset to the original one.
+     */
+    appendToDocumentTitle: function(name){
+      if(name){
+        window.document.title = _originalDocumentTitle + " | " + name;
+      } else {
+        window.document.title = _originalDocumentTitle;
+      }
     }
   });
 

--- a/dist/reference/assets/js/reference.js
+++ b/dist/reference/assets/js/reference.js
@@ -4212,8 +4212,14 @@ define('itemView',[
 
         renderCode();
 
-        // Set the document title
-        App.pageView.appendToDocumentTitle(item.name);
+        // Set the document title.
+        // If it is a method, add parentheses to the name
+        if (item.itemtype === "method"){
+            App.pageView.appendToDocumentTitle(item.name + "()");
+        }
+        else {
+            App.pageView.appendToDocumentTitle(item.name);
+        }
 
         // Hook up alt-text for examples
         setTimeout(function() {
@@ -4501,7 +4507,7 @@ define('pageView',[
   'libraryView'
 ], function(App, searchView, listView, itemView, menuView, libraryView) {
 
-  // Store the original title so we can append different names later on.
+  // Store the original title parts so we can substitue different endings.
   var _originalDocumentTitle = window.document.title;
 
   var pageView = Backbone.View.extend({
@@ -4569,12 +4575,13 @@ define('pageView',[
       return this;
     },
     /**
-     * Append the supplied name to the original document title.
+     * Append the supplied name to the first part of original document title.
      * If no name is supplied, the title will reset to the original one.
      */
     appendToDocumentTitle: function(name){
       if(name){
-        window.document.title = _originalDocumentTitle + " | " + name;
+        let firstTitlePart = _originalDocumentTitle.split(" | ")[0];
+        window.document.title = [firstTitlePart, name].join(" | ");
       } else {
         window.document.title = _originalDocumentTitle;
       }


### PR DESCRIPTION
This PR is related to #187 and responds to the comment there from @trych that it would be preferable for reference titles to drop the 'reference' part when displaying help on a method, constant, class or variable, as shown in the following screen grab. 

![image](https://user-images.githubusercontent.com/92529/38772813-aea62196-4082-11e8-9756-f35f56ff09d7.png)

I have made this a separate pull request rather than adjusting the previous one so that you can choose the one that best suits your needs. 
