### PR TITLE
texture example: mute video for autoplay

### DIFF
--- a/src/data/examples/en/20_3D/04_textures.js
+++ b/src/data/examples/en/20_3D/04_textures.js
@@ -12,6 +12,7 @@ function setup(){
 
   img = loadImage("assets/cat.jpg");
   vid = createVideo(["assets/360video_256crop_v2.mp4"]);
+  vid.elt.muted = true;
   vid.loop();
   vid.hide();
 }

--- a/src/data/examples/es/20_3D/04_textures.js
+++ b/src/data/examples/es/20_3D/04_textures.js
@@ -12,6 +12,7 @@ function setup(){
 
   img = loadImage("assets/cat.jpg");
   vid = createVideo(["assets/360video_256crop_v2.mp4"]);
+  vid.elt.muted = true;
   vid.loop();
   vid.hide();
 }

--- a/src/data/examples/zh-Hans/20_3D/04_textures.js
+++ b/src/data/examples/zh-Hans/20_3D/04_textures.js
@@ -12,6 +12,7 @@ function setup(){
 
   img = loadImage("assets/cat.jpg");
   vid = createVideo(["assets/360video_256crop_v2.mp4"]);
+  vid.elt.muted = true;
   vid.loop();
   vid.hide();
 }


### PR DESCRIPTION
This fix mutes video sound; the current texture example doesn't play video because autoplay is prohibited when the sound is on.

https://github.com/processing/p5.js/issues/3184
https://github.com/processing/p5.js/issues/2911

you can test it [here](https://mlarghydracept.github.io/test-texture-gl-release/) (thanks @mlarghydracept!)