### PR TITLE
[Porting Examples] Add Load JSON File Example

### DIFF
--- a/src/data/en.yml
+++ b/src/data/en.yml
@@ -383,6 +383,7 @@ examples:
   Typography: "Typography"
   3D: "3D"
   Input: "Input"
+  Advanced_Data: "Advanced Data"
   Sound: "Sound"
   Mobile: "Mobile"
   Hello_P5: "Hello p5"

--- a/src/data/es.yml
+++ b/src/data/es.yml
@@ -387,6 +387,7 @@ examples:
   3D: "3D"
   Input: "Input"
   Sound: "Sonido"
+  Advanced_Data: "Avanzado Datos"
   Mobile: "Móvil"
   Hello_P5: "Hola p5"
 

--- a/src/data/examples/assets/bubbles.json
+++ b/src/data/examples/assets/bubbles.json
@@ -1,0 +1,20 @@
+{
+  "bubbles": [
+    {
+      "position": {
+        "x": 160,
+        "y": 103
+      },
+      "diameter": 43.19838,
+      "label": "Happy"
+    },
+    {
+      "position": {
+        "x": 372,
+        "y": 137
+      },
+      "diameter": 52.42526,
+      "label": "Sad"
+    }
+  ]
+}

--- a/src/data/examples/en/22_Advanced_Data/00_Load_Saved_JSON.js
+++ b/src/data/examples/en/22_Advanced_Data/00_Load_Saved_JSON.js
@@ -1,0 +1,105 @@
+/*
+ * @name Load Saved JSON
+ * @description Create a Bubble class, instantiate multiple bubbles using data from
+ * a JSON file, and display results on the screen.
+ *  Because the web browsers differ in where they save files, we do not make use of 
+ * saveJSON, unlike the Processing example.<br><br>
+ * Based on Daniel Shiffman's <a href="https://processing.org/examples/loadsavejson.html">LoadSaveJSON Example</a> for Processing.
+ */
+var data = {}; // Global object to hold results from the loadJSON call
+var bubbles = []; // Global array to hold all bubble objects
+
+// Put any asynchronous data loading in preload to complete before "setup" is run
+function preload() {
+  data = loadJSON('assets/bubbles.json');
+}
+
+// Convert saved Bubble data into Bubble Objects
+function loadData() {
+  var bubbleData = data['bubbles'];
+  for (var i = 0; i < bubbleData.length; i++) {
+    // Get each object in the array
+    var bubble = bubbleData[i];
+    // Get a position object
+    var position = bubble['position'];
+    // Get x,y from position
+    var x = position['x'];
+    var y = position['y'];
+
+    // Get diameter and label
+    var diameter = bubble['diameter'];
+    var label = bubble['label'];
+
+    // Put object in array
+    bubbles.push(new Bubble(x, y, diameter, label));
+  }
+}
+
+// Create a new Bubble each time the mouse is clicked.
+function mousePressed() {
+  // Add diameter and label to bubble
+  var diameter = random(40, 80);
+  var label = 'New Label';
+
+  // Append the new JSON bubble object to the array
+  bubbles.push(new Bubble(mouseX, mouseY, diameter, label));
+
+  // Prune Bubble Count if there are too many
+  if (bubbles.length > 10) {
+    bubbles.shift(); // remove first item from array
+  }
+}
+
+function setup() {
+  createCanvas(640, 360);
+  loadData();
+}
+
+function draw() {
+  background(255);
+
+  // Display all bubbles
+  for (var i = 0; i < bubbles.length; i++) {
+    bubbles[i].display();
+    bubbles[i].rollover(mouseX, mouseY);
+  }
+
+  // Label directions at bottom
+  textAlign(LEFT);
+  fill(0);
+  text('Click to add bubbles.', 10, height - 10);
+}
+
+// Bubble class
+function Bubble(x, y, diameter, name) {
+  this.x = x;
+  this.y = y;
+  this.diameter = diameter;
+  this.radius = diameter / 2;
+  this.name = name;
+
+  this.over = false;
+
+  // Check if mouse is over the bubble
+  this.rollover = function(px, py) {
+    var d = dist(px, py, this.x, this.y);
+    if (d < this.radius) {
+      this.over = true;
+    } else {
+      this.over = false;
+    }
+  };
+
+  // Display the Bubble
+  this.display = function() {
+    stroke(0);
+    strokeWeight(0.8);
+    noFill();
+    ellipse(this.x, this.y, this.diameter, this.diameter);
+    if (this.over) {
+      fill(0);
+      textAlign(CENTER);
+      text(this.name, this.x, this.y + this.radius + 20);
+    }
+  };
+}

