### PR TITLE
Fix top margin for methods table in reference page

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1342,6 +1342,9 @@ h4 + p {display: inline;}
     float:left;
 }
 
+.method_description p {
+  margin-top: 0;
+}
 
 section {
     padding:0;

--- a/src/yuidoc-p5-theme-src/scripts/tpl/class.html
+++ b/src/yuidoc-p5-theme-src/scripts/tpl/class.html
@@ -24,7 +24,7 @@
     <table>
     <% _.each(methods, function(item) { %>
       <tr>
-      <td><a href="<%=item.hash%>" <% if (item.module !== module) { %>class="addon"<% } %>><%=item.name%><% if (item.itemtype === 'method') { %>()<%}%></a></td><td><%= item.description %></td>
+      <td><a href="<%=item.hash%>" <% if (item.module !== module) { %>class="addon"<% } %>><%=item.name%><% if (item.itemtype === 'method') { %>()<%}%></a></td><td><div class="method_description"><%= item.description %></div></td>
       </tr>
     <% }); %>
     </table>


### PR DESCRIPTION
Fixes #411

The changes made in this PR are : 

1.add new class "method_description" to main.css , such that its children paragraph elements have 0 top margin.

2.wrap the method description paragraph elements in a div , whose class is "method_description".

@lmccart , please review these changes ,
Thank you !