### PR TITLE
fixed broken links for p5 speech

### DIFF
--- a/src/templates/pages/libraries/index.hbs
+++ b/src/templates/pages/libraries/index.hbs
@@ -255,10 +255,10 @@ slug: libraries/
       <div class="spacer"></div>
 
       <div class="left-column">
-        <a class="nounderline" href="http://abilitylab.nyu.edu/p5.js-speech/">
+        <a class="nounderline" href="http://ability.nyu.edu/p5.js-speech/">
         <div class="label">
         <img src="{{assets}}/img/libraries/p5.speech.jpg"></a>
-        <a class="nounderline" href="http://abilitylab.nyu.edu/p5.js-speech/"><h4>p5.speech</h4></a>
+        <a class="nounderline" href="http://ability.nyu.edu/p5.js-speech/"><h4>p5.speech</h4></a>
         </div>
         <p>{{#i18n "p5.speech"}}{{/i18n}}<a target='_blank' href='http://lukedubois.com/'>R. Luke DuBois</a>.</p>
       </div>


### PR DESCRIPTION
Fixes #476

 Changes: 
changed links


 Screenshots of the change: 
broeken:
<img width="1570" alt="Screen Shot 2019-08-14 at 5 12 42 PM" src="https://user-images.githubusercontent.com/19146133/63064817-1b223f80-beb8-11e9-8b80-413c60789602.png">
fixed:
<img width="1570" alt="Screen Shot 2019-08-14 at 5 12 50 PM" src="https://user-images.githubusercontent.com/19146133/63064828-22494d80-beb8-11e9-8cae-e2c63961c594.png">
