### PR TITLE
fixed brand logo collision with reference-page ul

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -306,10 +306,6 @@
   margin-top: 0.5em;
 }
 
-#reference-page ul {
-  margin-top: 0;
-}
-
 div.reference-group {
   display: inline-block;
 }


### PR DESCRIPTION
Fixes #554

 Changes: 
removed "margin-top:0" from 
"reference-page ul" 

file chnaged:
 src/assets/css/main.css


 Screenshots of the change: 
before : 
![isuuep5logo](https://user-images.githubusercontent.com/43696525/75308674-0d8d3f80-5875-11ea-8cc4-c492df27abca.png)


after:
![issue-solvedp5 logo](https://user-images.githubusercontent.com/43696525/75308689-13832080-5875-11ea-87cc-0d0324b9f1be.png)