--- a/src/data/examples/es/22_Advanced_Data/00_Load_Saved_JSON.js
+++ b/src/data/examples/es/22_Advanced_Data/00_Load_Saved_JSON.js
@@ -1,0 +1,105 @@
+/*
+ * @name Load Saved JSON
+ * @description Create a Bubble class, instantiate multiple bubbles using data from
+ * a JSON file, and display results on the screen.
+ *  Because the web browsers differ in where they save files, we do not make use of 
+ * saveJSON, unlike the Processing example.<br><br>
+ * Based on Daniel Shiffman's <a href="https://processing.org/examples/loadsavejson.html">LoadSaveJSON Example</a> for Processing.
+ */
+var data = {}; // Global object to hold results from the loadJSON call
+var bubbles = []; // Global array to hold all bubble objects
+
+// Put any asynchronous data loading in preload to complete before "setup" is run
+function preload() {
+  data = loadJSON('assets/bubbles.json');
+}
+
+// Convert saved Bubble data into Bubble Objects
+function loadData() {
+  var bubbleData = data['bubbles'];
+  for (var i = 0; i < bubbleData.length; i++) {
+    // Get each object in the array
+    var bubble = bubbleData[i];
+    // Get a position object
+    var position = bubble['position'];
+    // Get x,y from position
+    var x = position['x'];
+    var y = position['y'];
+
+    // Get diameter and label
+    var diameter = bubble['diameter'];
+    var label = bubble['label'];
+
+    // Put object in array
+    bubbles.push(new Bubble(x, y, diameter, label));
+  }
+}
+
+// Create a new Bubble each time the mouse is clicked.
+function mousePressed() {
+  // Add diameter and label to bubble
+  var diameter = random(40, 80);
+  var label = 'New Label';
+
+  // Append the new JSON bubble object to the array
+  bubbles.push(new Bubble(mouseX, mouseY, diameter, label));
+
+  // Prune Bubble Count if there are too many
+  if (bubbles.length > 10) {
+    bubbles.shift(); // remove first item from array
+  }
+}
+
+function setup() {
+  createCanvas(640, 360);
+  loadData();
+}
+
+function draw() {
+  background(255);
+
+  // Display all bubbles
+  for (var i = 0; i < bubbles.length; i++) {
+    bubbles[i].display();
+    bubbles[i].rollover(mouseX, mouseY);
+  }
+
+  // Label directions at bottom
+  textAlign(LEFT);
+  fill(0);
+  text('Click to add bubbles.', 10, height - 10);
+}
+
+// Bubble class
+function Bubble(x, y, diameter, name) {
+  this.x = x;
+  this.y = y;
+  this.diameter = diameter;
+  this.radius = diameter / 2;
+  this.name = name;
+
+  this.over = false;
+
+  // Check if mouse is over the bubble
+  this.rollover = function(px, py) {
+    var d = dist(px, py, this.x, this.y);
+    if (d < this.radius) {
+      this.over = true;
+    } else {
+      this.over = false;
+    }
+  };
+
+  // Display the Bubble
+  this.display = function() {
+    stroke(0);
+    strokeWeight(0.8);
+    noFill();
+    ellipse(this.x, this.y, this.diameter, this.diameter);
+    if (this.over) {
+      fill(0);
+      textAlign(CENTER);
+      text(this.name, this.x, this.y + this.radius + 20);
+    }
+  };
+}

