### PR TITLE
changed the server running command in Adding_examples.md

### DIFF
--- a/contributor_docs/Adding_examples.md
+++ b/contributor_docs/Adding_examples.md
@@ -54,7 +54,7 @@ Examples help demonstrate different programming concepts and functionality of th
 4. [Grunt](https://gruntjs.com/) should now be installed, and you can use it to build the website by navigating to the top level directory and typing:
 
     ```bash
-    grunt server
+    npm run watch
     ```
 
 5. A local build of the p5js.org site should open in your web browser and you can navigate to the examples page to see your changes.


### PR DESCRIPTION

Fixes #538 

 Changes: 
``grunt server`` command has been changed to ``npm run watch`` in **Adding_examples.md**.
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->