### PR TITLE
Fix missing comma in .eslintrc file

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -42,7 +42,7 @@
         "allowAfterThis": true,
         "allowAfterSuper": true
       }
-    ]
+    ],
     "no-unused-vars": ["error", { "args": "none" }],
     "no-empty": ["error", { "allowEmptyCatch": true }],
     "no-console": "off"


### PR DESCRIPTION
.eslintrc file is [missing a comma](https://github.com/processing/p5.js-website/blob/master/.eslintrc#L45), simply adds it.