### PR TITLE
Fix CSS and JS for scrolling of side menu to fix issue #189

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1738,10 +1738,11 @@ footer {
         /*float:left;*/
         border-top: transparent;
         border-bottom: transparent;
-        height: 14.25em;
         padding:1.25em 0;
         font-size: 0.92em;
         z-index: 100;
+        position: relative;
+        top: 0;
     }
 
     #menu li {

--- a/src/assets/js/scroll.js
+++ b/src/assets/js/scroll.js
@@ -27,6 +27,7 @@ $(function() {
   var $window           = $(window),
       $sidebar          = $("#menu"),
       sidebarOffset     = $sidebar.offset(),
+      finalTop          = 0;
       $rotationElements = $([
         '#download-page #asterisk-design-element',
         '#reference-page #asterisk-design-element'
@@ -37,20 +38,37 @@ $(function() {
     return window.matchMedia("(min-width: 720px)").matches;
   };
 
+  // Calculate what the top for the sidebar should be.
+  var getNewTop = function(){
+    return Math.max($window.scrollTop() - sidebarOffset.top, 0);
+  }
+
   // Change sidebar position:
-  var setSidebarPosition = function() {
-    if ($window.scrollTop() > sidebarOffset.top) {
-      $sidebar.stop().animate({
-        marginTop: $window.scrollTop() - sidebarOffset.top
-      });
-    } else {
-      $sidebar.stop().animate({
-        marginTop: 0
-      });
+  var setSidebarPosition = function(newTop) {
+    // Calculate new top if none passed in.
+    newTop = newTop || getNewTop();
+
+    // If it is already animating, return. This makes the animation less choppy.
+    // It will pick up the final top when the current animation ends.
+    finalTop = newTop;
+    if ($sidebar.is(':animated')){
+      return;
     }
+
+    $sidebar.animate({top: newTop}, { 
+      easing: 'linear',
+      duration: 100,
+      complete: function(){
+        // Go again if a new final top has been set since animation started.
+        if (newTop != finalTop){
+          setSidebarPosition(finalTop);
+        }
+      }
+    });
   };
-  if (isWidescreen() && $window.scrollTop() > sidebarOffset.top) {
-    $sidebar.css('margin-top', $window.scrollTop() - sidebarOffset.top);
+  
+  if (isWidescreen()){
+    $sidebar.css('top', getNewTop());
   }
 
   // Rotate specific elements:
@@ -65,7 +83,7 @@ $(function() {
 
   $window.scroll(function() {
     if (isWidescreen()) {
-      //setSidebarPosition(); // temp to stop buggy scrolling
+      setSidebarPosition();
       rotateElements();
     }
   });

--- a/src/assets/js/scroll.js
+++ b/src/assets/js/scroll.js
@@ -27,7 +27,6 @@ $(function() {
   var $window           = $(window),
       $sidebar          = $("#menu"),
       sidebarOffset     = $sidebar.offset(),
-      finalTop          = 0;
       $rotationElements = $([
         '#download-page #asterisk-design-element',
         '#reference-page #asterisk-design-element'
@@ -45,21 +44,21 @@ $(function() {
 
   // Change sidebar position:
   var setSidebarPosition = function(newTop) {
-    // Calculate new top if none passed in.
-    newTop = newTop || getNewTop();
-
     // If it is already animating, return. This makes the animation less choppy.
     // It will pick up the final top when the current animation ends.
-    finalTop = newTop;
     if ($sidebar.is(':animated')){
       return;
     }
+
+    // Calculate new top if none passed in.
+    newTop = newTop || getNewTop();
 
     $sidebar.animate({top: newTop}, { 
       easing: 'linear',
       duration: 100,
       complete: function(){
-        // Go again if a new final top has been set since animation started.
+        // Go again if a subsequent scroll has changed the final top.
+        var finalTop = getNewTop();
         if (newTop != finalTop){
           setSidebarPosition(finalTop);
         }


### PR DESCRIPTION
This PR is to address issue #189. 

I think the problem @lmccart describes with the animation causing the page scrolling to creep was due to the fact that it was animated on `marginTop`. I changed the animation to work on `top` instead (and set `position: relative` on the menu so that this works). 

I also adjusted the animation code slightly, so it animates a bit smoother (I don't stop the animation each time a scroll event happens).

I have only had time to test this on chrome and on the libraries page, but it seems to work ok. I was easily able to reproduce the bug that @lmccart described and it didn't come back after the fix.

Let me know if you need any more info. 