### PR TITLE
Improved developer docs written in markdown

### DIFF
--- a/contributor_docs/Adding_examples.md
+++ b/contributor_docs/Adding_examples.md
@@ -4,31 +4,32 @@ Examples help demonstrate different programming concepts and functionality of th
 
 ## Getting started
 
-  0. If you are not yet familiar with GitHub we recommend checking out this [tutorial](https://guides.github.com/activities/hello-world/).
-  1. Install [node.js](https://nodejs.org/en/), which also automatically installs the npm package manager.
-  2. [Fork](https://help.github.com/articles/fork-a-repo/) the [p5.js-website](https://github.com/processing/p5.js-website) repository into your own GitHub account.
-  3. [Clone](https://help.github.com/articles/cloning-a-repository/) your new fork of the repository from GitHub onto your local computer.
-  4. Using the command line, navigate to the `src/data/examples/build_examples` folder, and install all its necessary dependencies with npm.
-  ```
-  cd src/data/examples/build_examples
-  npm install
-  ```
+0. If you are not yet familiar with GitHub we recommend checking out this [tutorial](https://guides.github.com/activities/hello-world/).
+1. Install [node.js](https://nodejs.org/en/), which also automatically installs the npm package manager.
+2. [Fork](https://help.github.com/articles/fork-a-repo/) the [p5.js-website](https://github.com/processing/p5.js-website) repository into your own GitHub account.
+3. [Clone](https://help.github.com/articles/cloning-a-repository/) your new fork of the repository from GitHub onto your local computer.
+4. Using the command line, navigate to the `src/data/examples/build_examples` folder, and install all its necessary dependencies with npm.
+
+    ```bash
+    cd src/data/examples/build_examples
+    npm install
+    ```
 
 ## Make an issue
 
-  1.Open a new issue on the [p5.js-website repository](https://github.com/processing/p5.js-website/issues) listing the examples you are creating with your name, so efforts aren't duplicated.
+  1. Open a new issue on the [p5.js-website repository](https://github.com/processing/p5.js-website/issues) listing the examples you are creating with your name, so efforts aren't duplicated.
 
 ## Create your example
 
 1. First, build and test the example code using your own HTML file, linking to the most recent version of p5.js. You can find examples to port here.
-  * Please use two spaces tabs and see this code style guide.
-  * Examples should typically be 710px wide, and a recommended height is 400px. You can modify these dimensions (especially the height) as appropriate.
+    * Please use two spaces tabs and see this code style guide.
+    * Examples should typically be 710px wide, and a recommended height is 400px. You can modify these dimensions (especially the height) as appropriate.
 
 2. At the top of the JS file you create, add a heading using the template below.
-  * The @name field determines the title of the example and the text of it's corresponding link on the examples page.
-  * The @frame field determines the dimensions of the example frame on the page. If you leave this field out, your running example will default to the size you set with createCanvas(). If you'd like to specify an alternate size (maybe because you have elements outside the canvas, for example), include the @frame line with dimensions separated by comma.
+    * The @name field determines the title of the example and the text of it's corresponding link on the examples page.
+    * The @frame field determines the dimensions of the example frame on the page. If you leave this field out, your running example will default to the size you set with createCanvas(). If you'd like to specify an alternate size (maybe because you have elements outside the canvas, for example), include the @frame line with dimensions separated by comma.
 
-   ```
+   ```jsdoc
    /*
     * @name Your Example Name Here (This shows up on the examples page as well.)
     * @frame 710,400 (optional)
@@ -39,10 +40,11 @@ Examples help demonstrate different programming concepts and functionality of th
    ```
 
 ## Add your example to p5js.org
+
 1. Place the JS file with your code and heading (do not include the HTML or p5.js files) in `src/data/examples/en/` of your local repository.
-  * The subfolder the file is placed in determines the topic heading the examples displays under on [p5js.org/examples](https://p5js.org/examples/). Add your file into the appropriate folder, or create a new one if necessary.
-  * If you create a new folder, you will also need to add the folder name to the `examples` section in the `src/data/en.yml`, `src/data/es.yml`, and `src/data/zh-Hans.yml` files in order for the headings to show up properly.
-  * The filename should follow the format: `XX_name_of_your_example.js`. The XX_ prefix (starting with 00) indicates the order that the files will show up on the page.
+    * The subfolder the file is placed in determines the topic heading the examples displays under on [p5js.org/examples](https://p5js.org/examples/). Add your file into the appropriate folder, or create a new one if necessary.
+    * If you create a new folder, you will also need to add the folder name to the `examples` section in the `src/data/en.yml`, `src/data/es.yml`, and `src/data/zh-Hans.yml` files in order for the headings to show up properly.
+    * The filename should follow the format: `XX_name_of_your_example.js`. The XX_ prefix (starting with 00) indicates the order that the files will show up on the page.
 
 2. Place duplicate copies of the file in the corresponding folders in `src/data/examples/es/`, and `src/data/examples/zh-Hans/`. This allows us to build the Spanish and Chinese versions of the example. If you know either of these languages, feel free to translate the heading text and comments.
 
@@ -50,32 +52,32 @@ Examples help demonstrate different programming concepts and functionality of th
 
 4. [Grunt](https://gruntjs.com/) should now be installed, and you can use it to build the website by navigating to the top level directory and typing:
 
-```
-grunt server
-```
+    ```bash
+    grunt server
+    ```
 
 5. A local build of the p5js.org site should open in your web browser and you can navigate to the examples page to see your changes.
 
 6. Once everything is ready, submit your changes as a [pull request](https://help.github.com/articles/creating-a-pull-request/).
 
 ## Notes about translating examples
-  * The [p5js.org/examples](https://p5js.org/examples/) page is built from the data in [src/data/](https://github.com/processing/p5.js-website/tree/master/src/data).
-  * Within the examples folder, there is a folder for each of the three languages we currently support: `en/`, `es/`, and `zh-Hans/`.
-  * Translations for the topic headers on the example index page are done in the YML files `src/data/*.yml`.
+
+* The [p5js.org/examples](https://p5js.org/examples/) page is built from the data in [src/data/](https://github.com/processing/p5.js-website/tree/master/src/data).
+* Within the examples folder, there is a folder for each of the three languages we currently support: `en/`, `es/`, and `zh-Hans/`.
+* Translations for the topic headers on the example index page are done in the YML files `src/data/*.yml`.
 
 ## To add examples
-1. Locate the JS file within [`src/data/examples`] that corresponds to the example you want to add a translation for.
+
+1. Locate the JS file within `src/data/examples` that corresponds to the example you want to add a translation for.
 2. Translate the heading and comments. Do not change variable or function names. Do not change the filename.
 3. To update a category heading on [p5js.org/examples](https://p5js.org/examples/), edit the YML files at `src/data/*.yml`.
 
-## When adding a new examples
+## When adding a new example
+
 1. First add an English version of the file to the `en/` folder, then make sure it is duplicated in the same place in all other languages, then translate for whichever languages you can.
-2. The folder, file, and numbering structure should match exactly between the different languages. Do not change the filenames. The text for the example name, description, and source code are all in the .js files in the folders.
+2. The folder, file, and numbering structure should match exactly between the different languages. Do not change the filenames. The text for the example name, description, and source code are all in the `.js` files in the folders.
 3. If you have created a new folder, add entries to the "Examples" section of each of the YML files `src/data/*.yml` with the foldername as the key.
 
 ## Questions
+
 Email [hello@p5js.org](mailto:hello@p5js.org) for help!
-
-
-
-

--- a/contributor_docs/i18n_contribution.md
+++ b/contributor_docs/i18n_contribution.md
@@ -31,10 +31,10 @@ If you want to contribute with p5.js website translations, you are in the right 
 
 1. Install node.js by following the instructions [here](https://nodejs.org/en/download/).
 2. [Fork](https://help.github.com/articles/fork-a-repo/) the p5.js-website repository to your Github account. Click the *Fork* button on the upper-right side of the p5.js-website Github repo. This will automatically open your fork repo on Github.
-![processing/p5.js-website repository menu. At the right bottom of the menu the "fork" button is highlighted](https://github.com/processing/p5.js-website/tree/master/contributor_docs/assets/fork.png)
+![processing/p5.js-website repository menu. At the right bottom of the menu the "fork" button is highlighted](https://github.com/processing/p5.js-website/raw/master/contributor_docs/assets/fork.png)
 3. On your fork click the green *Clone or download* button. It will display a bar from where you can copy your `repo_URL`.
 
-    ![processing/p5.js-website repository menu. The "Clone or download" button is pressed and a tab is displayed under it from which the repository's link can be copied.](https://github.com/processing/p5.js-website/tree/master/contributor_docs/assets/clone.png)
+    ![processing/p5.js-website repository menu. The "Clone or download" button is pressed and a tab is displayed under it from which the repository's link can be copied.](https://github.com/processing/p5.js-website/raw/master/contributor_docs/assets/clone.png)
 
 4. Open your command-line interface (CLI) and [clone](https://help.github.com/articles/cloning-a-repository/) your fork of the p5.js-website repository to `your_directory` on your laptop by typing:
 

--- a/contributor_docs/i18n_contribution.md
+++ b/contributor_docs/i18n_contribution.md
@@ -1,6 +1,6 @@
 # Contributing to p5.js website internationalization (i18n)
 
-If you want to contribute with p5.js website translations you are in the right place. The translation of the p5.js website to languages other than English is part of its internationalization -abbreviated [*i18n*](https://en.wikipedia.org/wiki/Internationalization_and_localization)- process. You can improve content that has been already translated -at the reference, examples or other pages within the website- as well as start a new language translation.
+If you want to contribute with p5.js website translations, you are in the right place. The translation of the p5.js website to languages other than English is part of its internationalization - abbreviated [*i18n*](https://en.wikipedia.org/wiki/Internationalization_and_localization) - process. You can improve content that has been already translated - at the reference, examples or other pages within the website - as well as start a new language translation.
 
 ## Table of Contents
 
@@ -15,80 +15,102 @@ If you want to contribute with p5.js website translations you are in the right p
   * [Translation of Examples](#translation-of-examples)
 
 ## How the website works
-1. Due to internationalization (i18n) this website is built from templates that retrieve the text content from data files
+
+1. Due to internationalization (i18n), this website is built from templates that retrieve the text content from data files
 2. There are three kind of pages and each works differently:
    * [Reference](#translation-of-reference): Pages are built in English and swapped to other languages using JS on the front-end. Translation content is stored in a JSON object.
-   * [Examples](#translation-of-examples): Examples pages are built from from templates handlebars with handlebars, while examples are stored in JS files.
+   * [Examples](#translation-of-examples): Examples pages are built from templates with handlebars, while examples are stored in JS files.
    * [Other](#translation-of-all-pages-except-reference-and-examples): Pages are built from templates in which handlebars point to the content in the actual language when rendered.
 3. Every time a modification is submitted the website is rendered again.
 4. Built web is stored under `dist/` directory whilst data and templates are stored under `src/` directory. For further information check the [File Structure](#file-structure).
 5. When collaborating code editing have to be done in files under `src/`, but not under `dist/` as files in there are removed and recreated on build.
 
-
 ## Setting up before start your contribution
+
 *Please do this only once before you start your contribution.*
+
 1. Install node.js by following the instructions [here](https://nodejs.org/en/download/).
 2. [Fork](https://help.github.com/articles/fork-a-repo/) the p5.js-website repository to your Github account. Click the *Fork* button on the upper-right side of the p5.js-website Github repo. This will automatically open your fork repo on Github.
 ![processing/p5.js-website repository menu. At the right bottom of the menu the "fork" button is highlighted](https://github.com/processing/p5.js-website/tree/master/contributor_docs/assets/fork.png)
 3. On your fork click the green *Clone or download* button. It will display a bar from where you can copy your `repo_URL`.
-![processing/p5.js-website repository menu. The "Clone or download" button is pressed and a tab is displayed under it from which the repository's link can be copied.](https://github.com/processing/p5.js-website/tree/master/contributor_docs/assets/clone.png)
+
+    ![processing/p5.js-website repository menu. The "Clone or download" button is pressed and a tab is displayed under it from which the repository's link can be copied.](https://github.com/processing/p5.js-website/tree/master/contributor_docs/assets/clone.png)
+
 4. Open your command-line interface (CLI) and [clone](https://help.github.com/articles/cloning-a-repository/) your fork of the p5.js-website repository to `your_directory` on your laptop by typing:
-```bash
-$ git clone repo_URL
-```
+
+    ```bash
+    $ git clone repo_URL
+    ```
+
 5. Go to the repository's directory `[your_directory]/p5.js-website/` and install all the packages and dependencies for the website by typing (if you work on Mac it should be like `Users/[your_user]/[your_directory]/p5.js-website/`):
-```bash
-$ npm install
-```
+
+    ```bash
+    $ npm install
+    ```
 6. Check if the packages are correctly installed by typing:
-```bash
-$ npm run watch
-```
+
+    ```bash
+    $ npm run watch
+    ```
+
 7. This should open a window in your browser with the site running at http://localhost:9000.
 8. Set `github.com/processing/p5.js-website` as the upstream of your local. Type the following to list the configured remote for your fork (or follow this [tutorial](https://help.github.com/articles/configuring-a-remote-for-a-fork/)):
-```bash
-$ git remote -v
-origin  https://github.com/YOUR_USERNAME/YOUR_FORK.git (fetch)
-origin  https://github.com/YOUR_USERNAME/YOUR_FORK.git (push)
-```
+
+    ```bash
+    $ git remote -v
+      origin  https://github.com/YOUR_USERNAME/YOUR_FORK.git (fetch)
+      origin  https://github.com/YOUR_USERNAME/YOUR_FORK.git (push)
+    ```
+
 Then specify a new remote upstream for your fork (don't forget that by doing this you are setting the upstream for your local fork, but not for your fork on Github):
-```bash
-$ git remote add upstream github.com/processing/p5.js-website
-```
+
+    ```bash
+    $ git remote add upstream github.com/processing/p5.js-website
+    ```
+
 Finally verify if your remote upstream has been set (it should look like this):
-```bash
-$ git remote -v
-origin  https://github.com/YOUR_USERNAME/YOUR_FORK.git (fetch)
-origin  https://github.com/YOUR_USERNAME/YOUR_FORK.git (push)
-upstream  https://github.com/processing/p5.js-website.git (fetch)
-upstream  https://github.com/processing/p5.js-website.git (push)
-```
+
+    ```bash
+    $ git remote -v
+      origin  https://github.com/YOUR_USERNAME/YOUR_FORK.git (fetch)
+      origin  https://github.com/YOUR_USERNAME/YOUR_FORK.git (push)
+      upstream  https://github.com/processing/p5.js-website.git (fetch)
+      upstream  https://github.com/processing/p5.js-website.git (push)
+    ```
 
 ## Before submitting a Pull Request
+
 *Please do this every time you submit a PR.*
+
 1. Sync your fork to keep it up-to-date with the upstream repository following the next commands or this [tutorial](https://help.github.com/articles/syncing-a-fork/). First fetch the upstream repo and its commits -commits will be stored on your local fork- and then merge changes from upstream to your local:
-```bash
-$ git fetch upstream
-$ git merge upstream/master
-```
+
+    ```bash
+    $ git fetch upstream
+    $ git merge upstream/master
+    ```
+
 2. Make changes only at files under the `src/` directory.
 3. Check if your changes are correct and don't break the website render by typing `npm run watch`.
 4. Commit the files you have changed, type:
-```bash
-$ git add -A
-$ git commit -m "add a message to your commit"
-$ git push
-```
+
+    ```bash
+    $  git add -A
+    $ git commit -m "add a message to your commit"
+    $ git push
+    ```
+
 5. Commit to your repository at your github account and create a new [Pull Request](https://github.com/processing/p5.js-website/wiki/Pull-requests). Click the *Pull Reques* tab on your fork page and then click the green button *New Pull Request*.
 ![processing/p5.js-website repository menu. "Pull requests" tab is opened and a green button with the text "New pull request" is displayed a the right bottom of the menu.](https://github.com/processing/p5.js-website/tree/master/contributor_docs/assets/pull_request.png)
 
 ## File Structure
 Under this repo there are two directories in which we have to focus:
-```
-p5.js-website/
-  src/
-  dist/
-```
+
+    ```
+    p5.js-website/
+      src/
+      dist/
+    ```
+
 * `dist/`: the actual website is stored under this directory and its files **must never be modified by hand**, they are overwritten each time the web is built.
 * `src/`: contains the files from where the page is rendered, which means .hbs and .yml files for the website itself and .js and .json files for Reference and Examples. **All your changes must be done here**.
   * `assets/` – All static files (imgs, css, fonts, js, p5_featured homepage sketches)
@@ -101,28 +123,32 @@ p5.js-website/
 * `Gruntfile.js` – This file contains all the tasks for using assemble and YAML to generate the final, static site. It uses the task runner [grunt](http://gruntjs.com/).
 
 ## Start a new translation
+
 1. Define an abbreviation for your language following the [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) standard. It's expected that abbreviations are two-letter, but for macro languages can be added extra extensions depending on each case.
 2. Open a new issue and propose the addition of the new language. If both the proposal and the abbreviation are approved proceed with the next step.
 3. Add an entry with the new language abbreviation at `package.json` to the `languages` category -located under the repository root directory.
-```JSON
-"languages": [
-  "en",
-  "es",
-  "zh-Hans",
-  "new language here"
-],
-```
-4. Duplicate `en.yml` -stored under `src/data/`- and name it `language_abbreviation.yml`. For example, when the Spanish version was created it was named `es.yml`. Check [How the website works](#how-the-website-works) and [File Structure](#file-structure) for further information.
-5. Duplicate `es.json` -stored under `src/data/reference/`- and name it `[language_abbreviation].json`.
+
+    ```JSON
+    "languages": [
+      "en",
+      "es",
+      "zh-Hans",
+      "new language here"
+    ],
+    ```
+
+4. Duplicate `en.yml` - stored under `src/data/` - and name it `language_abbreviation.yml`. For example, when the Spanish version was created it was named `es.yml`. Check [How the website works](#how-the-website-works) and [File Structure](#file-structure) for further information.
+5. Duplicate `es.json` - stored under `src/data/reference/` - and name it `[language_abbreviation].json`.
 
 ## Working on existing translations
 
 ### Translation of all pages except Reference and Examples
+
 Each webpage is written in [.hbs](https://www.npmjs.com/package/hbs) format -files created with the library Handlebars and written using HTML rules- using handlers to access the i18n data of each language and render. Each handler binds a specific spot on the HTML script with a specific content stored in a database, and is replaced by it when the page is built. Hbs files are stored under `src/template/pages`.
 
 The i18n data is stored in [.yml](https://en.wikipedia.org/wiki/YAML) files in the `src/data` folder of this repo. For example, under the above mentioned path the .yml files for English, Spanish and Chinese can be found as follows:
 
-```
+```filenames
 en.yml
 es.yml
 zh-Hans.yml
@@ -172,6 +198,7 @@ Instead of this, the color-related handler must be added to the `learn` list of 
 In some cases, the text translated from the original .hbs file (written in HTML) included double quotes used to highlight some idea. In those cases remember to use the scape command `\` before the quotes, otherwise your compiler will interpret it as a syntax error because the handlers finish more than one time.
 
 ### Translation of Reference
+
 * The reference works a bit differently. The pages are built in English based on the inline documentation in the source code. They are then swapped out using JS on the front-end.
 * The top level keys in the JSON object correspond to the page headings, menu, footer, etc. You can see all the swaps in [this file](https://github.com/processing/p5.js-website/blob/master/dist/reference/index.html#L130).
 * The "p5" key in the JSON object contains individual keys for each reference entry, indexed by variable/function/object name.
@@ -180,7 +207,9 @@ In some cases, the text translated from the original .hbs file (written in HTML)
 * The source content for the reference is handled inline in the [p5.js source code](https://github.com/processing/p5.js). See [Inline documentation](https://github.com/processing/p5.js/blob/master/developer_docs/inline_documentation.md) in the p5.js repo for information on how to contribute.
 
 ### Translation of Examples
+
 The examples are handled a bit differently from other pages.
+
 * All examples pages are built from `src/data/examples`.
 * Within the examples folder, there is a folder for each of the three languages we currently support: `en/`, `es/`, and `zh-Hans/`. When adding a new example, first add an English version of the file to the `en/` folder, then make sure it is duplicated in the same place in all other languages, then translate for whichever languages you can. If you have created a new folder, add entries to the YAML files with the foldername as the key.
 * The folder, file, and numbering structure should match exactly between the different languages. Do not change the filenames. The text for the example name, description, and source code are all in the .js files in the folders.


### PR DESCRIPTION
1. Applied markdown linting - resulting in proper spacing between headings and lists, and correct indentation of nested lists and fenced code blocks
2. Fixed small spelling issues
3. Fixed URL to image.