### PR TITLE
Updating Structure Examples to ES6 standards

### DIFF
--- a/src/data/examples/en/00_Structure/00_Coordinates.js
+++ b/src/data/examples/en/00_Structure/00_Coordinates.js
@@ -1,9 +1,9 @@
 /*
  * @name Coordinates
- * @description All shapes drawn to the screen have a position that is 
+ * @description All shapes drawn to the screen have a position that is
  * specified as a coordinate. All coordinates are measured as the distance from
  * the origin in units of pixels. The origin [0, 0] is the coordinate in the
- * upper left of the window and the coordinate in the lower right is [width-1, 
+ * upper left of the window and the coordinate in the lower right is [width-1,
  * height-1].
  */
 function setup() {
@@ -16,24 +16,24 @@ function draw() {
   background(0);
   noFill();
 
-  // The two parameters of the point() method each specify 
+  // The two parameters of the point() method each specify
   // coordinates.
-  // The first parameter is the x-coordinate and the second is the Y 
+  // The first parameter is the x-coordinate and the second is the Y
   stroke(255);
   point(width * 0.5, height * 0.5);
-  point(width * 0.5, height * 0.25); 
+  point(width * 0.5, height * 0.25);
 
   // Coordinates are used for drawing all shapes, not just points.
-  // Parameters for different functions are used for different 
-  // purposes. For example, the first two parameters to line()  
-  // specify the coordinates of the first endpoint and the second  
+  // Parameters for different functions are used for different
+  // purposes. For example, the first two parameters to line()
+  // specify the coordinates of the first endpoint and the second
   // two parameters specify the second endpoint
   stroke(0, 153, 255);
-  line(0, height*0.33, width, height*0.33);
+  line(0, height * 0.33, width, height * 0.33);
 
-  // By default, the first two parameters to rect() are the 
+  // By default, the first two parameters to rect() are the
   // coordinates of the upper-left corner and the second pair
   // is the width and height
   stroke(255, 153, 0);
-  rect(width*0.25, height*0.1, width * 0.5, height * 0.8);
+  rect(width * 0.25, height * 0.1, width * 0.5, height * 0.8);
 }

--- a/src/data/examples/en/00_Structure/01_Width_and_Height.js
+++ b/src/data/examples/en/00_Structure/01_Width_and_Height.js
@@ -1,7 +1,7 @@
 /*
  * @name Width and Height
- * @description The 'width' and 'height' variables contain the 
- * width and height of the display window as defined in the createCanvas() 
+ * @description The 'width' and 'height' variables contain the
+ * width and height of the display window as defined in the createCanvas()
  * function.
  */
 function setup() {
@@ -11,7 +11,7 @@ function setup() {
 function draw() {
   background(127);
   noStroke();
-  for (var i = 0; i < height; i += 20) {
+  for (let i = 0; i < height; i += 20) {
     fill(129, 206, 15);
     rect(0, i, width, 10);
     fill(255);

--- a/src/data/examples/en/00_Structure/02_Setup_and_Draw.js
+++ b/src/data/examples/en/00_Structure/02_Setup_and_Draw.js
@@ -1,27 +1,27 @@
 /*
  * @name Setup and Draw
- * @description The code inside the draw() function runs continuously from top 
+ * @description The code inside the draw() function runs continuously from top
  * to bottom until the program is stopped.
  */
-var y = 100;
+let y = 100;
 
-// The statements in the setup() function 
+// The statements in the setup() function
 // execute once when the program begins
 function setup() {
-	// createCanvas must be the first statement
-  createCanvas(720, 400);  
-  stroke(255);     // Set line drawing color to white
+  // createCanvas must be the first statement
+  createCanvas(720, 400);
+  stroke(255); // Set line drawing color to white
   frameRate(30);
 }
-// The statements in draw() are executed until the 
-// program is stopped. Each statement is executed in 
-// sequence and after the last line is read, the first 
+// The statements in draw() are executed until the
+// program is stopped. Each statement is executed in
+// sequence and after the last line is read, the first
 // line is executed again.
-function draw() { 
-  background(0);   // Set the background to black
-  y = y - 1; 
-  if (y < 0) { 
-    y = height; 
-  } 
-  line(0, y, width, y);  
-} 
+function draw() {
+  background(0); // Set the background to black
+  y = y - 1;
+  if (y < 0) {
+    y = height;
+  }
+  line(0, y, width, y);
+}

--- a/src/data/examples/en/00_Structure/03_No_Loop.js
+++ b/src/data/examples/en/00_Structure/03_No_Loop.js
@@ -1,30 +1,30 @@
 /*
  * @name No Loop
- * @description The noLoop() function causes draw() to only execute once. 
+ * @description The noLoop() function causes draw() to only execute once.
  * Without calling noLoop(), the code inside draw() is run continually.
  */
-var y;
+let y;
 
-// The statements in the setup() function 
+// The statements in the setup() function
 // execute once when the program begins
-function setup() 
-{
+function setup() {
   // createCanvas should be the first statement
-  createCanvas(720, 400);  
-  stroke(255);     // Set line drawing color to white
+  createCanvas(720, 400);
+  stroke(255); // Set line drawing color to white
   noLoop();
-  
+
   y = height * 0.5;
 }
 
-// The statements in draw() are executed until the 
-// program is stopped. Each statement is executed in 
-// sequence and after the last line is read, the first 
+// The statements in draw() are executed until the
+// program is stopped. Each statement is executed in
+// sequence and after the last line is read, the first
 // line is executed again.
-function draw() 
-{ 
-  background(0);   // Set the background to black
-  y = y - 1; 
-  if (y < 0) { y = height; } 
-  line(0, y, width, y);  
-} 
+function draw() {
+  background(0); // Set the background to black
+  y = y - 1;
+  if (y < 0) {
+    y = height;
+  }
+  line(0, y, width, y);
+}

--- a/src/data/examples/en/00_Structure/04_Loop.js
+++ b/src/data/examples/en/00_Structure/04_Loop.js
@@ -1,26 +1,26 @@
 /*
  * @name Loop
- * @description The code inside the draw() function runs continuously from top 
+ * @description The code inside the draw() function runs continuously from top
  * to bottom until the program is stopped.
  */
-var y = 100;
+let y = 100;
 
-// The statements in the setup() function 
+// The statements in the setup() function
 // execute once when the program begins
 function setup() {
-  createCanvas(720, 400);  // Size must be the first statement
-  stroke(255);     // Set line drawing color to white
+  createCanvas(720, 400); // Size must be the first statement
+  stroke(255); // Set line drawing color to white
   frameRate(30);
 }
-// The statements in draw() are executed until the 
-// program is stopped. Each statement is executed in 
-// sequence and after the last line is read, the first 
+// The statements in draw() are executed until the
+// program is stopped. Each statement is executed in
+// sequence and after the last line is read, the first
 // line is executed again.
-function draw() { 
-  background(0);   // Set the background to black
-  y = y - 1; 
-  if (y < 0) { 
-    y = height; 
-  } 
-  line(0, y, width, y);  
-} 
+function draw() {
+  background(0); // Set the background to black
+  y = y - 1;
+  if (y < 0) {
+    y = height;
+  }
+  line(0, y, width, y);
+}

--- a/src/data/examples/en/00_Structure/05_Redraw.js
+++ b/src/data/examples/en/00_Structure/05_Redraw.js
@@ -2,11 +2,11 @@
  * @name Redraw
  * @description The redraw() function makes draw() execute once. In this example,
  * draw() is executed once every time the mouse is clicked.
-*/
+ */
 
-var y;
+let y;
 
-// The statements in the setup() function 
+// The statements in the setup() function
 // execute once when the program begins
 function setup() {
   createCanvas(720, 400);
@@ -15,9 +15,9 @@ function setup() {
   y = height * 0.5;
 }
 
-// The statements in draw() are executed until the 
-// program is stopped. Each statement is executed in 
-// sequence and after the last line is read, the first 
+// The statements in draw() are executed until the
+// program is stopped. Each statement is executed in
+// sequence and after the last line is read, the first
 // line is executed again.
 function draw() {
   background(0);
@@ -29,5 +29,5 @@ function draw() {
 }
 
 function mousePressed() {
-  redraw(); 
+  redraw();
 }

--- a/src/data/examples/en/00_Structure/06_Functions.js
+++ b/src/data/examples/en/00_Structure/06_Functions.js
@@ -1,9 +1,9 @@
 /*
  *@name Functions
- *@description The drawTarget() function makes it easy to draw many distinct 
+ *@description The drawTarget() function makes it easy to draw many distinct
  *targets. Each call to drawTarget() specifies the position, size, and number of
  *rings for each target.
-*/
+ */
 
 function setup() {
   createCanvas(720, 400);
@@ -13,16 +13,16 @@ function setup() {
 }
 
 function draw() {
-  drawTarget(width*0.25, height*0.4, 200, 4);
-  drawTarget(width*0.5, height*0.5, 300, 10);
-  drawTarget(width*0.75, height*0.3, 120, 6);
+  drawTarget(width * 0.25, height * 0.4, 200, 4);
+  drawTarget(width * 0.5, height * 0.5, 300, 10);
+  drawTarget(width * 0.75, height * 0.3, 120, 6);
 }
 
 function drawTarget(xloc, yloc, size, num) {
-  var grayvalues = 255/num;
-  var steps = size/num;
-  for (var i = 0; i < num; i++) {
-    fill(i*grayvalues);
-    ellipse(xloc, yloc, size - i*steps, size - i*steps);
+  let grayvalues = 255 / num;
+  let steps = size / num;
+  for (let i = 0; i < num; i++) {
+    fill(i * grayvalues);
+    ellipse(xloc, yloc, size - i * steps, size - i * steps);
   }
 }

--- a/src/data/examples/en/00_Structure/06_Functions.js
+++ b/src/data/examples/en/00_Structure/06_Functions.js
@@ -19,8 +19,8 @@ function draw() {
 }
 
 function drawTarget(xloc, yloc, size, num) {
-  let grayvalues = 255 / num;
-  let steps = size / num;
+  const grayvalues = 255 / num;
+  const steps = size / num;
   for (let i = 0; i < num; i++) {
     fill(i * grayvalues);
     ellipse(xloc, yloc, size - i * steps, size - i * steps);

--- a/src/data/examples/en/00_Structure/07_Recursion.js
+++ b/src/data/examples/en/00_Structure/07_Recursion.js
@@ -16,7 +16,7 @@ function draw() {
 }
 
 function drawCircle(x, radius, level) {
-  let tt = (126 * level) / 4.0;
+  const tt = (126 * level) / 4.0;
   fill(tt);
   ellipse(x, height / 2, radius * 2, radius * 2);
   if (level > 1) {

--- a/src/data/examples/en/00_Structure/07_Recursion.js
+++ b/src/data/examples/en/00_Structure/07_Recursion.js
@@ -3,7 +3,7 @@
  *@description A demonstration of recursion, which means functions call themselves.
  * Notice how the drawCircle() function calls itself at the end of its block.
  * It continues to do this until the variable "level" is equal to 1.
-*/
+ */
 
 function setup() {
   createCanvas(720, 400);
@@ -12,16 +12,16 @@ function setup() {
 }
 
 function draw() {
-  drawCircle(width/2, 280, 6);
+  drawCircle(width / 2, 280, 6);
 }
 
-function drawCircle(x, radius, level) {                    
-  var tt = 126 * level/4.0;
+function drawCircle(x, radius, level) {
+  let tt = (126 * level) / 4.0;
   fill(tt);
-  ellipse(x, height/2, radius*2, radius*2);      
-  if(level > 1) {
+  ellipse(x, height / 2, radius * 2, radius * 2);
+  if (level > 1) {
     level = level - 1;
-    drawCircle(x - radius/2, radius/2, level);
-    drawCircle(x + radius/2, radius/2, level);
+    drawCircle(x - radius / 2, radius / 2, level);
+    drawCircle(x + radius / 2, radius / 2, level);
   }
 }

--- a/src/data/examples/en/00_Structure/08_Create_Graphics.js
+++ b/src/data/examples/en/00_Structure/08_Create_Graphics.js
@@ -1,18 +1,18 @@
 /*
  * @name Create Graphics
- * @description Creates and returns a new p5.Renderer object. Use this 
+ * @description Creates and returns a new p5.Renderer object. Use this
  * class if you need to draw into an off-screen graphics buffer. The two parameters
  * define the width and height in pixels.
  */
 
-var pg;
+let pg;
 
-function setup(){
+function setup() {
   createCanvas(710, 400);
   pg = createGraphics(400, 250);
 }
 
-function draw(){
+function draw() {
   fill(0, 12);
   rect(0, 0, width, height);
   fill(255);
@@ -22,7 +22,7 @@ function draw(){
   pg.background(51);
   pg.noFill();
   pg.stroke(255);
-  pg.ellipse(mouseX-150, mouseY-75, 60, 60);
+  pg.ellipse(mouseX - 150, mouseY - 75, 60, 60);
 
   //Draw the offscreen buffer to the screen with image()
   image(pg, 150, 75);

--- a/src/data/examples/es/00_Structure/00_Coordinates.js
+++ b/src/data/examples/es/00_Structure/00_Coordinates.js
@@ -1,39 +1,37 @@
 /*
- * @name Coordinates
- * @description All shapes drawn to the screen have a position that is
- * specified as a coordinate. All coordinates are measured as the distance from
- * the origin in units of pixels. The origin [0, 0] is the coordinate in the
- * upper left of the window and the coordinate in the lower right is [width-1,
- * height-1].
+ * @name Coordenadas
+ * @description Todas las formas dibujadas en la pantalla tienen una posición que es
+ * especificada como una coordenada. Todas las coordenadas son medidas como una distancia desde el origen, usando el pixel como unidad de medida.
+ * El origen [0, 0] es la coordenada en la esquina superior izquierda de la ventana y la coordenada de la esquina inferior derecha es [ancho-1, altura-1].
  */
 function setup() {
-  // Sets the screen to be 720 pixels wide and 400 pixels high
+  // Definir lienzo de 720 pixeles de ancho y 400 pixeles de alto
   createCanvas(720, 400);
 }
 
 function draw() {
-  // Set the background to black and turn off the fill color
+  // Definir el color del fondo como negro
+  // y definir que las figuras sean pintadas sin relleno
   background(0);
   noFill();
 
-  // The two parameters of the point() method each specify
-  // coordinates.
-  // The first parameter is the x-coordinate and the second is the Y
+  // Los dos parámetros del método point() especifican coordenadas.
+  // El primer parámetro es la coordenada x y el segundo es la y.
   stroke(255);
   point(width * 0.5, height * 0.5);
   point(width * 0.5, height * 0.25);
 
-  // Coordinates are used for drawing all shapes, not just points.
-  // Parameters for different functions are used for different
-  // purposes. For example, the first two parameters to line()
-  // specify the coordinates of the first endpoint and the second
-  // two parameters specify the second endpoint
+  // Las coordenadas se usan para dibujar figuras, no solo puntos.
+  // Los parámetros de las funciones son usados para múltiples
+  // propósitos. Por ejemplo, los dos primeros parámetros
+  // de line() especifican las coordenadas del primer extremo
+  //y los siguientes dos parámetros del segundo extremo.
   stroke(0, 153, 255);
   line(0, height * 0.33, width, height * 0.33);
 
-  // By default, the first two parameters to rect() are the
-  // coordinates of the upper-left corner and the second pair
-  // is the width and height
+  // Por defecto, los dos primeros parámetros de rect() son
+  // las coordenadas de la esquina superior izquierda y el
+  // segundo par son el ancho y el alto.
   stroke(255, 153, 0);
   rect(width * 0.25, height * 0.1, width * 0.5, height * 0.8);
 }

--- a/src/data/examples/es/00_Structure/00_Coordinates.js
+++ b/src/data/examples/es/00_Structure/00_Coordinates.js
@@ -1,39 +1,39 @@
 /*
- * @name Coordenadas
- * @description Todas las formas dibujadas en la pantalla tienen una posición que es
- * especificada como una coordenada. Todas las coordenadas son medidas como una distancia desde el origen, usando el pixel como unidad de medida.
- * El origen [0, 0] es la coordenada en la esquina superior izquierda de la ventana y la coordenada de la esquina inferior derecha es [ancho-1, altura-1].
+ * @name Coordinates
+ * @description All shapes drawn to the screen have a position that is
+ * specified as a coordinate. All coordinates are measured as the distance from
+ * the origin in units of pixels. The origin [0, 0] is the coordinate in the
+ * upper left of the window and the coordinate in the lower right is [width-1,
+ * height-1].
  */
 function setup() {
-
-  // Definir lienzo de 720 pixeles de ancho y 400 pixeles de alto
+  // Sets the screen to be 720 pixels wide and 400 pixels high
   createCanvas(720, 400);
 }
 
 function draw() {
-  // Definir el color del fondo como negro
-  // y definir que las figuras sean pintadas sin relleno
+  // Set the background to black and turn off the fill color
   background(0);
   noFill();
 
-  // Los dos parámetros del método point() especifican coordenadas.
-  // El primer parámetro es la coordenada x y el segundo es la y.
+  // The two parameters of the point() method each specify
+  // coordinates.
+  // The first parameter is the x-coordinate and the second is the Y
   stroke(255);
   point(width * 0.5, height * 0.5);
   point(width * 0.5, height * 0.25);
 
-  // Las coordenadas se usan para dibujar figuras, no solo puntos.
-  // Los parámetros de las funciones son usados para múltiples
-  // propósitos. Por ejemplo, los dos primeros parámetros
-  // de line() especifican las coordenadas del primer extremo
-  //y los siguientes dos parámetros del segundo extremo.
+  // Coordinates are used for drawing all shapes, not just points.
+  // Parameters for different functions are used for different
+  // purposes. For example, the first two parameters to line()
+  // specify the coordinates of the first endpoint and the second
+  // two parameters specify the second endpoint
   stroke(0, 153, 255);
-  line(0, height*0.33, width, height*0.33);
+  line(0, height * 0.33, width, height * 0.33);
 
-
-  // Por defecto, los dos primeros parámetros de rect() son
-  // las coordenadas de la esquina superior izquierda y el
-  // segundo par son el ancho y el alto.
+  // By default, the first two parameters to rect() are the
+  // coordinates of the upper-left corner and the second pair
+  // is the width and height
   stroke(255, 153, 0);
-  rect(width*0.25, height*0.1, width * 0.5, height * 0.8);
+  rect(width * 0.25, height * 0.1, width * 0.5, height * 0.8);
 }

--- a/src/data/examples/es/00_Structure/01_Width_and_Height.js
+++ b/src/data/examples/es/00_Structure/01_Width_and_Height.js
@@ -1,8 +1,7 @@
 /*
- * @name Width and Height
- * @description The 'width' and 'height' variables contain the
- * width and height of the display window as defined in the createCanvas()
- * function.
+ * @name width y height
+ * @description Las variables 'width' (ancho) y 'height' (altura) contienen
+ * el ancho y la altura del lienzo, como fue definido en la función createCanvas().
  */
 function setup() {
   createCanvas(720, 400);

--- a/src/data/examples/es/00_Structure/01_Width_and_Height.js
+++ b/src/data/examples/es/00_Structure/01_Width_and_Height.js
@@ -1,7 +1,8 @@
 /*
- * @name width y height
- * @description Las variables 'width' (ancho) y 'height' (altura) contienen
- * el ancho y la altura del lienzo, como fue definido en la función createCanvas().
+ * @name Width and Height
+ * @description The 'width' and 'height' variables contain the
+ * width and height of the display window as defined in the createCanvas()
+ * function.
  */
 function setup() {
   createCanvas(720, 400);
@@ -10,7 +11,7 @@ function setup() {
 function draw() {
   background(127);
   noStroke();
-  for (var i = 0; i < height; i += 20) {
+  for (let i = 0; i < height; i += 20) {
     fill(129, 206, 15);
     rect(0, i, width, 10);
     fill(255);

--- a/src/data/examples/es/00_Structure/02_Setup_and_Draw.js
+++ b/src/data/examples/es/00_Structure/02_Setup_and_Draw.js
@@ -1,25 +1,24 @@
 /*
- * @name Setup y Draw
- * @description El código dentro de la función draw() corre continuamente de arriba
- * a a bajo hasta que el programa es parado.
+ * @name Setup and Draw
+ * @description The code inside the draw() function runs continuously from top
+ * to bottom until the program is stopped.
  */
-var y = 100;
+let y = 100;
 
-// Las instrucciones dentro de la función setup()
-// se ejecutan una vez, al principio del programa
-function setup() ({
-	// createCanvas() debe ser la primera instrucción
+// The statements in the setup() function
+// execute once when the program begins
+function setup() {
+  // createCanvas must be the first statement
   createCanvas(720, 400);
-  stroke(255);     // Hacer que el color de trazado sea blanco
+  stroke(255); // Set line drawing color to white
   frameRate(30);
 }
-
-// Las instrucciones en draw() son ejecutadas hasta que
-// el programa es parado. Cada instrucción es ejecutada
-// en orden y luego de que la última línea es leída,
-// se vuelve a ejecutar draw() desde el principio
+// The statements in draw() are executed until the
+// program is stopped. Each statement is executed in
+// sequence and after the last line is read, the first
+// line is executed again.
 function draw() {
-  background(0);   // Hacer que el color del fondo sea negro
+  background(0); // Set the background to black
   y = y - 1;
   if (y < 0) {
     y = height;

--- a/src/data/examples/es/00_Structure/02_Setup_and_Draw.js
+++ b/src/data/examples/es/00_Structure/02_Setup_and_Draw.js
@@ -1,24 +1,25 @@
 /*
- * @name Setup and Draw
- * @description The code inside the draw() function runs continuously from top
- * to bottom until the program is stopped.
+ * @name Setup y Draw
+ * @description El código dentro de la función draw() corre continuamente de arriba
+ * a a bajo hasta que el programa es parado.
  */
 let y = 100;
 
-// The statements in the setup() function
-// execute once when the program begins
+// Las instrucciones dentro de la función setup()
+// se ejecutan una vez, al principio del programa
 function setup() {
-  // createCanvas must be the first statement
+  // createCanvas() debe ser la primera instrucción
   createCanvas(720, 400);
-  stroke(255); // Set line drawing color to white
+  stroke(255); // Hacer que el color de trazado sea blanco
   frameRate(30);
 }
-// The statements in draw() are executed until the
-// program is stopped. Each statement is executed in
-// sequence and after the last line is read, the first
-// line is executed again.
+
+// Las instrucciones en draw() son ejecutadas hasta que
+// el programa es parado. Cada instrucción es ejecutada
+// en orden y luego de que la última línea es leída,
+// se vuelve a ejecutar draw() desde el principio
 function draw() {
-  background(0); // Set the background to black
+  background(0); // Hacer que el color del fondo sea negro
   y = y - 1;
   if (y < 0) {
     y = height;

--- a/src/data/examples/es/00_Structure/03_No_Loop.js
+++ b/src/data/examples/es/00_Structure/03_No_Loop.js
@@ -1,7 +1,7 @@
 /*
  * @name No Loop
- * @description The noLoop() function causes draw() to only execute once.
- * Without calling noLoop(), the code inside draw() is run continually.
+ * @description La función noLoop() hace que draw() se ejecuta solo una vez.
+ * Sin ejecutar noLoop(), el código dentro de draw() es ejecutado continuamente.
  */
 let y;
 
@@ -16,10 +16,10 @@ function setup() {
   y = height * 0.5;
 }
 
-// The statements in draw() are executed until the
-// program is stopped. Each statement is executed in
-// sequence and after the last line is read, the first
-// line is executed again.
+// Las instrucciones en draw() son ejecutadas hasta que
+// el programa es parado. Cada instrucción es ejecutada
+// en orden y luego de que la última línea es leída,
+// se vuelve a ejecutar draw() desde el principio
 function draw() {
   background(0); // Set the background to black
   y = y - 1;

--- a/src/data/examples/es/00_Structure/03_No_Loop.js
+++ b/src/data/examples/es/00_Structure/03_No_Loop.js
@@ -1,30 +1,30 @@
 /*
  * @name No Loop
- * @description La función noLoop() hace que draw() se ejecuta solo una vez.
- * Sin ejecutar noLoop(), el código dentro de draw() es ejecutado continuamente.
+ * @description The noLoop() function causes draw() to only execute once.
+ * Without calling noLoop(), the code inside draw() is run continually.
  */
-var y;
+let y;
 
 // The statements in the setup() function
 // execute once when the program begins
-function setup()
-{
+function setup() {
   // createCanvas should be the first statement
   createCanvas(720, 400);
-  stroke(255);     // Set line drawing color to white
+  stroke(255); // Set line drawing color to white
   noLoop();
 
   y = height * 0.5;
 }
 
-// Las instrucciones en draw() son ejecutadas hasta que
-// el programa es parado. Cada instrucción es ejecutada
-// en orden y luego de que la última línea es leída,
-// se vuelve a ejecutar draw() desde el principio
-function draw()
-{
-  background(0);   // Set the background to black
+// The statements in draw() are executed until the
+// program is stopped. Each statement is executed in
+// sequence and after the last line is read, the first
+// line is executed again.
+function draw() {
+  background(0); // Set the background to black
   y = y - 1;
-  if (y < 0) { y = height; }
+  if (y < 0) {
+    y = height;
+  }
   line(0, y, width, y);
 }

--- a/src/data/examples/es/00_Structure/04_Loop.js
+++ b/src/data/examples/es/00_Structure/04_Loop.js
@@ -1,23 +1,23 @@
 /*
- * @name Loop
- * @description The code inside the draw() function runs continuously from top
- * to bottom until the program is stopped.
+ * @name Bucle
+ * @description El código dentro de la función draw() corre continuamente de arriba a abajo hasta que el prorgrama para.
  */
 let y = 100;
 
-// The statements in the setup() function
-// execute once when the program begins
+// Las instrucciones dentro de la función setup()
+// se ejecutan una vez, cuando el programa empieza
 function setup() {
-  createCanvas(720, 400); // Size must be the first statement
-  stroke(255); // Set line drawing color to white
+  createCanvas(720, 400); // El tamaño debe ser la primera instrucción
+  stroke(255); // Definir que el color del trazado sea blanco
   frameRate(30);
 }
-// The statements in draw() are executed until the
-// program is stopped. Each statement is executed in
-// sequence and after the last line is read, the first
-// line is executed again.
+
+// Las instrucciones en draw() son ejecutadas hasta que
+// el programa es parado. Cada instrucción es ejecutada
+// en orden y luego de que la última línea es leída,
+// se vuelve a ejecutar draw() desde el principio
 function draw() {
-  background(0); // Set the background to black
+  background(0); // Definir que el color del fondo sea negro
   y = y - 1;
   if (y < 0) {
     y = height;

--- a/src/data/examples/es/00_Structure/04_Loop.js
+++ b/src/data/examples/es/00_Structure/04_Loop.js
@@ -1,24 +1,23 @@
 /*
- * @name Bucle
- * @description El código dentro de la función draw() corre continuamente de arriba a abajo hasta que el prorgrama para.
+ * @name Loop
+ * @description The code inside the draw() function runs continuously from top
+ * to bottom until the program is stopped.
  */
-var y = 100;
+let y = 100;
 
-// Las instrucciones dentro de la función setup()
-// se ejecutan una vez, cuando el programa empieza
+// The statements in the setup() function
+// execute once when the program begins
 function setup() {
-  createCanvas(720, 400);  // El tamaño debe ser la primera instrucción
-  stroke(255);     // Definir que el color del trazado sea blanco
+  createCanvas(720, 400); // Size must be the first statement
+  stroke(255); // Set line drawing color to white
   frameRate(30);
 }
-
-
-// Las instrucciones en draw() son ejecutadas hasta que
-// el programa es parado. Cada instrucción es ejecutada
-// en orden y luego de que la última línea es leída,
-// se vuelve a ejecutar draw() desde el principio
+// The statements in draw() are executed until the
+// program is stopped. Each statement is executed in
+// sequence and after the last line is read, the first
+// line is executed again.
 function draw() {
-  background(0);   // Definir que el color del fondo sea negro
+  background(0); // Set the background to black
   y = y - 1;
   if (y < 0) {
     y = height;

--- a/src/data/examples/es/00_Structure/05_Redraw.js
+++ b/src/data/examples/es/00_Structure/05_Redraw.js
@@ -1,13 +1,13 @@
 /*
  * @name Redraw
- * @description La función redraw() hace que draw() se ejecute una vez. En este ejemplo,
- * draw() se ejecutado una vez cada vez que el ratón hace click.
-*/
+ * @description The redraw() function makes draw() execute once. In this example,
+ * draw() is executed once every time the mouse is clicked.
+ */
 
-var y;
+let y;
 
-// Las instrucciones dentro de la función setup()
-// se ejecutan una vez, cuando el programa se inicia
+// The statements in the setup() function
+// execute once when the program begins
 function setup() {
   createCanvas(720, 400);
   stroke(255);
@@ -15,10 +15,10 @@ function setup() {
   y = height * 0.5;
 }
 
-// Las instrucciones en draw() son ejecutadas hasta que
-// el programa es parado. Cada instrucción es ejecutada
-// en orden y luego de que la última línea es leída,
-// se vuelve a ejecutar draw() desde el principio
+// The statements in draw() are executed until the
+// program is stopped. Each statement is executed in
+// sequence and after the last line is read, the first
+// line is executed again.
 function draw() {
   background(0);
   y = y - 4;

--- a/src/data/examples/es/00_Structure/05_Redraw.js
+++ b/src/data/examples/es/00_Structure/05_Redraw.js
@@ -1,13 +1,13 @@
 /*
  * @name Redraw
- * @description The redraw() function makes draw() execute once. In this example,
- * draw() is executed once every time the mouse is clicked.
+ * @description La función redraw() hace que draw() se ejecute una vez. En este ejemplo,
+ * draw() se ejecutado una vez cada vez que el ratón hace click.
  */
 
 let y;
 
-// The statements in the setup() function
-// execute once when the program begins
+// Las instrucciones dentro de la función setup()
+// se ejecutan una vez, cuando el programa se inicia
 function setup() {
   createCanvas(720, 400);
   stroke(255);
@@ -15,10 +15,10 @@ function setup() {
   y = height * 0.5;
 }
 
-// The statements in draw() are executed until the
-// program is stopped. Each statement is executed in
-// sequence and after the last line is read, the first
-// line is executed again.
+// Las instrucciones en draw() son ejecutadas hasta que
+// el programa es parado. Cada instrucción es ejecutada
+// en orden y luego de que la última línea es leída,
+// se vuelve a ejecutar draw() desde el principio
 function draw() {
   background(0);
   y = y - 4;

--- a/src/data/examples/es/00_Structure/06_Functions.js
+++ b/src/data/examples/es/00_Structure/06_Functions.js
@@ -1,9 +1,9 @@
 /*
- *@name Funciones
- *@description La función drawTarget() hace fácil dibujar muchas dianas distintos.
- * Cada llamada a drawTarget() especifica la posición, tamaño y número de
- * anillos por cada diana.
-*/
+ *@name Functions
+ *@description The drawTarget() function makes it easy to draw many distinct
+ *targets. Each call to drawTarget() specifies the position, size, and number of
+ *rings for each target.
+ */
 
 function setup() {
   createCanvas(720, 400);
@@ -13,16 +13,16 @@ function setup() {
 }
 
 function draw() {
-  drawTarget(width*0.25, height*0.4, 200, 4);
-  drawTarget(width*0.5, height*0.5, 300, 10);
-  drawTarget(width*0.75, height*0.3, 120, 6);
+  drawTarget(width * 0.25, height * 0.4, 200, 4);
+  drawTarget(width * 0.5, height * 0.5, 300, 10);
+  drawTarget(width * 0.75, height * 0.3, 120, 6);
 }
 
 function drawTarget(xloc, yloc, size, num) {
-  grayvalues = 255/num;
-  steps = size/num;
-  for (i = 0; i < num; i++) {
-    fill(i*grayvalues);
-    ellipse(xloc, yloc, size - i*steps, size - i*steps);
+  let grayvalues = 255 / num;
+  let steps = size / num;
+  for (let i = 0; i < num; i++) {
+    fill(i * grayvalues);
+    ellipse(xloc, yloc, size - i * steps, size - i * steps);
   }
 }

--- a/src/data/examples/es/00_Structure/06_Functions.js
+++ b/src/data/examples/es/00_Structure/06_Functions.js
@@ -1,8 +1,8 @@
 /*
- *@name Functions
- *@description The drawTarget() function makes it easy to draw many distinct
- *targets. Each call to drawTarget() specifies the position, size, and number of
- *rings for each target.
+ *@name Funciones
+ *@description La función drawTarget() hace fácil dibujar muchas dianas distintos.
+ * Cada llamada a drawTarget() especifica la posición, tamaño y número de
+ * anillos por cada diana.
  */
 
 function setup() {
@@ -19,9 +19,9 @@ function draw() {
 }
 
 function drawTarget(xloc, yloc, size, num) {
-  let grayvalues = 255 / num;
-  let steps = size / num;
-  for (let i = 0; i < num; i++) {
+  grayvalues = 255 / num;
+  steps = size / num;
+  for (i = 0; i < num; i++) {
     fill(i * grayvalues);
     ellipse(xloc, yloc, size - i * steps, size - i * steps);
   }

--- a/src/data/examples/es/00_Structure/06_Functions.js
+++ b/src/data/examples/es/00_Structure/06_Functions.js
@@ -19,9 +19,9 @@ function draw() {
 }
 
 function drawTarget(xloc, yloc, size, num) {
-  grayvalues = 255 / num;
-  steps = size / num;
-  for (i = 0; i < num; i++) {
+  const grayvalues = 255 / num;
+  const steps = size / num;
+  for (let i = 0; i < num; i++) {
     fill(i * grayvalues);
     ellipse(xloc, yloc, size - i * steps, size - i * steps);
   }

--- a/src/data/examples/es/00_Structure/07_Recursion.js
+++ b/src/data/examples/es/00_Structure/07_Recursion.js
@@ -1,9 +1,9 @@
 /*
- *@name Recursión
- *@description Una demonstración de recursión, que significa funciones llamándose a sí mismas.
- * Fíjate cómo la función drawCircle() se llama a sí misma al final del bloque de código.
- * Continúa haciéndolo hasta que la variable "level" es igual a 1.
-*/
+ *@name Recursion
+ *@description A demonstration of recursion, which means functions call themselves.
+ * Notice how the drawCircle() function calls itself at the end of its block.
+ * It continues to do this until the variable "level" is equal to 1.
+ */
 
 function setup() {
   createCanvas(720, 400);
@@ -12,16 +12,16 @@ function setup() {
 }
 
 function draw() {
-  drawCircle(width/2, 280, 6);
+  drawCircle(width / 2, 280, 6);
 }
 
 function drawCircle(x, radius, level) {
-  var tt = 126 * level/4.0;
+  let tt = (126 * level) / 4.0;
   fill(tt);
-  ellipse(x, height/2, radius*2, radius*2);
-  if(level > 1) {
+  ellipse(x, height / 2, radius * 2, radius * 2);
+  if (level > 1) {
     level = level - 1;
-    drawCircle(x - radius/2, radius/2, level);
-    drawCircle(x + radius/2, radius/2, level);
+    drawCircle(x - radius / 2, radius / 2, level);
+    drawCircle(x + radius / 2, radius / 2, level);
   }
 }

--- a/src/data/examples/es/00_Structure/07_Recursion.js
+++ b/src/data/examples/es/00_Structure/07_Recursion.js
@@ -16,7 +16,7 @@ function draw() {
 }
 
 function drawCircle(x, radius, level) {
-  let tt = (126 * level) / 4.0;
+  const tt = (126 * level) / 4.0;
   fill(tt);
   ellipse(x, height / 2, radius * 2, radius * 2);
   if (level > 1) {

--- a/src/data/examples/es/00_Structure/07_Recursion.js
+++ b/src/data/examples/es/00_Structure/07_Recursion.js
@@ -1,8 +1,8 @@
 /*
- *@name Recursion
- *@description A demonstration of recursion, which means functions call themselves.
- * Notice how the drawCircle() function calls itself at the end of its block.
- * It continues to do this until the variable "level" is equal to 1.
+ *@name Recursión
+ *@description Una demonstración de recursión, que significa funciones llamándose a sí mismas.
+ * Fíjate cómo la función drawCircle() se llama a sí misma al final del bloque de código.
+ * Continúa haciéndolo hasta que la variable "level" es igual a 1.
  */
 
 function setup() {

--- a/src/data/examples/es/00_Structure/08_Create_Graphics.js
+++ b/src/data/examples/es/00_Structure/08_Create_Graphics.js
@@ -1,18 +1,18 @@
 /*
- * @name createGraphics
- * @description Crea y retorna un nuevo objeto p5.Renderer. Usa esta
- * clase si necesitas dibujar en un buffer gráfico fuera-de-pantalla. Los dos parámetros
- * definen el ancho y la altura en pixeles.
+ * @name Create Graphics
+ * @description Creates and returns a new p5.Renderer object. Use this
+ * class if you need to draw into an off-screen graphics buffer. The two parameters
+ * define the width and height in pixels.
  */
 
 let pg;
 
-function setup(){
+function setup() {
   createCanvas(710, 400);
   pg = createGraphics(400, 250);
 }
 
-function draw(){
+function draw() {
   fill(0, 12);
   rect(0, 0, width, height);
   fill(255);
@@ -22,8 +22,8 @@ function draw(){
   pg.background(51);
   pg.noFill();
   pg.stroke(255);
-  pg.ellipse(mouseX-150, mouseY-75, 60, 60);
+  pg.ellipse(mouseX - 150, mouseY - 75, 60, 60);
 
-  //El buffer fuera de pantalla es dibujado en la pantalla con image()
+  //Draw the offscreen buffer to the screen with image()
   image(pg, 150, 75);
 }

--- a/src/data/examples/es/00_Structure/08_Create_Graphics.js
+++ b/src/data/examples/es/00_Structure/08_Create_Graphics.js
@@ -1,8 +1,8 @@
 /*
- * @name Create Graphics
- * @description Creates and returns a new p5.Renderer object. Use this
- * class if you need to draw into an off-screen graphics buffer. The two parameters
- * define the width and height in pixels.
+ * @name createGraphics
+ * @description Crea y retorna un nuevo objeto p5.Renderer. Usa esta
+ * clase si necesitas dibujar en un buffer gráfico fuera-de-pantalla. Los dos parámetros
+ * definen el ancho y la altura en pixeles.
  */
 
 let pg;
@@ -24,6 +24,6 @@ function draw() {
   pg.stroke(255);
   pg.ellipse(mouseX - 150, mouseY - 75, 60, 60);
 
-  //Draw the offscreen buffer to the screen with image()
+  //El buffer fuera de pantalla es dibujado en la pantalla con image()
   image(pg, 150, 75);
 }

--- a/src/data/examples/zh-Hans/00_Structure/00_Coordinates.js
+++ b/src/data/examples/zh-Hans/00_Structure/00_Coordinates.js
@@ -1,39 +1,29 @@
 /*
- * @name Coordinates
- * @description All shapes drawn to the screen have a position that is
- * specified as a coordinate. All coordinates are measured as the distance from
- * the origin in units of pixels. The origin [0, 0] is the coordinate in the
- * upper left of the window and the coordinate in the lower right is [width-1,
- * height-1].
+ * @name 坐标
+ * @description 绘制到屏幕上的所有形状都有一个指定为坐标的位置。所有的坐标都是以像素为单位，以距原点的距离来衡量的。原点 [0,0] 是窗口左上角的坐标，右下角的坐标是 [宽度-, 高度-1] 。
  */
 function setup() {
-  // Sets the screen to be 720 pixels wide and 400 pixels high
+  // 制作一个 720 像素宽 400 像素高的画布。
   createCanvas(720, 400);
 }
 
 function draw() {
-  // Set the background to black and turn off the fill color
+  // 将背景设置为黑色，关闭填色功能。
   background(0);
   noFill();
 
-  // The two parameters of the point() method each specify
-  // coordinates.
-  // The first parameter is the x-coordinate and the second is the Y
+  // point() 函数的两个参数分别为指定的坐标。
+  // 第一个参数是 x 坐标，第二个参数是 y 。
   stroke(255);
   point(width * 0.5, height * 0.5);
   point(width * 0.5, height * 0.25);
 
-  // Coordinates are used for drawing all shapes, not just points.
-  // Parameters for different functions are used for different
-  // purposes. For example, the first two parameters to line()
-  // specify the coordinates of the first endpoint and the second
-  // two parameters specify the second endpoint
+  // 坐标用于绘制所有形状，而不仅仅是点。
+  // 不同功能的参数用于不同的目的。例如，line() 的前两个参数指定第一个端点的坐标，后两个参数指定第二个端点的坐标。
   stroke(0, 153, 255);
   line(0, height * 0.33, width, height * 0.33);
 
-  // By default, the first two parameters to rect() are the
-  // coordinates of the upper-left corner and the second pair
-  // is the width and height
+  // 默认情况下，rect() 的前两个参数是左上角的坐标，后两个参数是宽度和高度。
   stroke(255, 153, 0);
   rect(width * 0.25, height * 0.1, width * 0.5, height * 0.8);
 }

--- a/src/data/examples/zh-Hans/00_Structure/00_Coordinates.js
+++ b/src/data/examples/zh-Hans/00_Structure/00_Coordinates.js
@@ -1,30 +1,39 @@
 /*
- * @name 坐标
- * @description 绘制到屏幕上的所有形状都有一个指定为坐标的位置。所有的坐标都是以像素为单位，以距原点的距离来衡量的。原点 [0,0] 是窗口左上角的坐标，右下角的坐标是 [宽度-, 高度-1] 。
+ * @name Coordinates
+ * @description All shapes drawn to the screen have a position that is
+ * specified as a coordinate. All coordinates are measured as the distance from
+ * the origin in units of pixels. The origin [0, 0] is the coordinate in the
+ * upper left of the window and the coordinate in the lower right is [width-1,
+ * height-1].
  */
 function setup() {
-  // 制作一个 720 像素宽 400 像素高的画布。
+  // Sets the screen to be 720 pixels wide and 400 pixels high
   createCanvas(720, 400);
 }
 
 function draw() {
-  // 将背景设置为黑色，关闭填色功能。
+  // Set the background to black and turn off the fill color
   background(0);
   noFill();
 
-
-  // point() 函数的两个参数分别为指定的坐标。
-  // 第一个参数是 x 坐标，第二个参数是 y 。
+  // The two parameters of the point() method each specify
+  // coordinates.
+  // The first parameter is the x-coordinate and the second is the Y
   stroke(255);
   point(width * 0.5, height * 0.5);
-  point(width * 0.5, height * 0.25); 
+  point(width * 0.5, height * 0.25);
 
-  // 坐标用于绘制所有形状，而不仅仅是点。
-  // 不同功能的参数用于不同的目的。例如，line() 的前两个参数指定第一个端点的坐标，后两个参数指定第二个端点的坐标。
+  // Coordinates are used for drawing all shapes, not just points.
+  // Parameters for different functions are used for different
+  // purposes. For example, the first two parameters to line()
+  // specify the coordinates of the first endpoint and the second
+  // two parameters specify the second endpoint
   stroke(0, 153, 255);
-  line(0, height*0.33, width, height*0.33);
+  line(0, height * 0.33, width, height * 0.33);
 
-  // 默认情况下，rect() 的前两个参数是左上角的坐标，后两个参数是宽度和高度。
+  // By default, the first two parameters to rect() are the
+  // coordinates of the upper-left corner and the second pair
+  // is the width and height
   stroke(255, 153, 0);
-  rect(width*0.25, height*0.1, width * 0.5, height * 0.8);
+  rect(width * 0.25, height * 0.1, width * 0.5, height * 0.8);
 }

--- a/src/data/examples/zh-Hans/00_Structure/01_Width_and_Height.js
+++ b/src/data/examples/zh-Hans/00_Structure/01_Width_and_Height.js
@@ -1,6 +1,8 @@
 /*
- * @name Width 和 Height
- * @description 'width'（宽度）和 'height'（高度）变量包含 createCanvas() 函数中定义的显示窗口的宽度和高度。
+ * @name Width and Height
+ * @description The 'width' and 'height' variables contain the
+ * width and height of the display window as defined in the createCanvas()
+ * function.
  */
 function setup() {
   createCanvas(720, 400);
@@ -9,7 +11,7 @@ function setup() {
 function draw() {
   background(127);
   noStroke();
-  for (var i = 0; i < height; i += 20) {
+  for (let i = 0; i < height; i += 20) {
     fill(129, 206, 15);
     rect(0, i, width, 10);
     fill(255);

--- a/src/data/examples/zh-Hans/00_Structure/01_Width_and_Height.js
+++ b/src/data/examples/zh-Hans/00_Structure/01_Width_and_Height.js
@@ -1,8 +1,6 @@
 /*
- * @name Width and Height
- * @description The 'width' and 'height' variables contain the
- * width and height of the display window as defined in the createCanvas()
- * function.
+ * @name Width 和 Height
+ * @description 'width'（宽度）和 'height'（高度）变量包含 createCanvas() 函数中定义的显示窗口的宽度和高度。
  */
 function setup() {
   createCanvas(720, 400);

--- a/src/data/examples/zh-Hans/00_Structure/02_Setup_and_Draw.js
+++ b/src/data/examples/zh-Hans/00_Structure/02_Setup_and_Draw.js
@@ -1,22 +1,27 @@
 /*
- * @name Setup 与 Draw
- * @description draw() 函数中的代码从上到下连续运行，直到程序停止。
+ * @name Setup and Draw
+ * @description The code inside the draw() function runs continuously from top
+ * to bottom until the program is stopped.
  */
-var y = 100;
+let y = 100;
 
-// 程序开始时，setup() 函数中的语句执行一次。
+// The statements in the setup() function
+// execute once when the program begins
 function setup() {
-	// createCanvas 必须是第一条语句
-  createCanvas(720, 400);  
-  stroke(255);     // 将线条绘制颜色设置为白色
+  // createCanvas must be the first statement
+  createCanvas(720, 400);
+  stroke(255); // Set line drawing color to white
   frameRate(30);
 }
-// draw() 中的语句一直执行到程序停止为止。每个语句都按顺序执行，并且在读取最后一行之后，将再次执行第一行。
-function draw() { 
-  background(0);   // 将背景设置为黑色
-  y = y - 1; 
-  if (y < 0) { 
-    y = height; 
-  } 
-  line(0, y, width, y);  
-} 
+// The statements in draw() are executed until the
+// program is stopped. Each statement is executed in
+// sequence and after the last line is read, the first
+// line is executed again.
+function draw() {
+  background(0); // Set the background to black
+  y = y - 1;
+  if (y < 0) {
+    y = height;
+  }
+  line(0, y, width, y);
+}

--- a/src/data/examples/zh-Hans/00_Structure/02_Setup_and_Draw.js
+++ b/src/data/examples/zh-Hans/00_Structure/02_Setup_and_Draw.js
@@ -1,24 +1,19 @@
 /*
- * @name Setup and Draw
- * @description The code inside the draw() function runs continuously from top
- * to bottom until the program is stopped.
+ * @name Setup 与 Draw
+ * @description draw() 函数中的代码从上到下连续运行，直到程序停止。
  */
 let y = 100;
 
-// The statements in the setup() function
-// execute once when the program begins
+// 程序开始时，setup() 函数中的语句执行一次。
 function setup() {
-  // createCanvas must be the first statement
+  // createCanvas 必须是第一条语句
   createCanvas(720, 400);
-  stroke(255); // Set line drawing color to white
+  stroke(255); // 将线条绘制颜色设置为白色
   frameRate(30);
 }
-// The statements in draw() are executed until the
-// program is stopped. Each statement is executed in
-// sequence and after the last line is read, the first
-// line is executed again.
+// draw() 中的语句一直执行到程序停止为止。每个语句都按顺序执行，并且在读取最后一行之后，将再次执行第一行。
 function draw() {
-  background(0); // Set the background to black
+  background(0); // 将背景设置为黑色
   y = y - 1;
   if (y < 0) {
     y = height;

--- a/src/data/examples/zh-Hans/00_Structure/03_No_Loop.js
+++ b/src/data/examples/zh-Hans/00_Structure/03_No_Loop.js
@@ -1,27 +1,23 @@
 /*
  * @name No Loop
- * @description The noLoop() function causes draw() to only execute once.
- * Without calling noLoop(), the code inside draw() is run continually.
+ * @description noLoop() 函数使 draw() 只执行一次。
+ *如果不调用 noLoop() ，draw() 内的代码会持续运行。
  */
 let y;
 
-// The statements in the setup() function
-// execute once when the program begins
+// 程序开始时，setup() 函数中的语句执行一次。
 function setup() {
-  // createCanvas should be the first statement
+  // createCanvas 必须是第一条语句
   createCanvas(720, 400);
-  stroke(255); // Set line drawing color to white
+  stroke(255); // 线条绘制颜色设置为白色
   noLoop();
 
   y = height * 0.5;
 }
 
-// The statements in draw() are executed until the
-// program is stopped. Each statement is executed in
-// sequence and after the last line is read, the first
-// line is executed again.
+// draw() 中的语句一直执行到程序停止为止。每个语句都按顺序执行，并且在读取最后一行之后，将再次执行第一行。
 function draw() {
-  background(0); // Set the background to black
+  background(0); // 将背景设置为黑色
   y = y - 1;
   if (y < 0) {
     y = height;

--- a/src/data/examples/zh-Hans/00_Structure/03_No_Loop.js
+++ b/src/data/examples/zh-Hans/00_Structure/03_No_Loop.js
@@ -1,26 +1,30 @@
 /*
  * @name No Loop
- * @description noLoop() 函数使 draw() 只执行一次。
- *如果不调用 noLoop() ，draw() 内的代码会持续运行。
+ * @description The noLoop() function causes draw() to only execute once.
+ * Without calling noLoop(), the code inside draw() is run continually.
  */
-var y;
+let y;
 
-// 程序开始时，setup() 函数中的语句执行一次。
-function setup() 
-{
-  // createCanvas 必须是第一条语句
-  createCanvas(720, 400);  
-  stroke(255);     // 线条绘制颜色设置为白色
+// The statements in the setup() function
+// execute once when the program begins
+function setup() {
+  // createCanvas should be the first statement
+  createCanvas(720, 400);
+  stroke(255); // Set line drawing color to white
   noLoop();
-  
+
   y = height * 0.5;
 }
 
-// draw() 中的语句一直执行到程序停止为止。每个语句都按顺序执行，并且在读取最后一行之后，将再次执行第一行。
-function draw() 
-{ 
-  background(0);   // 将背景设置为黑色
-  y = y - 1; 
-  if (y < 0) { y = height; } 
-  line(0, y, width, y);  
-} 
+// The statements in draw() are executed until the
+// program is stopped. Each statement is executed in
+// sequence and after the last line is read, the first
+// line is executed again.
+function draw() {
+  background(0); // Set the background to black
+  y = y - 1;
+  if (y < 0) {
+    y = height;
+  }
+  line(0, y, width, y);
+}

--- a/src/data/examples/zh-Hans/00_Structure/04_Loop.js
+++ b/src/data/examples/zh-Hans/00_Structure/04_Loop.js
@@ -1,21 +1,26 @@
 /*
  * @name Loop
- * @description draw() 函数中的代码从上到下连续运行，直到程序停止。
+ * @description The code inside the draw() function runs continuously from top
+ * to bottom until the program is stopped.
  */
-var y = 100;
+let y = 100;
 
-// 程序开始时，setup() 函数中的语句执行一次。
+// The statements in the setup() function
+// execute once when the program begins
 function setup() {
-  createCanvas(720, 400);  // createCanvas 必须是第一条语句
-  stroke(255);     // 线条绘制颜色设置为白色
+  createCanvas(720, 400); // Size must be the first statement
+  stroke(255); // Set line drawing color to white
   frameRate(30);
 }
-// draw() 中的语句一直执行到程序停止为止。每个语句都按顺序执行，并且在读取最后一行之后，将再次执行第一行。
-function draw() { 
-  background(0);   // 将背景设置为黑色
-  y = y - 1; 
-  if (y < 0) { 
-    y = height; 
-  } 
-  line(0, y, width, y);  
-} 
+// The statements in draw() are executed until the
+// program is stopped. Each statement is executed in
+// sequence and after the last line is read, the first
+// line is executed again.
+function draw() {
+  background(0); // Set the background to black
+  y = y - 1;
+  if (y < 0) {
+    y = height;
+  }
+  line(0, y, width, y);
+}

--- a/src/data/examples/zh-Hans/00_Structure/04_Loop.js
+++ b/src/data/examples/zh-Hans/00_Structure/04_Loop.js
@@ -1,23 +1,18 @@
 /*
  * @name Loop
- * @description The code inside the draw() function runs continuously from top
- * to bottom until the program is stopped.
+ * @description draw() 函数中的代码从上到下连续运行，直到程序停止。
  */
 let y = 100;
 
-// The statements in the setup() function
-// execute once when the program begins
+// 程序开始时，setup() 函数中的语句执行一次。
 function setup() {
-  createCanvas(720, 400); // Size must be the first statement
-  stroke(255); // Set line drawing color to white
+  createCanvas(720, 400); // createCanvas 必须是第一条语句
+  stroke(255); // 线条绘制颜色设置为白色
   frameRate(30);
 }
-// The statements in draw() are executed until the
-// program is stopped. Each statement is executed in
-// sequence and after the last line is read, the first
-// line is executed again.
+// draw() 中的语句一直执行到程序停止为止。每个语句都按顺序执行，并且在读取最后一行之后，将再次执行第一行。
 function draw() {
-  background(0); // Set the background to black
+  background(0); // 将背景设置为黑色
   y = y - 1;
   if (y < 0) {
     y = height;

--- a/src/data/examples/zh-Hans/00_Structure/05_Redraw.js
+++ b/src/data/examples/zh-Hans/00_Structure/05_Redraw.js
@@ -1,13 +1,11 @@
 /*
  * @name Redraw
- * @description The redraw() function makes draw() execute once. In this example,
- * draw() is executed once every time the mouse is clicked.
+ * @description redraw() 函数使 draw() 执行一次。在这个例子中，draw() 将在每次点击鼠标时执行一次。
  */
 
 let y;
 
-// The statements in the setup() function
-// execute once when the program begins
+// 程序开始时，setup() 函数中的语句执行一次。
 function setup() {
   createCanvas(720, 400);
   stroke(255);
@@ -15,10 +13,7 @@ function setup() {
   y = height * 0.5;
 }
 
-// The statements in draw() are executed until the
-// program is stopped. Each statement is executed in
-// sequence and after the last line is read, the first
-// line is executed again.
+// draw() 中的语句一直执行到程序停止为止。每个语句都按顺序执行，并且在读取最后一行之后，将再次执行第一行。.
 function draw() {
   background(0);
   y = y - 4;

--- a/src/data/examples/zh-Hans/00_Structure/05_Redraw.js
+++ b/src/data/examples/zh-Hans/00_Structure/05_Redraw.js
@@ -1,11 +1,13 @@
 /*
  * @name Redraw
- * @description redraw() 函数使 draw() 执行一次。在这个例子中，draw() 将在每次点击鼠标时执行一次。
-*/
+ * @description The redraw() function makes draw() execute once. In this example,
+ * draw() is executed once every time the mouse is clicked.
+ */
 
-var y;
+let y;
 
-// 程序开始时，setup() 函数中的语句执行一次。
+// The statements in the setup() function
+// execute once when the program begins
 function setup() {
   createCanvas(720, 400);
   stroke(255);
@@ -13,7 +15,10 @@ function setup() {
   y = height * 0.5;
 }
 
-// draw() 中的语句一直执行到程序停止为止。每个语句都按顺序执行，并且在读取最后一行之后，将再次执行第一行。.
+// The statements in draw() are executed until the
+// program is stopped. Each statement is executed in
+// sequence and after the last line is read, the first
+// line is executed again.
 function draw() {
   background(0);
   y = y - 4;
@@ -24,5 +29,5 @@ function draw() {
 }
 
 function mousePressed() {
-  redraw(); 
+  redraw();
 }

--- a/src/data/examples/zh-Hans/00_Structure/06_Functions.js
+++ b/src/data/examples/zh-Hans/00_Structure/06_Functions.js
@@ -1,8 +1,6 @@
 /*
- *@name Functions
- *@description The drawTarget() function makes it easy to draw many distinct
- *targets. Each call to drawTarget() specifies the position, size, and number of
- *rings for each target.
+ *@name 函数
+ *@description drawTarget() 函数可以很容易绘制许多不同的目标。每次调用 drawTarget() 都会为每个目标指定环的位置，大小和数量。
  */
 
 function setup() {

--- a/src/data/examples/zh-Hans/00_Structure/06_Functions.js
+++ b/src/data/examples/zh-Hans/00_Structure/06_Functions.js
@@ -17,8 +17,8 @@ function draw() {
 }
 
 function drawTarget(xloc, yloc, size, num) {
-  let grayvalues = 255 / num;
-  let steps = size / num;
+  const grayvalues = 255 / num;
+  const steps = size / num;
   for (let i = 0; i < num; i++) {
     fill(i * grayvalues);
     ellipse(xloc, yloc, size - i * steps, size - i * steps);

--- a/src/data/examples/zh-Hans/00_Structure/06_Functions.js
+++ b/src/data/examples/zh-Hans/00_Structure/06_Functions.js
@@ -1,7 +1,9 @@
 /*
- *@name 函数
- *@description drawTarget() 函数可以很容易绘制许多不同的目标。每次调用 drawTarget() 都会为每个目标指定环的位置，大小和数量。
-*/
+ *@name Functions
+ *@description The drawTarget() function makes it easy to draw many distinct
+ *targets. Each call to drawTarget() specifies the position, size, and number of
+ *rings for each target.
+ */
 
 function setup() {
   createCanvas(720, 400);
@@ -11,16 +13,16 @@ function setup() {
 }
 
 function draw() {
-  drawTarget(width*0.25, height*0.4, 200, 4);
-  drawTarget(width*0.5, height*0.5, 300, 10);
-  drawTarget(width*0.75, height*0.3, 120, 6);
+  drawTarget(width * 0.25, height * 0.4, 200, 4);
+  drawTarget(width * 0.5, height * 0.5, 300, 10);
+  drawTarget(width * 0.75, height * 0.3, 120, 6);
 }
 
 function drawTarget(xloc, yloc, size, num) {
-  var grayvalues = 255/num;
-  var steps = size/num;
-  for (var i = 0; i < num; i++) {
-    fill(i*grayvalues);
-    ellipse(xloc, yloc, size - i*steps, size - i*steps);
+  let grayvalues = 255 / num;
+  let steps = size / num;
+  for (let i = 0; i < num; i++) {
+    fill(i * grayvalues);
+    ellipse(xloc, yloc, size - i * steps, size - i * steps);
   }
 }

--- a/src/data/examples/zh-Hans/00_Structure/07_Recursion.js
+++ b/src/data/examples/zh-Hans/00_Structure/07_Recursion.js
@@ -1,8 +1,8 @@
 /*
- *@name Recursion
- *@description A demonstration of recursion, which means functions call themselves.
- * Notice how the drawCircle() function calls itself at the end of its block.
- * It continues to do this until the variable "level" is equal to 1.
+ *@name 递归
+ *@description 递归的一个演示，递归指的的是函数可以调用自身。
+ * 注意 drawCircle() 函数是如何在代码块的末尾调用它自身的。
+ * 它将继续这样执行直到变量 “level” 等于1。
  */
 
 function setup() {

--- a/src/data/examples/zh-Hans/00_Structure/07_Recursion.js
+++ b/src/data/examples/zh-Hans/00_Structure/07_Recursion.js
@@ -1,9 +1,9 @@
 /*
- *@name 递归
- *@description 递归的一个演示，递归指的的是函数可以调用自身。
- * 注意 drawCircle() 函数是如何在代码块的末尾调用它自身的。
- * 它将继续这样执行直到变量 “level” 等于1。
-*/
+ *@name Recursion
+ *@description A demonstration of recursion, which means functions call themselves.
+ * Notice how the drawCircle() function calls itself at the end of its block.
+ * It continues to do this until the variable "level" is equal to 1.
+ */
 
 function setup() {
   createCanvas(720, 400);
@@ -12,16 +12,16 @@ function setup() {
 }
 
 function draw() {
-  drawCircle(width/2, 280, 6);
+  drawCircle(width / 2, 280, 6);
 }
 
-function drawCircle(x, radius, level) {                    
-  var tt = 126 * level/4.0;
+function drawCircle(x, radius, level) {
+  let tt = (126 * level) / 4.0;
   fill(tt);
-  ellipse(x, height/2, radius*2, radius*2);      
-  if(level > 1) {
+  ellipse(x, height / 2, radius * 2, radius * 2);
+  if (level > 1) {
     level = level - 1;
-    drawCircle(x - radius/2, radius/2, level);
-    drawCircle(x + radius/2, radius/2, level);
+    drawCircle(x - radius / 2, radius / 2, level);
+    drawCircle(x + radius / 2, radius / 2, level);
   }
 }

--- a/src/data/examples/zh-Hans/00_Structure/08_Create_Graphics.js
+++ b/src/data/examples/zh-Hans/00_Structure/08_Create_Graphics.js
@@ -1,16 +1,18 @@
 /*
  * @name Create Graphics
- * @description 创建并返回一个新的 p5.Renderer 对象。如果你需要绘制到屏幕外的图形缓冲区，请使用这个种类。这两个参数以像素为单位定义宽度和高度。
+ * @description Creates and returns a new p5.Renderer object. Use this
+ * class if you need to draw into an off-screen graphics buffer. The two parameters
+ * define the width and height in pixels.
  */
 
-var pg;
+let pg;
 
-function setup(){
+function setup() {
   createCanvas(710, 400);
   pg = createGraphics(400, 250);
 }
 
-function draw(){
+function draw() {
   fill(0, 12);
   rect(0, 0, width, height);
   fill(255);
@@ -20,8 +22,8 @@ function draw(){
   pg.background(51);
   pg.noFill();
   pg.stroke(255);
-  pg.ellipse(mouseX-150, mouseY-75, 60, 60);
+  pg.ellipse(mouseX - 150, mouseY - 75, 60, 60);
 
-  //使用 image() 将屏幕外的缓冲区绘制到屏幕上
+  //Draw the offscreen buffer to the screen with image()
   image(pg, 150, 75);
 }

--- a/src/data/examples/zh-Hans/00_Structure/08_Create_Graphics.js
+++ b/src/data/examples/zh-Hans/00_Structure/08_Create_Graphics.js
@@ -1,8 +1,6 @@
 /*
  * @name Create Graphics
- * @description Creates and returns a new p5.Renderer object. Use this
- * class if you need to draw into an off-screen graphics buffer. The two parameters
- * define the width and height in pixels.
+ * @description 创建并返回一个新的 p5.Renderer 对象。如果你需要绘制到屏幕外的图形缓冲区，请使用这个种类。这两个参数以像素为单位定义宽度和高度。
  */
 
 let pg;
@@ -24,6 +22,6 @@ function draw() {
   pg.stroke(255);
   pg.ellipse(mouseX - 150, mouseY - 75, 60, 60);
 
-  //Draw the offscreen buffer to the screen with image()
+  //使用 image() 将屏幕外的缓冲区绘制到屏幕上
   image(pg, 150, 75);
 }


### PR DESCRIPTION
### Changes
All declarations with var have been changed to let and class syntax has been added where useful.
### Issue Solved
Fixes #316 