### PR TITLE
Fix 'letiable' typos

### DIFF
--- a/src/data/examples/en/09_Simulate/06_Spirograph.js
+++ b/src/data/examples/en/09_Simulate/06_Spirograph.js
@@ -10,7 +10,7 @@
 let NUMSINES = 20; // how many of these things can we do at once?
 let sines = new Array(NUMSINES); // an array to hold all the current angles
 let rad; // an initial radius value for the central sine
-let i; // a counter letiable
+let i; // a counter variable
 
 // play with these to get a sense of what's going on:
 let fund = 0.005; // the speed of the central sine

--- a/src/data/examples/en/09_Simulate/08_Spring.js
+++ b/src/data/examples/en/09_Simulate/08_Spring.js
@@ -18,7 +18,7 @@ let M = 0.8,  // Mass
     D = 0.92, // Damping
     R = 150;  // Rest position
 
-// Spring simulation letiables
+// Spring simulation variables
 let ps = R,   // Position
     vs = 0.0, // Velocity
     as = 0,   // Acceleration

--- a/src/data/examples/en/09_Simulate/09_Springs.js
+++ b/src/data/examples/en/09_Simulate/09_Springs.js
@@ -62,7 +62,7 @@ function Spring (_x, _y, _s, _d, _m, _k_in, _others, _id) {
   this.rest_posx = _x;  // Rest position X
   this.rest_posy = _y;  // Rest position Y
 
-  // Spring simulation letiables
+  // Spring simulation variables
   //float pos = 20.0; // Position
   this.velx = 0.0;   // X Velocity
   this.vely = 0.0;   // Y Velocity

--- a/src/data/examples/en/09_Simulate/11_SmokeParticleSystem.js
+++ b/src/data/examples/en/09_Simulate/11_SmokeParticleSystem.js
@@ -7,7 +7,7 @@
 // texture for the particle
 let particle_texture = null;
 
-// letiable holding our particle system
+// variable holding our particle system
 let ps = null;
 
 function preload() {
@@ -79,8 +79,8 @@ let ParticleSystem = function(num, v, img_) {
  */
 ParticleSystem.prototype.run = function() {
 
-  // cache length of the array we're going to loop into a letiable
-  // You may see <letiable>.length in a for loop, from time to time but
+  // cache length of the array we're going to loop into a variable
+  // You may see <variable>.length in a for loop, from time to time but
   // we cache it here because otherwise the length is re-calculated for each iteration of a loop
   let len = this.particles.length;
 

--- a/src/data/examples/es/09_Simulate/06_Spirograph.js
+++ b/src/data/examples/es/09_Simulate/06_Spirograph.js
@@ -10,7 +10,7 @@
 let NUMSINES = 20; // cuántas partículas podemos hacer al mismo tiempo?
 let sines = new Array(NUMSINES); // un arreglo para almacenar todos los ángulos actuales
 let rad; // un valor de radio inicial para la sinusoide central
-let i; // una letiable contador
+let i; // una variable contador
 
 // juega con estos valores para entender lo que está pasando:
 let fund = 0.005; // la velocidad de la sinusoide central

--- a/src/data/examples/es/09_Simulate/08_Spring.js
+++ b/src/data/examples/es/09_Simulate/08_Spring.js
@@ -18,7 +18,7 @@ let M = 0.8,  // Masa
     D = 0.92, // Amortiguamiento
     R = 150;  // Posición de reposo
 
-// letiables de simulación de resorte
+// variables de simulación de resorte
 let ps = R,   // Posición
     vs = 0.0, // Velocidad
     as = 0,   // Aceleración

--- a/src/data/examples/es/09_Simulate/09_Springs.js
+++ b/src/data/examples/es/09_Simulate/09_Springs.js
@@ -62,7 +62,7 @@ function Spring (_x, _y, _s, _d, _m, _k_in, _others, _id) {
 	this.rest_posx = _x;  // Rest position X
 	this.rest_posy = _y;  // Rest position Y
 
-	// Spring simulation letiables
+	// Spring simulation variables
 	//float pos = 20.0; // Position
 	this.velx = 0.0;   // X Velocity
 	this.vely = 0.0;   // Y Velocity

--- a/src/data/examples/es/09_Simulate/11_SmokeParticleSystem.js
+++ b/src/data/examples/es/09_Simulate/11_SmokeParticleSystem.js
@@ -6,7 +6,7 @@
 // textura de la partícula
 let particle_texture = null;
 
-// letiabla para almacenar el sistema de partículas
+// variabla para almacenar el sistema de partículas
 let ps = null;
 
 function preload() {
@@ -78,8 +78,8 @@ let ParticleSystem = function(num, v, img_) {
  */
 ParticleSystem.prototype.run = function() {
 
-    // guardar en una letiable el largo del arreglo sobre el que vamos a iterar
-    // Puedes encontrar este largo con la sintaxis <letiable>.length dentro un bucle for
+    // guardar en una variable el largo del arreglo sobre el que vamos a iterar
+    // Puedes encontrar este largo con la sintaxis <variable>.length dentro un bucle for
     // pero lo guardamos acá porque en caso contrario, estaríamos recalculando el largo en cada iteración del bucle for
     let len = this.particles.length;
 

--- a/src/data/examples/zh-Hans/09_Simulate/06_Spirograph.js
+++ b/src/data/examples/zh-Hans/09_Simulate/06_Spirograph.js
@@ -10,7 +10,7 @@
 let NUMSINES = 20; // how many of these things can we do at once?
 let sines = new Array(NUMSINES); // an array to hold all the current angles
 let rad; // an initial radius value for the central sine
-let i; // a counter letiable
+let i; // a counter variable
 
 // play with these to get a sense of what's going on:
 let fund = 0.005; // the speed of the central sine

--- a/src/data/examples/zh-Hans/09_Simulate/08_Spring.js
+++ b/src/data/examples/zh-Hans/09_Simulate/08_Spring.js
@@ -18,7 +18,7 @@ let M = 0.8,  // Mass
     D = 0.92, // Damping
     R = 150;  // Rest position
 
-// Spring simulation letiables
+// Spring simulation variables
 let ps = R,   // Position
     vs = 0.0, // Velocity
     as = 0,   // Acceleration

--- a/src/data/examples/zh-Hans/09_Simulate/09_Springs.js
+++ b/src/data/examples/zh-Hans/09_Simulate/09_Springs.js
@@ -62,7 +62,7 @@ function Spring (_x, _y, _s, _d, _m, _k_in, _others, _id) {
 	this.rest_posx = _x;  // Rest position X
 	this.rest_posy = _y;  // Rest position Y
 
-	// Spring simulation letiables
+	// Spring simulation variables
 	//float pos = 20.0; // Position
 	this.velx = 0.0;   // X Velocity
 	this.vely = 0.0;   // Y Velocity

--- a/src/data/examples/zh-Hans/09_Simulate/11_SmokeParticleSystem.js
+++ b/src/data/examples/zh-Hans/09_Simulate/11_SmokeParticleSystem.js
@@ -7,7 +7,7 @@
 // texture for the particle
 let particle_texture = null;
 
-// letiable holding our particle system
+// variable holding our particle system
 let ps = null;
 
 function preload() {
@@ -79,8 +79,8 @@ let ParticleSystem = function(num, v, img_) {
  */
 ParticleSystem.prototype.run = function() {
 
-    // cache length of the array we're going to loop into a letiable
-    // You may see <letiable>.length in a for loop, from time to time but
+    // cache length of the array we're going to loop into a variable
+    // You may see <variable>.length in a for loop, from time to time but
     // we cache it here because otherwise the length is re-calculated for each iteration of a loop
     let len = this.particles.length;
 


### PR DESCRIPTION
A bunch of the word "variable" got changed into "letiable".

Bulk find replace of `var` into `let` without checking causes typo like this, I would advice doing find replace one by one to make sure this doesn't happen in the future.

I should have caught all unintended replace but no way to be sure really, at least there definitely isn't any "letiable" left.