### PR TITLE
Reformat + fix arduino sensor example

### DIFF
--- a/src/data/examples/en/10_Interaction/28_ArduinoSensor.js
+++ b/src/data/examples/en/10_Interaction/28_ArduinoSensor.js
@@ -5,8 +5,9 @@
  * 
  * https://github.com/publiclab/webjack
  * 
- * Note: WebJack library must be added to your index.html as
+ * Note: WebJack and p5-webjack libraries must be added to your index.html as follows:
  * <pre><code class="language-markup">&lt;script src="https://webjack.io/dist/webjack.js">&lt;/script></code></pre>
+ * <pre><code class="language-markup">&lt;script src="https://jywarren.github.io/p5-webjack/lib.js">&lt;/script></code></pre>
  * 
  * Testing audio: https://www.youtube.com/watch?v=GtJW1Dlt3cg
  * Load this sketch onto an Arduino: 

--- a/src/data/examples/en/10_Interaction/28_ArduinoSensor.js
+++ b/src/data/examples/en/10_Interaction/28_ArduinoSensor.js
@@ -18,17 +18,16 @@ function setup() {
   createCanvas(400, 400);
   noStroke();
   fill('#ff00aa22');
-} 
+  receiveSensorData(handleData);
+}
 
-// Set up the WebJack connection.
-// Use default profile: https://github.com/publiclab/webjack/blob/master/src/profiles.js
-let profile = WebJack.Profiles["SoftModem"];
-let connection = new WebJack.Connection(profile);
+function handleData(data) {
 
-// Runs every time a signal is 'heard'
-connection.listen(function(data) {
-  
-  // Draw an ellipse at a height corresponding to the value received from the Arduino (sensor)
-  ellipse(400/2, 400 - (data * 5), 20, 20);
+  console.log(data); // output the values to log
+  // data[0] is the 1st value, data[1] 2nd, etc.
 
-});
+  // draw stuff! Browse http://p5js.org/reference/
+  background('#ddd');
+  ellipse(200, 200, data[0]+10, data[0]+10);
+
+}

--- a/src/data/examples/en/10_Interaction/28_ArduinoSensor.js
+++ b/src/data/examples/en/10_Interaction/28_ArduinoSensor.js
@@ -31,6 +31,6 @@ function handleData(data) {
 
   // draw stuff! Browse http://p5js.org/reference/
   background('#ddd');
-  ellipse(200, 200, data[0]+10, data[0]+10);
+  ellipse(100, 200, data[0]+10, data[0]+10);
 
 }

--- a/src/data/examples/en/10_Interaction/28_ArduinoSensor.js
+++ b/src/data/examples/en/10_Interaction/28_ArduinoSensor.js
@@ -9,6 +9,8 @@
  * <pre><code class="language-markup">&lt;script src="https://webjack.io/dist/webjack.js">&lt;/script></code></pre>
  * <pre><code class="language-markup">&lt;script src="https://jywarren.github.io/p5-webjack/lib.js">&lt;/script></code></pre>
  * 
+ * Working example: https://editor.p5js.org/jywarren/sketches/rkztwSt8M
+ * 
  * Testing audio: https://www.youtube.com/watch?v=GtJW1Dlt3cg
  * Load this sketch onto an Arduino: 
  * https://create.arduino.cc/editor/jywarren/023158d8-be51-4c78-99ff-36c63126b554/preview

--- a/src/data/examples/en/10_Interaction/28_ArduinoSensor.js
+++ b/src/data/examples/en/10_Interaction/28_ArduinoSensor.js
@@ -6,7 +6,7 @@
  * https://github.com/publiclab/webjack
  * 
  * Note: WebJack library must be added to your index.html as
- * <script src="https://webjack.io/dist/webjack.js"></script>
+ * <pre><code class="language-markup">&lt;script src="https://webjack.io/dist/webjack.js">&lt;/script></code></pre>
  * 
  * Testing audio: https://www.youtube.com/watch?v=GtJW1Dlt3cg
  * Load this sketch onto an Arduino: 

--- a/src/data/examples/es/10_Interaction/28_ArduinoSensor.js
+++ b/src/data/examples/es/10_Interaction/28_ArduinoSensor.js
@@ -18,17 +18,16 @@ function setup() {
   createCanvas(400, 400);
   noStroke();
   fill('#ff00aa22');
+  receiveSensorData(handleData);
 } 
 
