### PR TITLE
 Adding second push of Korean translations

### DIFF
--- a/src/data/ko.yml
+++ b/src/data/ko.yml
@@ -498,4 +498,4 @@ contributors-conference:
   contributors-conference-support6: "Thank you!"
 
 reference:
-  Reference: "Reference"
+  Reference: "레퍼런스"

--- a/src/data/ko.yml
+++ b/src/data/ko.yml
@@ -32,7 +32,7 @@ home:
   p1x1: "안녕하세요! p5.js는 "
   p1x2: "의 목표를 지키고 이를 온라인 공간으로 확장하고자 시작된 자바스크립트 라이브러리로, 예술가, 디자이너, 교육자, 초보자를 위해 만들어졌습니다. "
   p2x1: "마치 다양한 미술 도구로 스케치북에 그림을 그리듯이, p5.js를 이용하면 인터넷 브라우저의 '캔버스(canvas)'를 스케치북 삼아 그림을 그릴 수 있습니다. 뿐만 아니라, p5.js의 추가 "
-  libraries: " 라이브러리"
+  libraries: "라이브러리"
   p2x2: "를 이용하면 텍스트, 입력값, 비디오, 웹캠, 소리와 같은 HTML5 오브젝트를 "
   interact: "쉽게 다루고 "
   p2x3: " , '캔버스'를 너머 인터넷 브라우저 자체를 당신의 스케치북으로 삼을 수 있습니다."
@@ -116,7 +116,7 @@ get started:
   book2: 2015 Lauren McCarthy, Casey Reas, and Ben Fry. All rights reserved.
 
 download:
-  Download: "Download"
+  Download: "다운로드"
   complete-library-title: "Complete Library"
   p5.js-complete: "p5.js complete"
   includes-1: "Includes:"
@@ -171,7 +171,7 @@ download:
   support-33: " was founded in 2012 after more than a decade of work with the original Processing software. The Foundation’s mission is to promote software literacy within the visual arts, and visual literacy within technology-related fields — and to make these fields accessible to diverse communities. Our goal is to empower people of all interests and backgrounds to learn how to program and make creative work with code, especially those who might not otherwise have access to these tools and resources."
 
 learn:
-  learn-title: "Learn"
+  learn-title: "학습"
   learn1: "These tutorials provide more in-depth or step-by-step overviews of particular topics. Check out the "
   learn2: "examples page"
   learn3: "to see short demonstrations of various p5.js topics."
@@ -347,7 +347,7 @@ learn:
 test-tutorial:
 
 libraries:
-  Libraries: "Libraries"
+  Libraries: "라이브러리"
   p5.dom: "p5.dom lets you interact with HTML5 objects beyond the canvas, including video, audio, webcam, input, and text."
   p5.sound: "p5.sound extends p5 with Web Audio functionality including audio input, playback, analysis and synthesis."
   p5.accessibility: "p5.accessibility makes the p5 canvas more accessible to people who are blind and visually impaired."
@@ -443,10 +443,10 @@ community:
   people1: "blah"
 
 books:
-  books-title: "Books"
+  books-title: "관련 책"
 
 examples:
-  Examples: "Examples"
+  Examples: "예제"
   back-examples: "Back to Examples"
   Structure: "Structure"
   Form: "Form"

--- a/src/data/reference/ko.json
+++ b/src/data/reference/ko.json
@@ -4,34 +4,34 @@
   "Start": "시작하기",
   "Reference": "레퍼런스",
   "reference-tagline": "la intuición de Processing x el poder de JavaScript",
-  "reference-search": "Busca en la API",
-  "reference-menu-home": "Inicio",
-  "reference-menu-download": "Descargar",
-  "reference-menu-get-started": "Empezar",
-  "reference-menu-reference": "Referencia",
-  "reference-menu-libraries": "Bibliotecas",
-  "reference-menu-learn": "Aprender",
-  "reference-menu-examples": "Ejemplos",
-  "reference-menu-books": "Libros",
-  "reference-menu-community": "Comunidad",
-  "reference-menu-forum": "Foro",
-  "reference-description1": "¿No encuentras lo que buscas? Quizás debas revisar en",
-  "reference-description2": "o",
-  "reference-description3": "Puedes descargar una versión de la referencia",
-  "reference-description4": "aquí",
-  "reference-contribute1": "잘못된 부분이나 제안사항이 있다면 ",
-  "reference-contribute2": "알려주세요.",
-  "reference-error1": "¿Encontraste algún error?",
-  "reference-error2": "está documentado y definido en",
-  "reference-error3": "Por favor siéntete libre de ",
-  "reference-error4": "editar el archivo",
-  "reference-error5": "y de indicar un pull request.",
-  "reference-example": "Ejemplo",
+  "reference-search": "API 검색",
+  "reference-menu-home": "홈",
+  "reference-menu-download": "다운로드",
+  "reference-menu-get-started": "시작하기",
+  "reference-menu-reference": "레퍼런스",
+  "reference-menu-libraries": "라이브러리",
+  "reference-menu-learn": "학습",
+  "reference-menu-examples": "예제",
+  "reference-menu-books": "관련 책",
+  "reference-menu-community": "커뮤니티",
+  "reference-menu-forum": "포럼",
+  "reference-description1": "찾는 항목이 이곳에 없다면, 다음의 페이지를 살펴보세요:",
+  "reference-description2": " 혹은 ",
+  "reference-description3": "오프라인 버전의 레퍼런스는 다음 링크에서 다운받을 수 있습니다: ",
+  "reference-description4": "레퍼런스 다운로드",
+  "reference-contribute1": "잘못된 부분이나 제안사항이 있다면",
+  "reference-contribute2": "알려주세요",
+  "reference-error1": "오타나 버그를 발견했다구요?",
+  "reference-error2": "관련 문서는 이곳에 있습니다: ",
+  "reference-error3": "p5.js에 기여하고 싶다면, ",
+  "reference-error4": "파일을 수정하고",
+  "reference-error5": "pull request 해주세요!",
+  "reference-example": "예제",
   "reference-description": "설명",
