### PR TITLE
Fixed 404 due to incorrect case

### DIFF
--- a/dist/learn/curves.html
+++ b/dist/learn/curves.html
@@ -179,7 +179,7 @@
       </p>
 
       <!-- iframe for the curve and dragging points -->
-      <iframe src="../assets/learn/Curves/curve_ex/embed.html" width="350px" height="350px">
+      <iframe src="../assets/learn/curves/curve_ex/embed.html" width="350px" height="350px">
       </iframe>
 
 
@@ -230,7 +230,7 @@
       <p> bezier(x1, y1, cpx1, cpy1, cpx2, cpy2, x2, y2); </p>
 
       <!-- iframe of Bezier example -->
-      <iframe src="../assets/learn/Curves/bezier/embed.html" width="400px" height="400px">
+      <iframe src="../assets/learn/curves/bezier/embed.html" width="400px" height="400px">
       </iframe>
 
       <p>
@@ -241,7 +241,7 @@
     </p>
 
       <!-- image of bezier with lines -->
-      <img src="../assets/learn/Curves/bezier_with_lines/bezier_with_lines.png" style="width:150px;">
+      <img src="../assets/learn/curves/bezier_with_lines/bezier_with_lines.png" style="width:150px;">
 
       <h2> Continuous Bézier Curves</h2>
 


### PR DESCRIPTION
`/assets/learn/Curves/`

Should be 

`/assets/learn/curves/`

per your directory structure