### PR TITLE
Rename developer docs website to contributor-docs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,7 +55,7 @@ module.exports = function(grunt) {
           '<%= config.dist %>/assets/img/*.{png,jpg,jpeg,gif,webp,svg,ico}',
           '<%= config.dist %>/assets/p5_featured/{,*/}*.*',
           '<%= config.dist %>/assets/learn/{,*/}*.*',
-          '<%= config.dist %>/assets/developer-docs/*.*'
+          '<%= config.dist %>/assets/contributor-docs/*.*'
         ]
       }
     },
@@ -230,11 +230,11 @@ module.exports = function(grunt) {
         src: ['**', '!build_examples/**' ],
         dest: '<%= config.dist %>/assets/examples'
       },
-      developer_docs: {
+      contributor_docs: {
         expand: true,
-        cwd: '<%= config.src %>/assets/developer-docs',
+        cwd: '<%= config.src %>/assets/contributor-docs',
         src: '**',
-        dest: '<%= config.dist %>/developer-docs'
+        dest: '<%= config.dist %>/contributor-docs'
       },
       reference: {
         expand: true,

--- a/src/assets/contributor-docs/index.html
+++ b/src/assets/contributor-docs/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>p5.js Developers Docs</title>
+  <title>p5.js Contributor Docs</title>
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-  <meta name="description" content="p5.js Developers Docs">
+  <meta name="description" content="p5.js Contributor Docs">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="https://unpkg.com/docsify/lib/themes/buble.css">
 </head>
@@ -23,7 +23,7 @@
       basePath:
       'https://raw.githubusercontent.com/processing/p5.js/master/contributor_docs/',
       logo: '../assets/img/p5js.svg',
-      name: 'p5.js Developer Docs',
+      name: 'p5.js Contributor Docs',
       repo: 'https://github.com/processing/p5.js',
     }
   </script>


### PR DESCRIPTION
 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
This renames [the built contributor docs](https://p5js.org/developer-docs/#/) from `developer-docs` to `contributor-docs` in order to make usage consistent with p5.js repo. Contributor is a more accurate term to describe who the docs are for.

With these changes https://p5js.org/contributor-docs/ will be the new address for the contributor website.