### PR TITLE
fixes #369

### DIFF
--- a/src/assets/js/scroll.js
+++ b/src/assets/js/scroll.js
@@ -1,89 +1,41 @@
-/*
-
-Hastily written scroll to fixed position:
-
-TO DO:
-
-    - needs to not fail on resize of resize after scrolling,
-    - and needs to use animate() to add jquery easing
-
-*/
-
-// if (window.matchMedia("min-width:720px").matches) {
-//   var elementPosition = $('#menu').offset();
-//
-//   $(window).scroll(function(){
-//     if($(window).scrollTop() > elementPosition.top){
-//       var top = Math.round($(window).scrollTop()-elementPosition.top);
-//       $('#menu').css({'margin-top': top});
-//     } else {
-//       $('#menu').css({'margin-top': 0});
-//     }
-//   });
-// }
-
 $(function() {
+    var $window = $(window),
+        $sidebar = $("#menu"),
+        sidebarTopOffset = $sidebar.offset().top,
+        $rotationElements = $(
+            ["#download-page #asterisk-design-element", "#reference-page #asterisk-design-element"].join()
+        ),
+        rotationDegrees = 0;
 
-  var $window           = $(window),
-      $sidebar          = $("#menu"),
-      sidebarOffset     = $sidebar.offset(),
-      $rotationElements = $([
-        '#download-page #asterisk-design-element',
-        '#reference-page #asterisk-design-element'
-      ].join()),
-      rotationDegrees   = 0;
+    var isWidescreen = function() {
+        return window.matchMedia("(min-width: 720px)").matches;
+    };
 
-  var isWidescreen = function() {
-    return window.matchMedia("(min-width: 720px)").matches;
-  };
-
-  // Calculate what the top for the sidebar should be.
-  var getNewTop = function(){
-    return Math.max($window.scrollTop() - sidebarOffset.top, 0);
-  }
-
-  // Change sidebar position:
-  var setSidebarPosition = function(newTop) {
-    // If it is already animating, return. This makes the animation less choppy.
-    // It will pick up the final top when the current animation ends.
-    if ($sidebar.is(':animated')){
-      return;
-    }
-
-    // Calculate new top if none passed in.
-    newTop = newTop || getNewTop();
-
-    $sidebar.animate({top: newTop}, { 
-      easing: 'linear',
-      duration: 100,
-      complete: function(){
-        // Go again if a subsequent scroll has changed the final top.
-        var finalTop = getNewTop();
-        if (newTop != finalTop){
-          setSidebarPosition(finalTop);
+    var setSidebarPosition = function() {
+        var $colSpan = $sidebar.closest("nav").closest("div");
+        if ($window.scrollTop() >= sidebarTopOffset) {
+            $colSpan.css({ position: "fixed", top: "10px" });
+            $colSpan.next().css({ marginLeft: $colSpan.width() + 40 + "px", top: "20px" });
+        } else {
+            $colSpan.css({ position: "relative", top: "" });
+            $colSpan.next().css({ marginLeft: "1em", top: "" });
         }
-      }
-    });
-  };
-  
-  if (isWidescreen()){
-    $sidebar.css('top', getNewTop());
-  }
+    };
 
-  // Rotate specific elements:
-  var rotateElements = function() {
-    rotationDegrees = ($window.scrollTop() / 40) - 21;
-    $rotationElements.css({
-      '-ms-transform': 'rotate(' + rotationDegrees + 'deg)',
-      '-webkit-transform': 'rotate(' + rotationDegrees + 'deg)',
-      'transform': 'rotate(' + rotationDegrees + 'deg)'
-    });
-  };
+    // Rotate specific elements:
+    var rotateElements = function() {
+        rotationDegrees = $window.scrollTop() / 40 - 21;
+        $rotationElements.css({
+            "-ms-transform": "rotate(" + rotationDegrees + "deg)",
+            "-webkit-transform": "rotate(" + rotationDegrees + "deg)",
+            transform: "rotate(" + rotationDegrees + "deg)"
+        });
+    };
 
-  $window.scroll(function() {
-    if (isWidescreen()) {
-      setSidebarPosition();
-      rotateElements();
-    }
-  });
+    $window.scroll(function() {
+        if (isWidescreen()) {
+            setSidebarPosition();
+            rotateElements();
+        }
+    });
 });


### PR DESCRIPTION
The way this works now is it auto detects as soon as the sidebar is about to go out of view, and when it does, it fixes its position (`position: fixed`). When the user again scrolls up the position is reset back to `relative` and everything works as before.

I have closed the previous PR #372, as it didn't have a clean commit history, changed too many files in `dist/` and was still facing merge issues. Please review this PR. Thank you!