### PR TITLE
Resolving Issue 510: Fix Get Started link on Download page

### DIFF
--- a/src/templates/pages/download/index.hbs
+++ b/src/templates/pages/download/index.hbs
@@ -36,7 +36,7 @@ slug: download/
       <!-- COMPLETE LIBRARY -->
       <div class="link_group">
         <h2>{{#i18n "complete-library-title"}}{{/i18n}}</h2>
-        <p>{{#i18n "complete-library-intro1"}}{{/i18n}}<a href="get-started/">{{#i18n "complete-library-intro2"}}{{/i18n}}</a>{{#i18n "complete-library-intro3"}}{{/i18n}}</p>
+        <p>{{#i18n "complete-library-intro1"}}{{/i18n}}<a href="{{root}}/get-started/">{{#i18n "complete-library-intro2"}}{{/i18n}}</a>{{#i18n "complete-library-intro3"}}{{/i18n}}</p>
 
         <a  class='support_link p5_link' href="https://github.com/processing/p5.js/releases/download/[p5_version]/p5.zip">
           <div class="download_box">


### PR DESCRIPTION
Fixes #510

 Changes: 
Changes the link to the Get Started page to absolute (from the root) instead of relative the current Download page. 

 Screenshots of the change: 
click here: 
![p5js-fix-1](https://user-images.githubusercontent.com/4752801/68333925-2643d080-009f-11ea-91ea-760a6d1bbf4c.png)

go here:
![p5js-fix-2](https://user-images.githubusercontent.com/4752801/68333930-2a6fee00-009f-11ea-9737-aae83a33153f.png)

