### PR TITLE
Travis Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "lts/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,12 @@
 language: node_js
 node_js:
   - "lts/*"
+
+deploy:
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN
+  keep-history: true
+  local-dir: dist/
+  on:
+    branch: master


### PR DESCRIPTION
Adds a `.travis.yml`

- Builds the reference for PRs, which should hopefully give a status if the build is failing
- On push to master, use the built-in GitHub pages deployment to push the generated `dist/` folder to the `gh-pages` branch

Part of #147

Setup required:
- Set up Travis-ci for this repository, including adding a `GITHUB_TOKEN` environment variable to a personal access token.
- Repoint the deployment scripts to look at the `gh-pages` branch instead of `master` (noting that gh-pages is only the content of the current `dist/` directory) OR perhaps we can work on moving to actually running the reference from GitHub Pages - I have deployed the test version from my repository here: https://p5-web.meiamso.me/ which is mostly functional, barring the downloads page, but we could replace the `downloads/version.json` file with a fetch to the `p5.js` github repository's releases directly.