-// Set up the WebJack connection.
-// Use default profile: https://github.com/publiclab/webjack/blob/master/src/profiles.js
-let profile = WebJack.Profiles["SoftModem"];
-let connection = new WebJack.Connection(profile);
+function handleData(data) {
 
-// Runs every time a signal is 'heard'
-connection.listen(function(data) {
-  
-  // Draw an ellipse at a height corresponding to the value received from the Arduino (sensor)
-  ellipse(400/2, 400 - (data * 5), 20, 20);
+  console.log(data); // output the values to log
+  // data[0] is the 1st value, data[1] 2nd, etc.
 
-});
+  // draw stuff! Browse http://p5js.org/reference/
+  background('#ddd');
+  ellipse(200, 200, data[0]+10, data[0]+10);
+
+}

--- a/src/data/examples/es/10_Interaction/28_ArduinoSensor.js
+++ b/src/data/examples/es/10_Interaction/28_ArduinoSensor.js
@@ -5,8 +5,9 @@
  * 
  * https://github.com/publiclab/webjack
  * 
- * Note: WebJack library must be added to your index.html as
+ * Note: WebJack and p5-webjack libraries must be added to your index.html as follows:
  * <pre><code class="language-markup">&lt;script src="https://webjack.io/dist/webjack.js">&lt;/script></code></pre>
+ * <pre><code class="language-markup">&lt;script src="https://jywarren.github.io/p5-webjack/lib.js">&lt;/script></code></pre>
  * 
  * Testing audio: https://www.youtube.com/watch?v=GtJW1Dlt3cg
  * Load this sketch onto an Arduino: 

--- a/src/data/examples/es/10_Interaction/28_ArduinoSensor.js
+++ b/src/data/examples/es/10_Interaction/28_ArduinoSensor.js
@@ -31,6 +31,6 @@ function handleData(data) {
 
   // draw stuff! Browse http://p5js.org/reference/
   background('#ddd');
-  ellipse(200, 200, data[0]+10, data[0]+10);
+  ellipse(100, 200, data[0]+10, data[0]+10);
 
 }

--- a/src/data/examples/es/10_Interaction/28_ArduinoSensor.js
+++ b/src/data/examples/es/10_Interaction/28_ArduinoSensor.js
@@ -9,6 +9,8 @@
  * <pre><code class="language-markup">&lt;script src="https://webjack.io/dist/webjack.js">&lt;/script></code></pre>
  * <pre><code class="language-markup">&lt;script src="https://jywarren.github.io/p5-webjack/lib.js">&lt;/script></code></pre>
  * 
+ * Working example: https://editor.p5js.org/jywarren/sketches/rkztwSt8M
+ * 
  * Testing audio: https://www.youtube.com/watch?v=GtJW1Dlt3cg
  * Load this sketch onto an Arduino: 
  * https://create.arduino.cc/editor/jywarren/023158d8-be51-4c78-99ff-36c63126b554/preview

--- a/src/data/examples/es/10_Interaction/28_ArduinoSensor.js
+++ b/src/data/examples/es/10_Interaction/28_ArduinoSensor.js
@@ -6,7 +6,7 @@
  * https://github.com/publiclab/webjack
  * 
  * Note: WebJack library must be added to your index.html as
- * <script src="https://webjack.io/dist/webjack.js"></script>
+ * <pre><code class="language-markup">&lt;script src="https://webjack.io/dist/webjack.js">&lt;/script></code></pre>
  * 
  * Testing audio: https://www.youtube.com/watch?v=GtJW1Dlt3cg
  * Load this sketch onto an Arduino: 

--- a/src/data/examples/zh-Hans/10_Interaction/28_ArduinoSensor.js
+++ b/src/data/examples/zh-Hans/10_Interaction/28_ArduinoSensor.js
@@ -18,17 +18,16 @@ function setup() {
   createCanvas(400, 400);
   noStroke();
   fill('#ff00aa22');
+  receiveSensorData(handleData);
 } 
 
