### PR TITLE
Updating Transform Examples to ES6 standards

### DIFF
--- a/src/data/examples/en/18_Transform/00_Translate.js
+++ b/src/data/examples/en/18_Transform/00_Translate.js
@@ -1,14 +1,14 @@
 /*
  * @name Translate
- * @description The translate() function allows objects to be 
- * moved to any location within the window. The first parameter 
- * sets the x-axis offset and the second parameter sets the 
+ * @description The translate() function allows objects to be
+ * moved to any location within the window. The first parameter
+ * sets the x-axis offset and the second parameter sets the
  * y-axis offset. This example shows how transforms accumulate.
  */
 
-var x = 0;
-var y = 0;
-var dim = 80.0;
+let x = 0;
+let y = 0;
+let dim = 80.0;
 
 function setup() {
   createCanvas(720, 400);
@@ -22,20 +22,19 @@ function draw() {
   // If the shape goes off the canvas, reset the position
   if (x > width + dim) {
     x = -dim;
-  } 
-  
+  }
+
   // Even though our rect command draws the shape with its
-  // center at the origin, translate moves it to the new 
+  // center at the origin, translate moves it to the new
   // x and y position
-  translate(x, height/2-dim/2);
+  translate(x, height / 2 - dim / 2);
   fill(255);
-  rect(-dim/2, -dim/2, dim, dim);
-  
-  // Transforms accumulate. Notice how this rect moves 
-  // twice as fast as the other, but it has the same 
+  rect(-dim / 2, -dim / 2, dim, dim);
+
+  // Transforms accumulate. Notice how this rect moves
+  // twice as fast as the other, but it has the same
   // parameter for the x-axis value
   translate(x, dim);
   fill(0);
-  rect(-dim/2, -dim/2, dim, dim);
-  
+  rect(-dim / 2, -dim / 2, dim, dim);
 }

--- a/src/data/examples/en/18_Transform/01_Scale.js
+++ b/src/data/examples/en/18_Transform/01_Scale.js
@@ -8,8 +8,8 @@
  * interact depending on their order.
  */
 
