### PR TITLE
Build zh-Hans into the correct directory on case-sensitive file systems

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -100,7 +100,7 @@ module.exports = function(grunt) {
               {
                 pattern: ':lang',
                 replacement: function () {
-                  return this.language.toLowerCase() === 'en' ? '' : this.language.toLowerCase();
+                  return this.language.toLowerCase() === 'en' ? '' : this.language;
                 }
               },
               {


### PR DESCRIPTION
Keeps the case of the directory correct. Currently, in case-insensitive file systems this doesn't cause an issue as they end up in the same folder, but in a case-sensitive filesystem (Most *nix systems) the build results in a `dist/zh-hans/` and a `dist/zh-Hans/` folder. I have removed the `.toLowerCase()` to make the folder outputs the same. 

This is the issue causing some issues in #342