-// Set up the WebJack connection.
-// Use default profile: https://github.com/publiclab/webjack/blob/master/src/profiles.js
-let profile = WebJack.Profiles["SoftModem"];
-let connection = new WebJack.Connection(profile);
+function handleData(data) {
 
-// Runs every time a signal is 'heard'
-connection.listen(function(data) {
-  
-  // Draw an ellipse at a height corresponding to the value received from the Arduino (sensor)
-  ellipse(400/2, 400 - (data * 5), 20, 20);
+  console.log(data); // output the values to log
+  // data[0] is the 1st value, data[1] 2nd, etc.
 
-});
+  // draw stuff! Browse http://p5js.org/reference/
+  background('#ddd');
+  ellipse(200, 200, data[0]+10, data[0]+10);
+
+}

--- a/src/data/examples/zh-Hans/10_Interaction/28_ArduinoSensor.js
+++ b/src/data/examples/zh-Hans/10_Interaction/28_ArduinoSensor.js
@@ -5,8 +5,9 @@
  * 
  * https://github.com/publiclab/webjack
  * 
- * Note: WebJack library must be added to your index.html as
+ * Note: WebJack and p5-webjack libraries must be added to your index.html as follows:
  * <pre><code class="language-markup">&lt;script src="https://webjack.io/dist/webjack.js">&lt;/script></code></pre>
+ * <pre><code class="language-markup">&lt;script src="https://jywarren.github.io/p5-webjack/lib.js">&lt;/script></code></pre>
  * 
  * Testing audio: https://www.youtube.com/watch?v=GtJW1Dlt3cg
  * Load this sketch onto an Arduino: 

--- a/src/data/examples/zh-Hans/10_Interaction/28_ArduinoSensor.js
+++ b/src/data/examples/zh-Hans/10_Interaction/28_ArduinoSensor.js
@@ -31,6 +31,6 @@ function handleData(data) {
 
   // draw stuff! Browse http://p5js.org/reference/
   background('#ddd');
-  ellipse(200, 200, data[0]+10, data[0]+10);
+  ellipse(100, 200, data[0]+10, data[0]+10);
 
 }

--- a/src/data/examples/zh-Hans/10_Interaction/28_ArduinoSensor.js
+++ b/src/data/examples/zh-Hans/10_Interaction/28_ArduinoSensor.js
@@ -9,6 +9,8 @@
  * <pre><code class="language-markup">&lt;script src="https://webjack.io/dist/webjack.js">&lt;/script></code></pre>
  * <pre><code class="language-markup">&lt;script src="https://jywarren.github.io/p5-webjack/lib.js">&lt;/script></code></pre>
  * 
+ * Working example: https://editor.p5js.org/jywarren/sketches/rkztwSt8M
+ * 
  * Testing audio: https://www.youtube.com/watch?v=GtJW1Dlt3cg
  * Load this sketch onto an Arduino: 
  * https://create.arduino.cc/editor/jywarren/023158d8-be51-4c78-99ff-36c63126b554/preview

--- a/src/data/examples/zh-Hans/10_Interaction/28_ArduinoSensor.js
+++ b/src/data/examples/zh-Hans/10_Interaction/28_ArduinoSensor.js
@@ -6,7 +6,7 @@
  * https://github.com/publiclab/webjack
  * 
  * Note: WebJack library must be added to your index.html as
- * <script src="https://webjack.io/dist/webjack.js"></script>
+ * <pre><code class="language-markup">&lt;script src="https://webjack.io/dist/webjack.js">&lt;/script></code></pre>
  * 
  * Testing audio: https://www.youtube.com/watch?v=GtJW1Dlt3cg
  * Load this sketch onto an Arduino: 


### PR DESCRIPTION
Follow-up to #166, fixes #463

 Changes: 

Proper escaping of `<script>` tags in:

```
src/data/examples/en/10_Interaction/24_ArduinoSensor.js
src/data/examples/es/10_Interaction/24_ArduinoSensor.js
src/data/examples/zh-Hans/10_Interaction/24_ArduinoSensor.js
```

Plus a re-arranging of code for readability, and use of a wrapper library here: https://github.com/jywarren/p5js-webjack-sensor/blob/main/webjack-p5-wrapper.js

Remaining:

* [ ] pack the wrapper and webjack.js into the same include file so there's only one
* [ ] update script file in header of each to point at the new combined wrapper