-var a = 0.0;
-var s = 0.0;
+let a = 0.0;
+let s = 0.0;
 
 function setup() {
   createCanvas(720, 400);
@@ -21,26 +21,26 @@ function setup() {
 
 function draw() {
   background(102);
-  
+
   //Slowly increase 'a' and then animate 's' with
   //a smooth cyclical motion by finding the cosine of 'a'
   a = a + 0.04;
-  s = cos(a)*2;
-  
+  s = cos(a) * 2;
+
   //Translate our rectangle from the origin to the middle of
   //the canvas, then scale it with 's'
-  translate(width/2, height/2);
-  scale(s); 
+  translate(width / 2, height / 2);
+  scale(s);
   fill(51);
-  rect(0, 0, 50, 50); 
-  
+  rect(0, 0, 50, 50);
+
   //Translate and scale are accumulating, so this translate
   //moves the second rectangle further right than the first
-  //and the scale is getting doubled. Note that cosine is 
-  //making 's' both negative and positive, thus it cycles 
-  //from left to right. 
+  //and the scale is getting doubled. Note that cosine is
+  //making 's' both negative and positive, thus it cycles
+  //from left to right.
   translate(75, 0);
   fill(255);
   scale(s);
-  rect(0, 0, 50, 50);       
+  rect(0, 0, 50, 50);
 }

--- a/src/data/examples/en/18_Transform/02_Rotate.js
+++ b/src/data/examples/en/18_Transform/02_Rotate.js
@@ -1,6 +1,6 @@
 /*
  * @name Rotate
- * @description Rotating a square around the Z axis. 
+ * @description Rotating a square around the Z axis.
  * To get the results you expect, send the rotate function angle
  * parameters that are values between 0 and PI*2 (TWO_PI which is
  * roughly 6.28). If you prefer to think about angles as degrees
@@ -11,8 +11,8 @@
  * CCW at the speed determined by the last jitter value.
  */
 
-var angle = 0.0;
-var jitter = 0.0;
+let angle = 0.0;
+let jitter = 0.0;
 
 function setup() {
   createCanvas(720, 400);
@@ -28,16 +28,16 @@ function draw() {
 
   // during even-numbered seconds (0, 2, 4, 6...) add jitter to
   // the rotation
-  if (second() % 2 == 0) {  
+  if (second() % 2 === 0) {
     jitter = random(-0.1, 0.1);
   }
   //increase the angle value using the most recent jitter value
   angle = angle + jitter;
   //use cosine to get a smooth CW and CCW motion when not jittering
-  var c = cos(angle);
+  let c = cos(angle);
   //move the shape to the center of the canvas
-  translate(width/2, height/2);
+  translate(width / 2, height / 2);
   //apply the final rotation
   rotate(c);
-  rect(0, 0, 180, 180);   
+  rect(0, 0, 180, 180);
 }

--- a/src/data/examples/en/18_Transform/03_Arm.js
+++ b/src/data/examples/en/18_Transform/03_Arm.js
@@ -8,18 +8,18 @@
  * pop() matrix group.
  */
 
-var x, y;
-var angle1 = 0.0;
-var angle2 = 0.0;
-var segLength = 100;
+let x, y;
+let angle1 = 0.0;
+let angle2 = 0.0;
+let segLength = 100;
 
 function setup() {
   createCanvas(720, 400);
   strokeWeight(30);
-  
+
   //Stroke with a semi-transparent white
   stroke(255, 160);
-  
+
   //Position the "shoulder" of the arm in the center of the canvas
   x = width * 0.5;
   y = height * 0.5;
@@ -27,16 +27,16 @@ function setup() {
 
 function draw() {
   background(0);
-  
-  //Change the angle of the segments according to the mouse positions 
-  angle1 = (mouseX/float(width) - 0.5) * -TWO_PI;
-  angle2 = (mouseY/float(height) - 0.5) * PI;
-  
+
+  //Change the angle of the segments according to the mouse positions
+  angle1 = (mouseX / float(width) - 0.5) * -TWO_PI;
+  angle2 = (mouseY / float(height) - 0.5) * PI;
+
   //use push and pop to "contain" the transforms. Note that
   // even though we draw the segments using a custom function,
   // the transforms still accumulate
   push();
-  segment(x, y, angle1); 
+  segment(x, y, angle1);
   segment(segLength, 0, angle2);
   pop();
 }

--- a/src/data/examples/es/18_Transform/00_Translate.js
+++ b/src/data/examples/es/18_Transform/00_Translate.js
@@ -7,9 +7,9 @@
  * transformadas se acumulan.
  */
 
-var x = 0;
-var y = 0;
-var dim = 80.0;
+let x = 0;
+let y = 0;
+let dim = 80.0;
 
 function setup() {
   createCanvas(720, 400);
@@ -27,15 +27,14 @@ function draw() {
 
   // Aunque nuestro comando rect() dibuja la figura con su centro
   // en el origen, translate() lo mueve a una nueva posición x,y
-  translate(x, height/2-dim/2);
+  translate(x, height / 2 - dim / 2);
   fill(255);
-  rect(-dim/2, -dim/2, dim, dim);
+  rect(-dim / 2, -dim / 2, dim, dim);
 
   // Las transformaciones se acumulan. Observa cómo este rect se mueve
   // al doble de velocidad que el otro, a pesar de que tiene el mismo
   // parámetro para el valor de x.
   translate(x, dim);
   fill(0);
-  rect(-dim/2, -dim/2, dim, dim);
-
+  rect(-dim / 2, -dim / 2, dim, dim);
 }

--- a/src/data/examples/es/18_Transform/01_Scale.js
+++ b/src/data/examples/es/18_Transform/01_Scale.js
@@ -9,8 +9,8 @@
  * orden.
  */
 
-var a = 0.0;
-var s = 0.0;
+let a = 0.0;
+let s = 0.0;
 
 function setup() {
   createCanvas(720, 400);
@@ -26,11 +26,11 @@ function draw() {
   // Lentamente aumenta 'a' y luego anima 's' con un movimiento
   // cíclico suave mediante el cálculo de coseno de 'a'
   a = a + 0.04;
-  s = cos(a)*2;
+  s = cos(a) * 2;
 
   // Traslada nuestro rectángulo desde el origen hacia el centro
   // del lienzo, luego escálalo con 's'
-  translate(width/2, height/2);
+  translate(width / 2, height / 2);
   scale(s);
   fill(51);
   rect(0, 0, 50, 50);

--- a/src/data/examples/es/18_Transform/02_Rotate.js
+++ b/src/data/examples/es/18_Transform/02_Rotate.js
@@ -32,16 +32,16 @@ function draw() {
 
   // Durante los segundos pares (0, 2, 4, 6...), añade jitter a
   // la rotación
-  if (second() % 2 == 0) {
+  if (second() % 2 === 0) {
     jitter = random(-0.1, 0.1);
   }
   //increase the angle value using the most recent jitter value
   angulo = angulo + jitter;
   // Usa coseno para obtener un movimiento suave a favor y en contra
   // de las manecillas del reloj cuando no esté  haciendo jittering
-  var c = cos(angulo);
+  let c = cos(angulo);
   // Mueve la figura al centro del lienzo
-  translate(width/2, height/2);
+  translate(width / 2, height / 2);
   // Aplica la rotación final
   rotate(c);
   rect(0, 0, 180, 180);

--- a/src/data/examples/es/18_Transform/03_Arm.js
+++ b/src/data/examples/es/18_Transform/03_Arm.js
@@ -28,8 +28,8 @@ function draw() {
   background(0);
 
   //Modifica el ángulo de los segmentos según la posición del ratón
-  angulo1 = (mouseX/float(width) - 0.5) * -TWO_PI;
-  angulo2 = (mouseY/float(height) - 0.5) * PI;
+  angulo1 = (mouseX / float(width) - 0.5) * -TWO_PI;
+  angulo2 = (mouseY / float(height) - 0.5) * PI;
 
   // Usa push y pop para "contener" las transformaciones. Nota que
   // aunque dibujamos los segmentos usando una función de fabricación propia,

--- a/src/data/examples/zh-Hans/18_Transform/00_Translate.js
+++ b/src/data/examples/zh-Hans/18_Transform/00_Translate.js
@@ -1,14 +1,14 @@
 /*
  * @name Translate
- * @description The translate() function allows objects to be 
- * moved to any location within the window. The first parameter 
- * sets the x-axis offset and the second parameter sets the 
+ * @description The translate() function allows objects to be
+ * moved to any location within the window. The first parameter
+ * sets the x-axis offset and the second parameter sets the
  * y-axis offset. This example shows how transforms accumulate.
  */
 
-var x = 0;
-var y = 0;
-var dim = 80.0;
+let x = 0;
+let y = 0;
+let dim = 80.0;
 
 function setup() {
   createCanvas(720, 400);
@@ -22,20 +22,19 @@ function draw() {
   // If the shape goes off the canvas, reset the position
   if (x > width + dim) {
     x = -dim;
-  } 
-  
+  }
+
   // Even though our rect command draws the shape with its
-  // center at the origin, translate moves it to the new 
+  // center at the origin, translate moves it to the new
   // x and y position
-  translate(x, height/2-dim/2);
+  translate(x, height / 2 - dim / 2);
   fill(255);
-  rect(-dim/2, -dim/2, dim, dim);
-  
-  // Transforms accumulate. Notice how this rect moves 
-  // twice as fast as the other, but it has the same 
+  rect(-dim / 2, -dim / 2, dim, dim);
+
+  // Transforms accumulate. Notice how this rect moves
+  // twice as fast as the other, but it has the same
   // parameter for the x-axis value
   translate(x, dim);
   fill(0);
-  rect(-dim/2, -dim/2, dim, dim);
-  
+  rect(-dim / 2, -dim / 2, dim, dim);
 }

--- a/src/data/examples/zh-Hans/18_Transform/01_Scale.js
+++ b/src/data/examples/zh-Hans/18_Transform/01_Scale.js
@@ -8,8 +8,8 @@
  * interact depending on their order.
  */
 
-var a = 0.0;
-var s = 0.0;
+let a = 0.0;
+let s = 0.0;
 
 function setup() {
   createCanvas(720, 400);
@@ -21,26 +21,26 @@ function setup() {
 
 function draw() {
   background(102);
-  
+
   //Slowly increase 'a' and then animate 's' with
   //a smooth cyclical motion by finding the cosine of 'a'
   a = a + 0.04;
-  s = cos(a)*2;
-  
+  s = cos(a) * 2;
+
   //Translate our rectangle from the origin to the middle of
   //the canvas, then scale it with 's'
-  translate(width/2, height/2);
-  scale(s); 
+  translate(width / 2, height / 2);
+  scale(s);
   fill(51);
-  rect(0, 0, 50, 50); 
-  
+  rect(0, 0, 50, 50);
+
   //Translate and scale are accumulating, so this translate
   //moves the second rectangle further right than the first
-  //and the scale is getting doubled. Note that cosine is 
-  //making 's' both negative and positive, thus it cycles 
-  //from left to right. 
+  //and the scale is getting doubled. Note that cosine is
+  //making 's' both negative and positive, thus it cycles
+  //from left to right.
   translate(75, 0);
   fill(255);
   scale(s);
-  rect(0, 0, 50, 50);       
+  rect(0, 0, 50, 50);
 }

--- a/src/data/examples/zh-Hans/18_Transform/02_Rotate.js
+++ b/src/data/examples/zh-Hans/18_Transform/02_Rotate.js
@@ -1,6 +1,6 @@
 /*
  * @name Rotate
- * @description Rotating a square around the Z axis. 
+ * @description Rotating a square around the Z axis.
  * To get the results you expect, send the rotate function angle
  * parameters that are values between 0 and PI*2 (TWO_PI which is
  * roughly 6.28). If you prefer to think about angles as degrees
@@ -11,8 +11,8 @@
  * CCW at the speed determined by the last jitter value.
  */
 
-var angle = 0.0;
-var jitter = 0.0;
+let angle = 0.0;
+let jitter = 0.0;
 
 function setup() {
   createCanvas(720, 400);
@@ -28,16 +28,16 @@ function draw() {
 
   // during even-numbered seconds (0, 2, 4, 6...) add jitter to
   // the rotation
-  if (second() % 2 == 0) {  
+  if (second() % 2 === 0) {
     jitter = random(-0.1, 0.1);
   }
   //increase the angle value using the most recent jitter value
   angle = angle + jitter;
   //use cosine to get a smooth CW and CCW motion when not jittering
-  var c = cos(angle);
+  let c = cos(angle);
   //move the shape to the center of the canvas
-  translate(width/2, height/2);
+  translate(width / 2, height / 2);
   //apply the final rotation
   rotate(c);
-  rect(0, 0, 180, 180);   
+  rect(0, 0, 180, 180);
 }

--- a/src/data/examples/zh-Hans/18_Transform/03_Arm.js
+++ b/src/data/examples/zh-Hans/18_Transform/03_Arm.js
@@ -8,18 +8,18 @@
  * pop() matrix group.
  */
 
-var x, y;
-var angle1 = 0.0;
-var angle2 = 0.0;
-var segLength = 100;
+let x, y;
+let angle1 = 0.0;
+let angle2 = 0.0;
+let segLength = 100;
 
 function setup() {
   createCanvas(720, 400);
   strokeWeight(30);
-  
+
   //Stroke with a semi-transparent white
   stroke(255, 160);
-  
+
   //Position the "shoulder" of the arm in the center of the canvas
   x = width * 0.5;
   y = height * 0.5;
@@ -27,16 +27,16 @@ function setup() {
 
 function draw() {
   background(0);
-  
-  //Change the angle of the segments according to the mouse positions 
-  angle1 = (mouseX/float(width) - 0.5) * -TWO_PI;
-  angle2 = (mouseY/float(height) - 0.5) * PI;
-  
+
+  //Change the angle of the segments according to the mouse positions
+  angle1 = (mouseX / float(width) - 0.5) * -TWO_PI;
+  angle2 = (mouseY / float(height) - 0.5) * PI;
+
   //use push and pop to "contain" the transforms. Note that
   // even though we draw the segments using a custom function,
   // the transforms still accumulate
   push();
-  segment(x, y, angle1); 
+  segment(x, y, angle1);
   segment(segLength, 0, angle2);
   pop();
 }


### PR DESCRIPTION
### Changes
All declarations with var have been changed to let and class syntax has been added where useful.

### Issue Solved
Fixes #332 