### PR TITLE
Emit examples by iterating over its list

### DIFF
--- a/src/yuidoc-p5-theme-src/scripts/tpl/item.html
+++ b/src/yuidoc-p5-theme-src/scripts/tpl/item.html
@@ -6,7 +6,9 @@
   <span class="visuallyhidden">Examples for <%=item.name%></span>
 
 	<div class="example-content" data-alt="<%= item.alt %>">
-    <%= item.example %>
+    <% _.each(item.example, function(example){ %>
+      <%= example %>
+    <% }); %>
   </div>
 </div>
 <% } %>


### PR DESCRIPTION
Without this, multiple examples will render with a separating comma.

Alternatively, `item.example.join("")` will probably produce the same result, but I picked this style as it's already prevalent in the code base.