### PR TITLE
Fix reference page font to Montserrat

### DIFF
--- a/src/templates/pages/reference/index.html
+++ b/src/templates/pages/reference/index.html
@@ -7,7 +7,7 @@
     <meta name="description" content="p5.js a JS client-side library for creating graphic and interactive experiences, based on the core principles of Processing.">
     <title tabindex="1">reference | p5.js</title>
     <link rel="stylesheet" href="/../assets/css/all.css">
-    <script src="//fast.fonts.net/jsapi/5ace315e-3b19-4568-9e85-5bfcb29004c0.js"></script>
+    <link href="https://fonts.googleapis.com/css?family=Montserrat&display=swap" rel="stylesheet">
 
     <link rel="shortcut icon" href="/../assets/img/favicon.ico">
     <link rel="icon" href="/../assets/img/favicon.ico">
@@ -53,7 +53,7 @@
   <body>
 
     <a href="#content" class="sr-only">Skip to content</a>
-    
+
     <!-- p5*js language buttons -->
     <div id="i18n-btn">
       <h2 id="i18n-settings" class="sr-only">Language Settings</h2>
@@ -80,11 +80,11 @@
       </header>
       <!-- close logo -->
 
-      
+
 
 <div id="reference-page">
 
-  
+
   <!-- site navigation -->
   <div class="column-span">
     <nav>
@@ -121,10 +121,10 @@
 
     </main>
 
-    
+
     <footer>
       <h2 class="sr-only">Credits</h2>
-      <p> p5.js was created by <a href='http://lauren-mccarthy.com' target="_blank">Lauren McCarthy</a> and is developed by a community of collaborators, with support from the <a href="http://processing.org/foundation/" target="_blank">Processing Foundation</a>  and 
+      <p> p5.js was created by <a href='http://lauren-mccarthy.com' target="_blank">Lauren McCarthy</a> and is developed by a community of collaborators, with support from the <a href="http://processing.org/foundation/" target="_blank">Processing Foundation</a>  and
       <a href="http://itp.nyu.edu/itp/" target="_blank">NYU ITP</a>. Identity and graphic design by <a href="http://jereljohnson.com/" target="_blank">Jerel Johnson</a>. <a href="/copyright.html">&copy; Info.</a></p>
     </footer>
 
@@ -227,11 +227,11 @@
     }
     </script>
 
-  
+
   <!-- outside of column for footer to go across both -->
-  
+
   <p class="clearfix"> &nbsp; </p>
-  
+
   <object type="image/svg+xml" data="../assets/img/thick-asterisk-alone.svg" id="asterisk-design-element" aria-hidden="true">
        *<!-- to do: add fallback image in CSS -->
   </object>
@@ -241,7 +241,7 @@
 
     </div> <!-- close class='container'-->
 
-    
+
     <nav id="family" aria-labelledby="processing-sites-heading">
       <h2 id="processing-sites-heading" class="sr-only">Processing Sister Sites</h2>
       <ul id="processing-sites" aria-labelledby="processing-sites-heading">
@@ -252,7 +252,7 @@
         <li><a href="http://pi.processing.org/">Processing for Pi</a></li>
         <li><a href="https://processingfoundation.org/">Processing Foundation</a></li>
       </ul>
-    
+
     <!--   <p class="right">
       </p> -->
     </nav>


### PR DESCRIPTION
Mentioned in #175 

 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Change link from to refer to Monserrat font. Bunch of white space trim.

The text for searching reference is clipped so that will need more work after this PR is merged, see #175.


 Screenshots of the change: 
<!-- Add screenshots depicting the changes. -->
<img width="1337" alt="Screenshot 2019-11-21 at 1 44 42 pm" src="https://user-images.githubusercontent.com/7543950/69343262-29c18500-0c65-11ea-9b66-9a36d3aa7954.png">
