### PR TITLE
Fix npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,15 @@
 0. Install [node.js](https://nodejs.org/en/download/).
 1. Download this zip file or [clone this repository](https://help.github.com/articles/cloning-a-repository/) and navigate to the directory in the terminal.
 2. Type `npm install`.
-2. Rename `dist\download\version-sample.json` to `dist\download\version.json`.
-2. Type `npm install -g grunt-cli` to enable grunt.
-2. Type `grunt server` to run.
+2. Copy `dist\download\version-sample.json` to `dist\download\version.json`.
+2. Type `npm run watch` to run.
 3. This should open a window in your browser with the site running at http://localhost:9000.
 
 ## Running
 
 Once you've setup the site, to run again in the future:
 
-1. Type `grunt server` to run.
+1. Type `npm run watch` to run.
 2. This should open a window in your browser with the site running at http://localhost:9000.
 
 ## File structure
@@ -71,7 +70,7 @@ The examples are handled a bit differently from other pages.
 * The folder, file, and numbering structure should match exactly between the different languages. Do not change the filenames. The text for the example name, description, and source code are all in the .js files in the folders.
 * Assets for the examples are placed in `src/data/examples/assets`.
 * Translations for the topic headers on the example index page are done in the YAML files (`src/data/*.yml`).
-* When adding a new example, first add an english version of the file to the `en/` folder, then make sure it is duplicated in the same place in all other languages, then translate for whichever languages you can. If you have created a new folder, add entries to the YAML files with the foldername as the key.
+* When adding a new example, first add an English version of the file to the `en/` folder, then make sure it is duplicated in the same place in all other languages, then translate for whichever languages you can. If you have created a new folder, add entries to the YAML files with the foldername as the key.
 
 ## Documentation
 

--- a/dist/download/version-sample.json
+++ b/dist/download/version-sample.json
@@ -1,0 +1,1 @@
+{"version":"0.6.0","date":"January 19, 2018","editor_version":"0.6.2"}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3580,6 +3580,66 @@
         }
       }
     },
+    "grunt-cli": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
+      "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
+      "dev": true,
+      "requires": {
+        "findup-sync": "~0.3.0",
+        "grunt-known-options": "~1.1.0",
+        "nopt": "~3.0.6",
+        "resolve": "~1.1.0"
+      },
+      "dependencies": {
+        "findup-sync": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+          "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+          "dev": true,
+          "requires": {
+            "glob": "~5.0.0"
+          }
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+          "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
+        }
+      }
+    },
     "grunt-contrib-clean": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-0.6.0.tgz",
@@ -3883,6 +3943,12 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/grunt-file-append/-/grunt-file-append-0.0.7.tgz",
       "integrity": "sha1-P376M2lvoFdwsoCU9EUIyvxdLto=",
+      "dev": true
+    },
+    "grunt-known-options": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.0.tgz",
+      "integrity": "sha1-pCdO6zL6dl2lp6OxcSYXzjsUQUk=",
       "dev": true
     },
     "grunt-legacy-log": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "node": ">=0.10"
   },
   "scripts": {
-    "test": "grunt assemble"
+    "assemble": "grunt assemble",
+    "build": "grunt build",
+    "test": "grunt build",
+    "watch": "grunt server"
   },
   "licenses": [
     {
@@ -37,6 +40,7 @@
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.6.0",
     "grunt": "^0.4.5",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-compress": "^1.4.3",
     "grunt-contrib-concat": "^1.0.1",


### PR DESCRIPTION
Continues the work in #224.
grunt-cli is now included in the dependencies, so running `npm install` is all you need to get started.