### PR TITLE
Tie CDN link to latest version number

### DIFF
--- a/src/templates/pages/download/index.hbs
+++ b/src/templates/pages/download/index.hbs
@@ -79,7 +79,7 @@ slug: download/
           </li>
 
           <li>
-            <a class='support_link' href="https://cdn.jsdelivr.net/npm/p5" target="_blank">
+            <a class='support_link p5_link' href="https://cdn.jsdelivr.net/npm/p5@[p5_version]/lib/p5.min.js" target="_blank">
               <div class="download_box half_box last_box">
                 <span class="download_name">CDN</span>
                 <p>{{#i18n "link"}}{{/i18n}}


### PR DESCRIPTION
Related to https://github.com/processing/p5.js/issues/4336

 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Tying the link to the CDN version of the library with the latest release number in the same way the rest of the download links works.

