### PR TITLE
Fix download links for Chrome

### DIFF
--- a/src/templates/pages/download/index.hbs
+++ b/src/templates/pages/download/index.hbs
@@ -57,7 +57,7 @@ slug: download/
           </div>
         </a>
 
-        <a class='support_link' href="http://cdnjs.com/libraries/p5.js">
+        <a class='support_link' href="http://cdnjs.com/libraries/p5.js" target="_blank">
           <div class="download_box half_box last_box">
             <h4>CDN</h4>
             <p>{{#i18n "link"}}{{/i18n}}
@@ -73,7 +73,7 @@ slug: download/
       <div class="link_group">
         <a name="editor" class="anchor"><h2>{{#i18n "editor-title"}}{{/i18n}}</h2></a>
 
-        <a class='support_link' href="https://editor.p5js.org">
+        <a class='support_link' href="https://editor.p5js.org" target="_blank">
           <div class="download_box">
 
             <h4>{{#i18n "p5.js-editor"}}{{/i18n}}</h4>
@@ -124,14 +124,13 @@ slug: download/
         });
       });
       $('.support_link').on('click', function (e) {
-        e.preventDefault();
-        // if ($(this).hasClass('p5_link')) {
-        //   window.open($(this).attr('href'), '_self');
-        //   setTimeout( function() { window.location = 'support.html'; }, 2000);
-        // } else {
-          window.location = 'support.html';
-          window.open($(this).attr('href'));
-        // }
+        if ($(this).hasClass('p5_link')) {
+          e.preventDefault();
+          window.location = $(this).attr('href');
+          setTimeout( function() { window.location = 'support.html'; }, 2000);
+        } else {
+          setTimeout( function() { window.location = 'support.html'; }, 100);
+        }
 
       });
 


### PR DESCRIPTION
Fixes #484 

Fixes the links on the download page for Chrome. Preserves the behaviour across Firefox and Safari as well. I haven't tested it out on any other browsers but I expect the behaviour to be the same (original page will redirect to support page while download starts without a popup and external links opens new tab)