--- a/src/data/examples/zh-Hans/22_Advanced_Data/00_Load_Saved_JSON.js
+++ b/src/data/examples/zh-Hans/22_Advanced_Data/00_Load_Saved_JSON.js
@@ -1,0 +1,105 @@
+/*
+ * @name Load Saved JSON
+ * @description Create a Bubble class, instantiate multiple bubbles using data from
+ * a JSON file, and display results on the screen.
+ *  Because the web browsers differ in where they save files, we do not make use of 
+ * saveJSON, unlike the Processing example.<br><br>
+ * Based on Daniel Shiffman's <a href="https://processing.org/examples/loadsavejson.html">LoadSaveJSON Example</a> for Processing.
+ */
+var data = {}; // Global object to hold results from the loadJSON call
+var bubbles = []; // Global array to hold all bubble objects
+
+// Put any asynchronous data loading in preload to complete before "setup" is run
+function preload() {
+  data = loadJSON('assets/bubbles.json');
+}
+
+// Convert saved Bubble data into Bubble Objects
+function loadData() {
+  var bubbleData = data['bubbles'];
+  for (var i = 0; i < bubbleData.length; i++) {
+    // Get each object in the array
+    var bubble = bubbleData[i];
+    // Get a position object
+    var position = bubble['position'];
+    // Get x,y from position
+    var x = position['x'];
+    var y = position['y'];
+
+    // Get diameter and label
+    var diameter = bubble['diameter'];
+    var label = bubble['label'];
+
+    // Put object in array
+    bubbles.push(new Bubble(x, y, diameter, label));
+  }
+}
+
+// Create a new Bubble each time the mouse is clicked.
+function mousePressed() {
+  // Add diameter and label to bubble
+  var diameter = random(40, 80);
+  var label = 'New Label';
+
+  // Append the new JSON bubble object to the array
+  bubbles.push(new Bubble(mouseX, mouseY, diameter, label));
+
+  // Prune Bubble Count if there are too many
+  if (bubbles.length > 10) {
+    bubbles.shift(); // remove first item from array
+  }
+}
+
+function setup() {
+  createCanvas(640, 360);
+  loadData();
+}
+
+function draw() {
+  background(255);
+
+  // Display all bubbles
+  for (var i = 0; i < bubbles.length; i++) {
+    bubbles[i].display();
+    bubbles[i].rollover(mouseX, mouseY);
+  }
+
+  // Label directions at bottom
+  textAlign(LEFT);
+  fill(0);
+  text('Click to add bubbles.', 10, height - 10);
+}
+
+// Bubble class
+function Bubble(x, y, diameter, name) {
+  this.x = x;
+  this.y = y;
+  this.diameter = diameter;
+  this.radius = diameter / 2;
+  this.name = name;
+
+  this.over = false;
+
+  // Check if mouse is over the bubble
+  this.rollover = function(px, py) {
+    var d = dist(px, py, this.x, this.y);
+    if (d < this.radius) {
+      this.over = true;
+    } else {
+      this.over = false;
+    }
+  };
+
+  // Display the Bubble
+  this.display = function() {
+    stroke(0);
+    strokeWeight(0.8);
+    noFill();
+    ellipse(this.x, this.y, this.diameter, this.diameter);
+    if (this.over) {
+      fill(0);
+      textAlign(CENTER);
+      text(this.name, this.x, this.y + this.radius + 20);
+    }
+  };
+}

--- a/src/data/zh-Hans.yml
+++ b/src/data/zh-Hans.yml
@@ -381,6 +381,7 @@ examples:
   3D: "3D"
   Input: "Input"
   Sound: "音频"
+  Advanced_Data: "Advanced Data"
   Mobile: "移动设备"
   Hello_P5: "Hello p5"
 


### PR DESCRIPTION
This is a p5.js port of Daniel Shiffman's example on [this page](https://processing.org/examples/loadsavejson.html): 

It's not a 1:1 port, but I aimed to captured most of the spirit of the original example.

Primary differences include

- Making use of `preload` function
- Not supporting "saving" since data is loaded from the server, but can't be persisted back to the server
- Not using functions which have awareness of datatypes since Javascript is dynamically typed

I would have liked to use some ES6 features to simplify the looping, but stuck with familiar for-loops to maintain consistency with the other examples I saw in the project.

This is my first contribution to p5.js-website, so please let me know if there's anything else I need to do to prepare this PR appropriately. I wasn't sure about whether the `dist/` files should be committed into the repository, so I keep them in a separate commit for convenience.

cc @lmccart 