### PR TITLE
Fixing issue #515 - rotate example text

### DIFF
--- a/src/data/examples/en/18_Transform/02_Rotate.js
+++ b/src/data/examples/en/18_Transform/02_Rotate.js
@@ -5,9 +5,9 @@
  * parameters that are values between 0 and PI*2 (TWO_PI which is
  * roughly 6.28). If you prefer to think about angles as degrees
  * (0-360), you can use the radians() method to convert your values.
- * For example: scale(radians(90)) is identical to the statement
- * scale(PI/2). In this example, every even numbered second a jitter
- * is added to the rotation. During odd seconds rotation moves CW and
+ * For example: rotate(radians(90)) is identical to the statement
+ * rotate(PI/2). In this example, every even numbered second a jitter
+ * is added to the rotation. During odd seconds, rotation moves CW and
  * CCW at the speed determined by the last jitter value.
  */
 


### PR DESCRIPTION
Fixes #515 

 Changes: 
fixed wrong text in the example where it said scale instead of rotate.


 Screenshots of the change: 
<!-- Add screenshots depicting the changes. -->