### PR TITLE
Fix potential out of bounds error when showing tagline

### DIFF
--- a/src/assets/js/init.js
+++ b/src/assets/js/init.js
@@ -63,9 +63,11 @@ window.onload = function() {
     }
   }
   if (tagInd !== -1) {
-    var taglines = document.getElementsByClassName('tagline'); //divsToHide is an array
-    var taglineInd = Math.floor(6 * Math.random());
-    taglines[taglineInd].style.display = 'block';
+    var taglines = document.getElementsByClassName('tagline');
+    if (taglines.length) {
+      var taglineInd = Math.floor(taglines.length * Math.random());
+      taglines[taglineInd].style.display = 'block';
+    }
   }
 
 


### PR DESCRIPTION
The list of taglines apparently is not 6 elements long, so this currently throws

```
init.js:68 Uncaught TypeError: Cannot read property 'style' of undefined
    at window.onload (init.js:68)
```

quite often, making the script stop at that point.

See: https://github.com/processing/p5.js/pull/2871