-  "reference-extends": "Extiende",
-  "reference-parameters": "Parámetros",
-  "reference-syntax": "Sintaxis",
-  "reference-returns": "Retorna",
+  "reference-extends": "확장",
+  "reference-parameters": "변수",
+  "reference-syntax": "문법",
+  "reference-returns": "리턴",
   "footer1": "p5.js는 ",
   "footer2": "에 의해 설립되고 커뮤니티 구성원들에 의해 개발되었으며 ",
   "footer3": " 과 ",
@@ -44,55 +44,6 @@
   "Contribute": "기여하기",
   "Forum": "포럼",
   "h1": "레퍼런스",
-  "Color": "Color",
-  "Shape": "Forma",
-  "Creating & Reading": "Creación y lectura",
-  "Setting": "Configuración",
-  "2D Primitives": "Primitivas 2D",
-  "Attributes": "Atributos",
-  "Curves": "Curvas",
-  "Vertex": "Vértices",
-  "3D Models": "Modelos 3D",
-  "3D Primitives": "Primitivas 3D",
-  "Constants": "Constantes",
-  "Structure": "Estructura",
-  "Environment": "Ambiente",
-  "DOM": "DOM",
-  "Rendering": "Render",
-  "Transform": "Transformar",
-  "Data": "Datos",
-  "Dictionary": "Diccionario",
-  "Array Functions": "Funciones de arreglo",
-  "Conversion": "Conversión",
-  "String Functions": "Funciones de String",
-  "Events": "Eventos",
-  "Acceleration": "Aceleración",
-  "Keyboard": "Teclado",
-  "Mouse": "Ratón",
-  "Touch": "Tacto",
-  "Image": "Imagen",
-  "Loading & Displaying": "Cargar & Mostrar",
-  "Pixels": "Pixeles",
-  "IO": "Entrada y salida",
-  "Input": "Entrada",
-  "Output": "Salida",
-  "Table": "Tabla",
-  "Time & Date": "날짜와 시간",
-  "XML": "XML",
-  "Math": "수학",
-  "Calculation": "계산",
-  "Noise": "노이즈",
-  "Trigonometry": "Trigonometría",
-  "Typography": "타이포그래피",
-  "Font": "폰트",
-  "Lights, Camera": "Luces, cámara",
-  "Camera": "카메라",
-  "Lights": "빛",
-  "Material": "Materiales",
-  "footer1": "p5.js는 ",
-  "footer2": "에 의해 설립되고 커뮤니티 구성원들에 의해 개발되었으며 ",
-  "footer3": " 과 ",
-  "footer4": "의 후원을 받았습니다. 아이덴티티, 그래픽디자인 :",
   "p5": {
     "alpha": {
       "description": "Extrae el valor de alpha de un color o de un arreglo de pixeles.",
@@ -184,21 +135,10 @@
       "숫자: 배경색 투명도 (범위 기본값은 0-255이며, 범위는 설정에 따라 다를 수 있음)",
       "문자열: 문자열로 된 색상값",
       "숫자: 흑백 채도를 설정함",
-      "숫자 배열[]: red, green blud와 투명도를 포함한 배열",
-      "p5.Color"
-      ],
+      "숫자 배열[]: red, green blue와 투명도를 포함한 배열",
+      "p5.Color" ],
       "returns": "the p5 object"
     },
-
-    "p5.Color: color() 함수를 통해 만들어진 값",
-             "문자열: 색상 문자열, 정수 rgb()나 rgba(), 백분율 rgb()나 rgba(), 3자리 숫자 hex, 6자리 숫자 hex",
-             "숫자: 배경색 투명도 (범위 기본값은 0-255이며, 범위는 설정에 따라 다를 수 있음)",
-             "숫자: 흑백 채도를 설정함",
-             "숫자: 선택한 컬러모드와 색상값 범위에 따라, red값 혹은 hue값",
-             "숫자: 선택한 컬러모드와 색상값 범위에 따라, green값 혹은 saturation값",
-             "숫자: 선택한 컬러모드와 색상값 범위에 따라, blue값 혹은 brightness값",
-             "숫자 배열[]: red, green blud와 투명도를 포함한 배열",
-             "p5.Image: loadImage()나 createImage()로 생성된 이미지를 배경 이미지로 설정하는 경우 (스케치 창과 같은 사이즈여야 함)"],
     "noFill": {
       "description": "도형에 색을 채우지 않도록 설정합니다. noStroke() 과  noFill()을 동시에 사용하면, 화면에 아무것도 나타나지 않습니다.",
       "returns": "the p5 object"
@@ -217,7 +157,7 @@
       "숫자: 흑백 채도를 설정함",
       "숫자 배열[]: red, green blud와 투명도를 포함한 배열",
       "p5.Color"],
-      "returns": "el objeto p5"
+      "returns": "the p5 object"
     },
     "arc": {
       "description": "화면에 호를 그립니다. 모드 선택 없이 x, y, w, h, 시작, 끝만을 지정하면 호는 열린 파이조각 형태로 그려집니다. 모드 변수를 설정하기에 따라, 호는 각각 반원(OPEN), 닫혀진 반원(CHORD), 닫혀진 파이조각(PIE) 형태로 그려집니다. ellipseMode() 함수를 이용하면 시작점을 변경할 수 있습니다. 본 함수를 이용해 시작점을 0, 끝점을 TWO_PI로 설정해 원 전체를 그리려 시도하면, 시작점과 끝점이 같기 때문에 아무것도 그려지지 않습니다. 원 전체를 그릴때는 ellipse() 함수를, 원 일부를 그릴 때는 arc() 함수를 이용하세요.",
@@ -228,8 +168,7 @@
       "숫자: 시작점의 각도로, 호도(radians)로 설정",
       "숫자: 끝점의 각도로, 호도(radians)로 설정",
       "상수: 호를 그리는 방식을 설정함. CHORD, PIEC, OPEN 중 선택. 필수 변수는 아니며 필요한 경우에만 사용하면 됨.",
-      "숫자: WEBGL 모드에서만 사용하며, 호의 윤곽선을 구성하는 점(vertices)의 숫자를 지정한다. 필수 변수는 아니며 필요한 경우에만 사용하면 됨. 초기값은 25이다.",
-    ],
+      "숫자: WEBGL 모드에서만 사용하며, 호의 윤곽선을 구성하는 점(vertices)의 숫자를 지정한다. 필수 변수는 아니며 필요한 경우에만 사용하면 됨. 초기값은 25이다."],
       "returns": "the p5 object"
     },
     "ellipse": {
@@ -241,54 +180,79 @@
       "정수: 원을 몇 개의 부분으로 나누어 그릴 것인지 지정 (WEGBL 모드용)"],
       "returns": "the p5 object"
     },
