### PR TITLE
corrects errors present in modifying DOM example

### DIFF
--- a/src/data/examples/en/16_Dom/07_Modify_DOM.js
+++ b/src/data/examples/en/16_Dom/07_Modify_DOM.js
@@ -11,12 +11,15 @@ let dancingWords = [];
 class DanceSpan {
   constructor(element, x, y) {
     element.position(x, y);
+    this.element = element;
+    this.x = x;
+    this.y = y;
   }
 
   brownian() {
-    x += random(-6, 6);
-    y += random(-6, 6);
-    element.position(x, y);
+    this.x += random(-6, 6);
+    this.y += random(-6, 6);
+    this.element.position(this.x, this.y);
   }
 }
 
@@ -28,7 +31,7 @@ function setup() {
   createP(
     'I learn in this Letter, that Don Peter of Aragon, ' +
       ' comes this night to Messina'
-  ).addClass('text');
+  ).addClass('text').hide();
 
   // This line grabs the paragraph just created, but it would
   // also grab any other elements with class 'text' in the HTML

--- a/src/data/examples/es/16_Dom/07_Modify_DOM.js
+++ b/src/data/examples/es/16_Dom/07_Modify_DOM.js
@@ -11,12 +11,15 @@ let dancingWords = [];
 class DanceSpan {
   constructor(element, x, y) {
     element.position(x, y);
+    this.element = element;
+    this.x = x;
+    this.y = y;
   }
 
   brownian() {
-    x += random(-6, 6);
-    y += random(-6, 6);
-    element.position(x, y);
+    this.x += random(-6, 6);
+    this.y += random(-6, 6);
+    this.element.position(this.x, this.y);
   }
 }
 
@@ -25,9 +28,9 @@ function setup() {
   // Es para diferenciar entre la creación de un elemento y su selección.
   // Los elementos seleccionados no necesitan ser creados por p5js, pueden ser HTML plano.
   createP(
-    'I learne in this Letter, that Don Peter of Arragon, ' +
+    'I learn in this Letter, that Don Peter of Arragon, ' +
       ' comes this night to Messina'
-  ).addClass('text');
+  ).addClass('text').hide();
 
   // Esta línea toma el párrafo recién creado, pero podría también
   // tomar otros elementos de la clase 'text' en la página HTML.

--- a/src/data/examples/zh-Hans/16_Dom/07_Modify_DOM.js
+++ b/src/data/examples/zh-Hans/16_Dom/07_Modify_DOM.js
@@ -11,12 +11,15 @@ let dancingWords = [];
 class DanceSpan {
   constructor(element, x, y) {
     element.position(x, y);
+    this.element = element;
+    this.x = x;
+    this.y = y;
   }
 
   brownian() {
-    x += random(-6, 6);
-    y += random(-6, 6);
-    element.position(x, y);
+    this.x += random(-6, 6);
+    this.y += random(-6, 6);
+    this.element.position(this.x, this.y);
   }
 }
 
@@ -28,7 +31,7 @@ function setup() {
   createP(
     'I learn in this Letter, that Don Peter of Aragon, ' +
       ' comes this night to Messina'
-  ).addClass('text');
+  ).addClass('text').hide();
 
   // This line grabs the paragraph just created, but it would
   // also grab any other elements with class 'text' in the HTML


### PR DESCRIPTION
The changes made in the PR are:

- Correct the reference error present in the example, by including 'this' in the DanceSpan class, wherever 
necassary.
- Hiding the created paragraph to make the example a little cleaner.

**before:**
![x_not_defined](https://user-images.githubusercontent.com/35770004/52360183-6bc86400-2a61-11e9-9c64-6f3a6dfa0306.png)

**after:**
![corrected](https://user-images.githubusercontent.com/35770004/52360378-e1343480-2a61-11e9-8016-d4c20e154242.png)


I request the maintainers to review this PR, thank you!
