### PR TITLE
Fix link in curves tutorial

### DIFF
--- a/src/templates/pages/learn/curves.hbs
+++ b/src/templates/pages/learn/curves.hbs
@@ -130,7 +130,7 @@ slug: learn/
       <p> bezier(x1, y1, cpx1, cpy1, cpx2, cpy2, x2, y2); </p>
 
       <!-- iframe of Bezier example -->
-      <iframe src="{{assets}}/learn/Curves/bezier/embed.html" width="400px" height="400px">
+      <iframe src="{{assets}}/learn/curves/bezier/embed.html" width="400px" height="400px">
       </iframe>
 
       <p>
@@ -141,7 +141,7 @@ slug: learn/
     </p>
 
       <!-- image of bezier with lines -->
-      <img src="{{assets}}/learn/Curves/bezier_with_lines/bezier_with_lines.png" style="width:150px;">
+      <img src="{{assets}}/learn/curves/bezier_with_lines/bezier_with_lines.png" style="width:150px;">
 
       <h2> Continuous Bézier Curves</h2>
 


### PR DESCRIPTION
Related to #277 and #278.

Fixed the remaining two links

/assets/learn/Curves/
Should be
/assets/learn/curves/