+    "circle": {
+      "description": "화면에 원을 그립니다. 원은 단순한 단일폐곡선으로, 중심점으로부터 같은 좌표에 위치한 점들의 집합입니다. 원은 너비와 높이가 동일한 타원으로 ellipse() 함수를 이용해 그리는 것도 가능합니다. 이 경우 타원의 너비와 높이는 원의 지름과 동일합니다. 본 함수의 첫번째 두번째 변수는 원의 중심점을, 세번째 변수는 지름을 설정합니다.",
+      "params": ["숫자: 원 중심점의 x 좌표",
+      "숫자: 원 중심점의 y 좌표",
+      "숫자: 원의 지름"],
+      "returns": "the p5 object"
+    },
     "line": {
-      "description": "Dibuja una línea (un camino directo entre dos puntos) en la pantalla. La versión de line() con cuatro parámetros dibuja la línea en 2D. Para darle color a una línea, usa la función stroke(). Una línea no puede ser rellenada, por lo que la función fill() no afectará el color de una línea. Las líneas 2D son dibujadas con una ancho de un pixel por defecto, pero esto puede ser cambiado con la función strokeWeight().",
-      "params": ["Número: coordenada x del primer punto.",
-      "Número: coordenada y del primer punto.",
-      "Número: coordenada x del segundo punto.",
-      "Número: coordenada y del segundo punto."],
+      "description": "화면에 선, 즉 두 점을 연결하는 곧은 선을 그립니다. line() 함수에 4개의 변수를 입력하는 경우 이차원 평면에 선을 그립니다. 선의 색을 지정하려면 stroke() 함수를 이용하세요. 선은 면은 가지고 있지 않기 때문에 면 색을 채우는 fill() 함수는 적용되지 않습니다. 선의 굵기 초기값은 1픽셀이며 이를 변경하기 위해서는 strokeWeight() 함수를 이용합니다.",
+      "params": ["숫자: 첫번째 점의 x 좌표",
+      "숫자: 첫번째 점의 y 좌표",
+      "숫자: 두번째 점의 x 좌표",
+      "숫자: 첫번째 점의 y 좌표",
+      "숫자: 첫번째 점의 z 좌표",
+      "숫자: 두번째 점의 z 좌표"],
       "returns": "the p5 object"
     },
     "point": {
       "description": "Dibuja un punto, una coordenada en el espacio de un pixel de dimensión. El primer parámetro es la coordenada horizontal del punto, el segundo valor es la coordenada vertical del punto. El color del punto es determinado por el trazado actual con la función stroke().",
-      "params": ["Número: coordenada x.",
-      "Número: coordenada y ."],
+      "params": ["숫자: x 좌표",
+      "숫자: y 좌표",
+      "숫자: z 좌표 (WEBGL 모드 사용시)"],
       "returns": "the p5 object"
     },
     "quad": {
-      "description": "Dibuja un cuadrilátero, un polígono de cuatro lados. Es similar a un rectángulo, pero los ángulos entre sus bordes no están limitados a noventa grados. El primer par de parámetros (x1, y1) corresponde a las coordenadas del primer vértice y los pares siguientes deben seguir en el mismo orden, según las manecillas del reloj o en contra, alrededor de la figura a definir.",
-      "params": ["Número: coordenada x del primer punto.",
-      "Número: coordenada y del primer punto.",
-      "Número: coordenada x del segundo punto.",
-      "Número: coordenada y del segundo punto.",
-      "Número: coordenada x del tercer punto.",
-      "Número: coordenada y del tercer punto.",
-      "Número: coordenada x del cuarto punto.",
-      "Número: coordenada y del cuarto punto."],
+      "description": "네모꼴을 그립니다. 네모꼴은 4개의 변을 가진 다각형으로, 직사각형과 유사해 보이지만 직사각형과 다르게 변 사이의 각도가 90도로 고정되어 있지 않습니다. 첫 한 쌍의 변수는 첫 꼭지점을 설정하며 뒤따르는 다른 쌍의 변수들은 시계방향이나 반시계방향으로 차례대로 꼭지점을 설정합니다. z 변수는 WEBGL모드에서 quad() 함수를 사용하는 경우에만 적용됩니다.",
+      "params": ["숫자: 첫번째 꼭지점의 x 좌표",
+      "숫자: 첫번째 꼭지점의 y 좌표",
+      "숫자: 두번째 꼭지점의 x 좌표",
+      "숫자: 두번째 꼭지점의 y 좌표",
+      "숫자: 세번째 꼭지점의 x 좌표",
+      "숫자: 세번째 꼭지점의 y 좌표",
+      "숫자: 네번째 꼭지점의 x 좌표",
+      "숫자: 네번째 꼭지점의 y 좌표",
+      "숫자: 첫번째 꼭지점의 z 좌표",
+      "숫자: 두번째 꼭지점의 z 좌표",
+      "숫자: 세번째 꼭지점의 z 좌표",
+      "숫자: 네번째 꼭지점의 z 좌표"],
       "returns": "the p5 object"
     },
     "rect": {
-      "description": "Dibuja un rectángulo en la pantalla. Un rectángulo es una figura de cuatro lados con cada ángulo interior de noventa grados. Por defecto, los dos primeros parámetros definen la ubicación de la esquina superior izquierda, el tercero el ancho y el cuarto la altura. La manera en que estos parámetros son interpretados, sin embargo, puede ser cambiado con la función rectMode(). Los parámetros quinto, sexto, séptimo y octavo, si son especificados, determinan el radio de la esquina superior derecha, superior izquierda, inferior derecha e inferior izquierda, respectivamente. Si se omite un parámetro de radio de esquina, se usa el radio especificado por el valor anterior en la lista.",
-      "params": ["Número: coordenada x del rectángulo.",
-      "Número: coordenada y del rectángulo.",
-      "Número: ancho del rectángulo.",
-      "Número: altura del rectángulo.",
-      "Número: radio opcional de la esquina superior izquierda.",
-      "Número: radio opcional de la esquina superior derecha.",
-      "Número: radio opcional de la esquina inferior derecha.",
-      "Número: radio opcional de la esquina inferior izquierda.",
-      "Número:",
-      "Número:"],
-      "returns": "el objeto p5"
+      "description": "화면에 직사각형을 그립니다. 직사각형은 변이 네개이면서 모든 각도가 90도인 도형입니다. 첫 두 변수는 왼쪽 위 꼭지점의 좌표를, 세번째 변수는 사각형의 너비를, 네번째 변수는 높이를 설정합니다. rectMode() 함수로 사각형 모드를 변경하는 경우 변수 입력값들은 다르게 해석됩니다. 다섯번째, 여섯번째, 일곱번째, 여덟번째 변수를 입력하는 경우 각각의 숫자는 차계로 왼쪽 위, 오른쪽 위, 오른쪽 아래, 왼쪽 아래 모퉁이의 각도를 지정합니다. 각도 변수를 누락하는 경우 앞서 지정한 각도 값이 사용됩니다.",
+      "params": ["숫자: 직사각형의 x 좌표값",
+      "숫자: 직사각형의 y 좌표값",
+      "숫자: 직사각형의 너비",
+      "숫자: 직사각형의 높이",
+      "숫자: 왼쪽 위 모퉁이 각도 값. 필수 변수가 아니므로 필요한 경우에만 입력.",
+      "숫자: 오른쪽 위 모퉁이 각도 값. 필수 변수가 아니므로 필요한 경우에만 입력.",
+      "숫자: 오른쪽 아래 모퉁이 각도 값. 필수 변수가 아니므로 필요한 경우에만 입력.",
+      "숫자: 왼쪽 아래 모퉁이 각도 값. 필수 변수가 아니므로 필요한 경우에만 입력.",
+      "정수: x 방향의 segment 수 (WEBGL 모드에서 사용)",
+      "정수: y 방향의 segment 수 (WEBGL 모드에서 사용)"],
+      "returns": "the p5 object"
+    },
+    "square": {
+      "description": "화면에 정사각형을 그립니다. 정사각형은 변이 네개이면서 모든 각도가 90도이며 네 변의 길이가 같은 도형입니다. 정사격형은 사실상 rect() 함수로도 그릴 수 있는 도형으로, 너비와 높이가 모두 s로 같은 직사각형인 셈입니다. 첫 두 변수는 왼쪽 위 꼭지점의 좌표를, 세번째 변수는 한 변의 길이를 설정합니다. rectMode() 함수로 사각형 모드를 변경하는 경우 변수 입력값들은 다르게 해석됩니다. 네번째, 다섯번째, 여섯번째, 일곱번째 변수를 입력해 왼쪽 위, 오른쪽 위, 오른쪽 아래, 왼쪽 아래 모퉁이의 각도를 각각 지정할 수 있습니다. 각도 변수를 누락하는 경우 앞서 지정한 각도 값이 사용됩니다.",
+      "params": ["숫자: 정사각형의 x 좌표값",
+      "숫자: 정사각형의 y 좌표값",
+      "숫자: 정사각형 한 변의 길이",
+      "숫자: 왼쪽 위 모퉁이 각도 값. 필수 변수가 아니므로 필요한 경우에만 입력.",
+      "숫자: 오른쪽 위 모퉁이 각도 값. 필수 변수가 아니므로 필요한 경우에만 입력.",
+      "숫자: 오른쪽 아래 모퉁이 각도 값. 필수 변수가 아니므로 필요한 경우에만 입력.",
+      "숫자: 왼쪽 아래 모퉁이 각도 값. 필수 변수가 아니므로 필요한 경우에만 입력."],
+      "returns": "the p5 object"
     },
     "triangle": {
-      "description": "Un triángulo es un plano creado por la conexión de tres puntos. Los primeros dos argumentos especifican el primer punto, los parámetros centrales especifican el segundo punto, y los dos últimos parámetros especifican el tercer punto.",
-      "params": ["Número: coordenada x del primer punto.",
-      "Número: coordenada y del primer punto.",
-      "Número: coordenada x del segundo punto.",
-      "Número: coordenada y del segundo punto.",
-      "Número: coordenada x del tercer punto.",
-      "Número: coordenada y del tercer punto."],
+      "description": "삼각형은 세 점을 이어 만든 평면입니다. 첫 두 변수는 첫번째 꼭지점을, 가운데 두 변수는 두번째 꼭지점을, 마지막 두 변수는 세번째 꼭지점을 지저합니다.",
+      "params": ["숫자: 첫번째 꼭지점의 x 좌표",
+      "숫자: 첫번째 꼭지점의 y 좌표",
+      "숫자: 두번째 꼭지점의 x 좌표",
+      "숫자: 두번째 꼭지점의 y 좌표",
+      "숫자: 세번째 꼭지점의 x 좌표",
+      "숫자: 세번째 꼭지점의 y 좌표"],
       "returns": "the p5 object"
     },
     "ellipseMode": {
@@ -537,40 +501,40 @@
       "returns": "el objeto p5"
     },
     "preload": {
-      "description": "La función preload() es ejecutada antes de setup(), es usada para manejar la carga asíncrona de archivos externos. Si se define una función preload(), setup() esperará hasta que las llamadas a funciones load hayan terminado. Solo se deben incluir instrucciones de carga dentro de preload() (loadImage, loadJSON, loadFont, loadStrings, etc).",
-      "returns": "el objeto p5"
+      "description": "preload() 함수는 setup() 함수 직전에 호출되며, 외부 파일들의 비동기성 로딩을 blocking 방식으로 처리하기 위해 사용됩니다. preload() 함수를 사용하면 setup() 함수는 preload() 함수 내에 포함된 모든 로딩이 끝난 후에 실행됩니다. preload() 함수 내에는 loadImage, loadJSON, loadFont, LoadString과 같은 로딩 호출만 포함해야 합니다. 비동기적 로딩을 원하는 경우에는 setup() 함수 내 혹은 다른 적절한 위치에서 로딩하되, 콜백 매개변수와 함께 사용합니다. 로딩 페이지에는 'loading...' 문구가 표시됩니다. 로딩 페이지 문구나 디자인을 변경하려면 id가 'p5_loading'인 HTML 요소를 해당 페이지에 삽입하세요.",
+      "returns": "the p5 object"
     },
     "setup": {
-      "description": "La función setup() es ejecutada una vez, cuando el programa empieza. Es usada para definir propiedades iniciales como amaño de la pantalla y color de fondo y para cargar medios como imágenes y tipografías cuando el programa empieza. Solo puede haber una función setup() en cada programa y no debe ser llamada después de su ejecución inicial. Nota: las variables declaradas dentro de setup() no son accesibles dentro de otras funciones, como draw().",
-      "returns": "el objeto p5"
+      "description": "setup()은 화면의 크기나 배경 색과 같은 환경적 속성, 이미지나 서체와 같은 미디어 로딩을 정의하는데 사용하는 함수로, 프로그램을 시작 시 단 한 번만 실행됩니다. setup()은 한 프로그램 내 하나만 존재하며, 한번 실행된 이후에 다시 호출되어서는 안됩니다. 주의: setup() 내에서 정의된 변수는 draw()를 포함한 다른 함수에서 접근이 불가함.",
+      "returns": "the p5 object"
     },
     "draw": {
-      "description": "La función draw() es ejecutada después de setup(), y ejecuta contínuamente las líneas de código dentro de su bloque hasta que el programa es detenido o se ejecuta la función noLoop(). Notar que si noLoop() es ejecutada dentro de setup(), draw() igualmente será ejecutado una vez antes de parar. La función draw() es ejecutada automáticamente y nunca debiera ser ejecutada explícitamente. Siempre debería ser controlada con noLoop(), redraw() y loop(). Después de que noLoop() detiene la ejecución del código dentro de draw(), redraw() causa que el código dentro de draw() se ejecute una vez, y loop() causa que el código dentro de draw() siga ejecutándose de forma continua. El número de veces que draw() se ejecuta por segundo puede ser controlado con la función frameRate(). Solo puede haber una función draw() en cada bosquejo, y draw() solo debe existir si quieres que el código corra de forma continua, o para procesar eventos como mousePressed(). Algunas veces, podrías querer ejecutar una función draw() vacía, como se mostró en el ejemplo más arriba. Es importante notar que el sistema de coordenadas de dibujo será reiniciado al principio de cada ejecución de la función draw(). Si cualquier transformación es hecha dentro de draw() (por ejemplo: escalar, rotar, trasladar), sus efectos serán anulados al principio de cada ejecución de draw(), así que las transformaciones no se acumulan en el tiempo. Por el otro lado, el estilo aplicado (color de relleno, color de trazado) sí se mantendrá en efecto. ",
-      "returns": "el objeto p5"
+      "description": "setup()이 실행된 직후 호출되는 draw()는 프로그램이 종료되거나 noLoop() 함수가 호출될 때까지 계속해서 반복적으로 실행됩니다. 단, noLoop() 함수가 setup() 내에서 호출되는 경우에는 draw() 에 영향을 미치지 않아 실행을 종료시키지 않습니다. draw()는 자동적으로 호출되는 함수이며 절대로 임의로 호출해 사용할 수 없습니다. 대신, draw()는 noLoop(), redraw(), loop()로 조종이 가능합니다. noLoop()는 draw() 실행을 중단하고, redraw()는 draw() 내 코드를 한 번 실행시키며, loop()는 draw() 내 코드를 다시 반복적으로 실행시킵니다. frameRate() 함수를 이용하면 draw()를 일초에 몇 번 실행시킬 것인지 설정할 수 있습니다. draw()는 한 스케치에 꼭 하나만 존재합하며 mousePressed()와 같은 이벤트를 실행하기 위해서는 draw()가 반드시 필요합니다. 또하나 기억해야 할 점은 draw()를 시작할 때 좌표 시스템이 초기화된다는 점입니다. 즉, draw() 내에서 scale, rotate, translate와 같은 좌표 변형을 하는 경우 draw() 시작시 매번 이들이 초기화되기 때문에 변형 상태가 축적되지 않습니다. 한편, fill이나 stroke와 같은 스타일링은 draw() 시작시 초기화되지 않고 유지됩니다",
+      "returns": "the p5 object"
     },
     "remove": {
-      "description": "Remueve el bosquejo de p5 completamente. Esto removerá el lienzo y cualquier otro elemento creado por p5.js. También detendrá el bucle de dibujo y desvinculará cualquier propiedad o método global de la ventana. Dejará una variable p5 en caso que quieras crear un nuevo bosquejo p5. Si quieres, puedes definir p5 = null para borrar esta variable.",
-      "returns": "el objeto p5"
+      "description": "전체 p5 스케치를 제거합니다. 캔버스를 포함해 p5.js에 의해 생성된 모든 요소를 제거하고, draw loop을 정지시키며 윈도우 전역의 속성과 메소드를 무효화 합니다. 단, 당신이 새로운 p5 스케치를 만들고 싶어할 경우를 대비해 변수 'p5'는 제거하지 않는데, 이마저 제거하고 싶다면 'p5 = null'을 입력하면 됩니다. 이 함수는 p5 라이브러리에 의해 생성된 함수, 변수, 오브젝트만 제거하며 프로그램 내의 다른 변수는 제거하지 않습니다.",
+      "returns": "the p5 object"
     },
     "noLoop": {
-      "description": "Detiene la ejecución continua del código de draw() de p5.js. Si se llama a la función loop(), el código dentro de draw() empieza a correr de forma continua nuevamente. Si se usa noLoop() dentro de setup(), debe ser la última línea de código dentro del bloque. Cuando se usa noLoop(), no es posible manipular o acceder a la pantalla dentro de las funciones que manejan eventos como mousePressed() o keyPressed(). En vez de eso, usa estas funciones para llamar a redraw() o loop(), que permitirán la ejecución de draw(), lo que permite el refresco correcto de la pantalla. Esto significa que cuando noLoop() ha sido ejecutado, no se sigue dibujando, y funciones como saveFrame() o loadPixels() no se pueden usar. Notar que si el bosquejo es escalado, redraw() será llamado para actualizar el bosquejo, incluso si noLoop() ha sido ejecutada. Por otro lado, el bosquejo entrará a un estado singular, hasta que loop() sea ejecutado.",
-      "returns": "el objeto p5"
+      "description": "draw() 내 코드가 반복적으로 실행되는 것을 정지시킵니다. 정지 후에 다시 코드를 반복적으로 실행시키고 싶다면 loop()를 이용합니다. noLoop()이 setup() 내에서 사용하려면 가장 마지막 줄에 사용합니다. noLoop()이 호출되면 mousePressed()나 keyPressed()와 같은 이벤트 핸들러 함수를 접근하거나 조종할 수 없습니다. 대안으로는 draw()를 실행시킬 수 있는 redraw()나 loop()과 같은 함수를 이용해 화면을 적절히 업데이트하는 방법이 있습니다. noLoop()을 호출한 이후에는 스케치가 진행되지 않으며 saveFrame()이나 loadPixels과 같은 함수를 사용할 수도 없습니다. 주의: 스케치의 사이즈를 재설정(resize)하는 경우에는 noLoop()의 존재여부와 관계없이 redraw()가 자동적으로 호출됩니다. 사이즈 재설정 후 스케치를 업데이트하지 않으면 화면의 요소들이 제대로 보여지지 않기 때문입니다.",
+      "returns": "the p5 object"
     },
     "loop": {
-      "description": "Por defecto, p5.js repite de forma continua la función draw(), ejecutado el código dentro de su bloque. Sin embargo, el bucle de dibujo puede ser detenido llamando a la función noLoop(). En ese caso, el bucle de draw() puede ser retomado con loop().",
-      "returns": "el objeto p5"
+      "description": "p5.js는 draw() 내 코드를 끊임없이 반복해서 실행합니다. 이를 멈추고싶을 때는 noLoop()를 사용하세요. draw() 반복 실행을 재개하고 싶은 경우에는 loop()을 사용합니다.",
+      "returns": "the p5 object"
     },
     "push": {
-      "description": "La función push() graba la configuración actual de estilo de dibujo, y pop() restaura esta configuración. Notar que estas funciones siempre son usadas en conjunto. Permiten cambiar las configuraciones de estilo y transformaciones y luego volver a lo que tenías. Cuando un nuevo estado es iniciado con push(), construye encima de la información actual de estilo y transformación. Las funciones push() y pop() pueden ser embebidas para proveer más control (ver el segundo ejemplo para una demostración). push() almacena información relacionada a la configuración de estado de transformación y de estulo actual, controlada por las siguientes funciones: fill(), stroke(), tint(), strokeWeight(), strokeCap(), strokeJoin(), imageMode(), rectMode(), ellipseMode(), colorMode(), textAlign(), textFont(), textMode(), textSize(), textLeading().",
-      "returns": "el objeto p5"
+      "description": "push()와 pop()은 항상 함께 사용되는 함수로, push() 함수는 함수 이전에 설정된 드로잉 스타일과 좌표 시스템을 저장하고 pop() 함수는 이 저장값을 복구합니다. 이 함수를 사용하면 스타일과 좌표 시스템을 일시적으로 변경하고 이후 필요한 시점에 본래의 설정값으로 편리하게 되돌아올 수 있습니다. push() 함수를 호출한 이후에 입력하는 설정은 새로운 상태를 정의하며 이 설정은 pop() 함수가 등장하기 전까지 유효합니다. 두번째 예제와 같이 push()와 pop() 함수 세트 내에 다른 push()와 pop() 함수 세트를 내장하는 것도 가능합니다. push() 함수는 다음의 함수가 설정하는 현재의 좌표 시스템과 스타일을 저장합니다: fill(), stroke(), tint(), strokeWeight(), strokeCap(), strokeJoin(), imageMode(), rectMode(), ellipseMode(), colorMode(), texgtAlign(), textFont(), textSize(), textLoading(). WEBGL 모드에서는 다음 함수를 이용해 설정하는 추가적인 스타일도 저장됩니다: setCamera(), ambientLight(), directionalLight(), pointLight(), texture(), specularMaterial(), shineness(), normalMaterial(), shader().",
+      "returns": "the p5 object"
     },
     "pop": {
-      "description": "La función push() graba la configuración actual de estilo de dibujo, y pop() restaura esta configuración. Notar que estas funciones siempre son usadas en conjunto. Permiten cambiar las configuraciones de estilo y transformaciones y luego volver a lo que tenías. Cuando un nuevo estado es iniciado con push(), construye encima de la información actual de estilo y transformación. Las funciones push() y pop() pueden ser embebidas para proveer más control (ver el segundo ejemplo para una demostración). push() almacena información relacionada a la configuración de estado de transformación y de estulo actual, controlada por las siguientes funciones: fill(), stroke(), tint(), strokeWeight(), strokeCap(), strokeJoin(), imageMode(), rectMode(), ellipseMode(), colorMode(), textAlign(), textFont(), textMode(), textSize(), textLeading()."
+      "description": "push()와 pop()은 항상 함께 사용되는 함수로, push() 함수는 함수 이전에 설정된 드로잉 스타일과 좌표 시스템을 저장하고 pop() 함수는 이 저장값을 복구합니다. 이 함수를 사용하면 스타일과 좌표 시스템을 일시적으로 변경하고 이후 필요한 시점에 본래의 설정값으로 편리하게 되돌아올 수 있습니다. push() 함수를 호출한 이후에 입력하는 설정은 새로운 상태를 정의하며 이 설정은 pop() 함수가 등장하기 전까지 유효합니다. 두번째 예제와 같이 push()와 pop() 함수 세트 내에 다른 push()와 pop() 함수 세트를 내장하는 것도 가능합니다. push() 함수는 다음의 함수가 설정하는 현재의 좌표 시스템과 스타일을 저장합니다: fill(), stroke(), tint(), strokeWeight(), strokeCap(), strokeJoin(), imageMode(), rectMode(), ellipseMode(), colorMode(), texgtAlign(), textFont(), textSize(), textLoading(). WEBGL 모드에서는 다음 함수를 이용해 설정하는 추가적인 스타일도 저장됩니다: setCamera(), ambientLight(), directionalLight(), pointLight(), texture(), specularMaterial(), shineness(), normalMaterial(), shader()."
     },
     "redraw": {
-      "description": "Ejecuta una vez el código dentro de la función draw(). Esta función permite al programa actualizar la ventana mostrada solamente cuando es necesario, por ejemplo, cuando un evento registrado por mousePressed() o keyPressed() ocurre. En la estructura de un programa, solo hace sentido llamar a redraw() dentro de eventos como mousePressed(). Esto es porque redraw() no hace que draw() se ejecute de forma inmediata (solo define una indicación de que se necesita un refresco). La función redraw() no funciona de forma correcta cuando se llama dentro de la función draw(). Para habilitar y deshabilitar animaciones, usa las funcioens loop() y noLoop(). Adicionalmente, puedes definir el número de veces que se dibuja por cada llamada a este método. Para esto, añade un entero como parámetro único a la función, que señale cuántas veces se requiere dibujar.",
-      "params": ["Entero: redibuja n-veces. Por defecto el valor es 1"],
-      "returns": "el objeto p5"
+      "description": "draw() 내 코드를 한 번 실행합니다. 본 함수를 이용하면 필요한 경우에만 화면을 업데이트할 수 있습니다. redraw()는 mousePressed()나 keyPressed()에 의해 일어나는 이벤트와 같이 조건적으로 일어나는 이벤트에 사용하면 유용합니다. 이 함수를 어느 위치에 사용하냐구요? redraw()는 draw()를 바로 실행시키는 것이 아니라 단지 업데이트가 필요하다는 표시를 하는 셈이기 때문에, mousePressed()와 같은 이벤트 내에서 호출해야 합니다. redraw() 함수는 draw()함수 내에 사용할 수는 없습니다. 애니메이션의 실행 여부를 조종하고 싶다면 loop()과 noLoop()를 이용하세요. redraw 횟수를 정하는 것도 가능한데, 이를 위해서는 정수를 redraw() 함수의 변수로 입력합니다.",
+      "params": ["정수: redraw를 n번 실행합니다. n의 초기값은 1입니다."],
+      "returns": "the p5 object"
     },
     "print": {
       "description": "La función print() escribe en la consola del navegador. Esta función es a menudo de ayuda para observar los datos que un programa está produciendo. Esta función crea una nueva línea de texto por cada ejecución de la función. Elementos individuales pueden ser separados por comillas ('') y unidos con el operador de adición (+). Aunque print() es similar a console.log(), no llama a console.log() directamente, para simular una manera más simple de entender el comportamiento del programa. Por esto mismo, es más lento. Para resultados más rápidos, usar directamente console.log().",
@@ -657,11 +621,10 @@
       "returns": "Objeto: parámetros de la URL"
     },
     "createCanvas": {
-      "description": "Crea un elemento canvas en el documento, y define sus dimensiones medidas en pixeles. Este método debe ser llamado solo una vez al comienzo de la función setup(). Llamar a la función createCanvas() más de una vez en un bosquejo puede resultar en comportamientos impredecibles. Si quieres más de un lienzo donde dibujar, debes usar la función createGraphics() (escondido por defecto, pero puede ser mostrado), Las variables de sistema width (ancho) y height (altura) son definidas por los parámetros pasados a la función. Si createCanvas() no es usado, la ventana tendrá un tamaño por defecto de 100 x 100 pixeles. Para más maneras de posicionar el lienzo, ver la sección de posición del lienzo.",
-      "params": ["Número: ancho del lienzo",
-      "Número: altura del lienzo",
-      "Constante: P2D o WEBGL"],
-      "returns": "Objeto: lienzo generado"
+      "description": "캔버스를 생성하고 픽셀 단위로 크기를 설정합니다. createCanvas()는 setup() 시작시에 한번만 실행되어야 합니다. createCanvas()를 1번 이상 호출하면 스케치가 예기치 못한 반응을 보일 수 있습니다. 2개 이상의 캔버스가 필요하다면 createGraphics()를 이용하세요. 설정한 캔버스 사이즈는 시스템 변수인 width와 height에 각각 저장됩니다. createCanvas() 자체를 생략하면 스케치는 디폴트 사이즈인 100x100픽셀이 됩니다. 캔버스의 위치를 정하는 다른 방식들을 알고싶다면, 위키 페이지의 'positioning the canvas'를  참고하세요.",
+      "params": ["숫자: 캔버스의 너비",
+      "숫자: 캔버스의 높이",
+      "상수: P2D 또는 WEBGL"]
     },
     "resizeCanvas": {
       "description": "Redimensiona el linezo al ancho y la altura dados. El lienzo será borrado y la función draw() será llamada inmediatamente, permitiendo que el bosquejo se ajuste al nuevo lienzo",
@@ -987,28 +950,26 @@
       "returns": "el objeto p5"
     },
     "loadImage": {
-      "description": "Carga una imagen desde una ruta de archivo y crea un objeto p5.Image. La imagen puede no estar inmediatamente disponible para render. Si quieres asegurarte que esté lista antes de hacer algo con ella, ubica la función loadImage() dentro de preload(). También puedes proveer una función callback para manejar la imagen cuando esté lista. La ruta a la imagen debe ser relativa al archivo HTML de tu bosquejo. Cargar desde una URL u otra ubicación remota podría estar bloqueado por las opciones de seguridad del navegador.",
-      "params": ["String: ruta de la imagen a cargar",
-      "Función(p5.Image): función a ser llamada una vez que la imagen sea cargada. Le será pasado el objeto p5.Image",
-      "Función(evento): llamada con el evento error si es que la carga de la imagen falla."],
-      "returns": "el objeto p5"
+      "description": "설정한 경로에서 이미지를 불러오고 p5.Image를 생성합니다. 이미지를 불러온 후 바로 렌더링이 가능하지 않은 경우도 있습니다. 이를 피하려면 loadImage()를 preload()에서 호출하거나, 이미지가 준비된 후 다른 명령을 하도록 하는 콜백 함수를 이용하세요. 이미지 경로는 스케치에 링크된 HTML 파일을 기준으로 상대 경로를 사용합니다. URL이나 원격 경로를 이용하면 브라우저의 보안 설정에 따라 이미지를 불러오는데에 문제가 생길 수 있습니다.",
+      "params": ["문자열: 불러올 이미지 경로",
+      "함수(p5.Image): 이미지를 불러온 후 호출할 함수",
+      "함수(Event): 이미지 불러오기를 실패하는 경우에 호출할 함수"]
     },
     "image": {
-      "description": "Dibuja una imagen en el lienzo principal del bosquejo p5.js.",
-      "params": ["p5.Image: la imagen a mostrar",
-      "Número: la coordenada x donde se ubicará la esquina superior de la imagen",
-      "Número: la coordenada y donde se ubicará la esquina superior de la imagen",
-      "Número: ancho de la imagen a dibujar",
-      "Número: altura de la imagen a dibujar",
-      "Número: la coordenada x en el lienzo de destino donde se ubicará la esquina superior izquierda de la imagen",
-      "Número: la coordenada y en el lienzo de destino donde se ubicará la esquina superior izquierda de la imagen",
-      "Número: ancho de la imagen a dibujar en el lienzo de destino",
-      "Número: altura de la imagen a dibujar en el lienzo de destino",
-      "Número: la coordenada x de la esquina superior izquierda del subrectángulo de la imagen original a dibujar en el lienzo de destino",
-      "Número: la coordenada y de la esquina superior izquierda del subrectángulo de la imagen original a dibujar en el lienzo de destino",
-      "Número: el ancho del subrectángulo de la imagen original a dibujar en el lienzo de destino",
-      "Número: la altura del subrectángulo de la imagen original a dibujar en el lienzo de destino"],
-      "returns": "el objeto p5"
+      "description": "p5.js 캔버스에 이미지를 배치합니다. 본 함수를 사용하는 몇가지 방법을 소개하자면 다음과 같습니다. (1) 가장 간단한 방법은 img, x, y 세 개의 변수를 사용하는 방법입니다. x, y는 이미지의 위치를 지정합니다. (2) 이미지의 크기를 설정하려면 img, x, y와 더불어 이미지의 너비와 높이를 설정하는 두개의 변수를 추가로 사용합니다. (3) 여덟개의 변수를 사용하는 방법입니다. 먼저, 각 변수들을 구별하기 위해 p5.js에서 사용하는 용어를 배워봅시다. 첫번째 용어는 '목적지 사각형(destination rectagle)로, dx, dy 등의 변수가 이에 해당합니다. 두번째 용어는 '원본 이미지(source image)'로, sx, sy등의 변수가 이에 해당합니다. '원본 이미지'의 크기를 설정하면 해당 이미지의 일부만을 디스플레이할 때 유용합니다. 자세한 사항은 아래 도식을 참고하세요.",
+      "params": ["p5.Image, p5.Element: 디스플레이할 이미지",
+      "숫자: 왼쪽 위 모서리의 x 좌표",
+      "숫자: 왼쪽 위 모서리의 y 좌표",
+      "숫자: 이미지 너비 설정",
+      "숫자: 이미지 높이 설정",
+      "숫자: 원본 이미지를 배치할 목적지 사각형의 x 좌표",
+      "숫자: 원본 이미지를 배치할 목적지 사각형의 y 좌표",
+      "숫자: 목적지 사각형의 너비",
+      "숫자: 목적지 사각형의 높이",
+      "숫자: 목적지 사각형에 배치할 원본 이미지 일부의 x좌표",
+      "숫자: 목적지 사각형에 배치할 원본 이미지 일부의 y좌표",
+      "숫자: 목적지 사각형에 배치할 원본 이미지 일부의 너비",
+      "숫자: 목적지 사각형에 배치할 원본 이미지 일부의 높이"]
     },
     "tint": {
       "description": "Define el valor de relleno para mostrar imágenes. Las imágenes pueden ser teñidas en colores específicos o hacerse transparentes al incluir un valor alpha. Para aplicar transparencia a una imagen sin afectar su color, usa blanco como color de teñido y especifica un valor alpha. Por ejemplo, tint(255, 128) hará una imagen 50% transparente (asumiendo el rango alpha por defecto entre 0 y 255, el que puede ser modificado con la función colorMode()). El valor del parámetro gris debe ser menor o igual al actual valor máximo según lo especificado por colorMode(). El valor máximo por defecto es 255.",


### PR DESCRIPTION
Korean translations completed for:

circle()
line()
point()
quad()
rect()
square()
triangle()
preload()
setup()
draw()
remove()
noLoop()
loop()
push()
pop()
redraw()
createCanvas()
loadImage()
image()

