### PR TITLE
Fix bug with p5.sound AudioWorklet preload in render.js

### DIFF
--- a/src/assets/js/render.js
+++ b/src/assets/js/render.js
@@ -193,6 +193,15 @@ var renderCode = function(exampleName) {
           'touchStarted', 'touchMoved', 'touchEnded',
           'keyPressed', 'keyReleased', 'keyTyped'];
         var _found = [];
+        // p.preload is an empty function created by the p5.sound library in order to use the p5.js preload system
+        // to load AudioWorklet modules before a sketch runs, even if that sketch doesn't have its own preload function.
+        // However, this causes an error in the eval code below because the _found array will always contain "preload",
+        // even if the sketch in question doesn't have a preload function. To get around this, we delete p.preload before
+        // eval-ing the sketch and add it back afterwards if the sketch doesn't contain its own preload function.
+        // For more info, see: https://github.com/processing/p5.js-sound/blob/master/src/audioWorklet/index.js#L22
+        if (p.preload) {
+          delete p.preload;
+        }
         with (p) {
           // Builds a function to detect declared functions via
           // them being hoisted past the return statement. Does
@@ -220,8 +229,9 @@ var renderCode = function(exampleName) {
           ].join('\n'));
         }
         // If we haven't found any functions we'll assume it's
-        // just a setup body.
+        // just a setup body with an empty preload.
         if (!_found.length) {
+          p.preload = function() {};
           p.setup = function() {
             p.createCanvas(100, 100);
             p.background(200);
@@ -237,10 +247,12 @@ var renderCode = function(exampleName) {
           _found.forEach(function(name) {
             p[name] = eval(name);
           });
+          // Ensure p.preload exists even if the sketch doesn't have a preload function.
+          p.preload = p.preload || function() {};
           p.setup = p.setup || function() {
             p.createCanvas(100, 100);
             p.background(200);
-          }
+          };
         }
       };
     }


### PR DESCRIPTION
This PR fixes an issue that has been blocking https://github.com/processing/p5.js/pull/3988.

The most recent version of p5.sound uses the p5.js preload system to asynchronously load [AudioWorklet](https://developer.mozilla.org/en-US/docs/Web/API/AudioWorkletNode) modules before a sketch runs. In order to ensure that the preload system is always invoked, p5.sound adds an empty preload function to a p5.js sketch if one doesn't already exist. For more details on this, see the [p5.sound repo](https://github.com/processing/p5.js-sound/blob/master/src/audioWorklet/index.js#L22).

This created a conflict with the render.js script used to display reference examples, which looks for lifecycle methods like `setup()` and `preload()` and hoists them if they exists, and otherwise wraps the example code in a `setup()` function.

Specifically, the presence of a `preload` key on the p5 instance object `p` causes an error because render.js incorrectly assumes that every p5.sound reference sketch contains a `preload()` function and attempts to `eval()` that function, which throws an error if there isn't a `preload()` function.

As a workaround, I've added some code that deletes the empty `preload()` function from the p5 instance object before calling `eval()` on the reference sketch code, and then adds it back afterwards if the sketch in question doesn't have its own `preload()` function.

