### PR TITLE
fix link in curves tutorial

### DIFF
--- a/src/templates/pages/learn/curves.hbs
+++ b/src/templates/pages/learn/curves.hbs
@@ -79,7 +79,7 @@ slug: learn/
       </p>
 
       <!-- iframe for the curve and dragging points -->
-      <iframe src="{{assets}}/learn/Curves/curve_ex/embed.html" width="350px" height="350px">
+      <iframe src="{{assets}}/learn/curves/curve_ex/embed.html" width="350px" height="350px">
       </iframe>
 
 


### PR DESCRIPTION
fix bug pointed out by @theTaikun in #277 

/assets/learn/Curves/
Should be
/assets/learn/curves/

