### PR TITLE
Add DocSearch

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -564,86 +564,6 @@ form {
   pointer-events: all;
 }
 
-#search_button {
-  background: url(../img/search.png) 100% no-repeat;
-}
-
-#search input[type="text"],
-#search input[type="search"] {
-  border: 1px solid rgba(200, 200, 200, .5);
-  font-family: "Montserrat", sans-serif;
-  font-size: 2.25em;
-  width: 9.75em;
-}
-
-#search ::-webkit-input-placeholder,
-#search .twitter-typeahead .tt-hint {
-  color: #ccc;
-}
-
-:-moz-placeholder,
- ::-moz-placeholder,
- :-ms-input-placeholder {
-  color: #ccc;
-}
-
-#search input[type="text"]:focus {
-  color: #2d7bb6;
-  outline-color: #2d7bb6;
-  outline-width: 1px;
-  outline-style: solid;
-}
-
-#search .twitter-typeahead .tt-dropdown-menu {
-  background-color: #fff;
-  border: 1px solid rgba(0, 0, 0, 0.2);
-  overflow-y: auto;
-  font-size: 1em;
-  line-height: 1.4em;
-}
-
-#search .twitter-typeahead .tt-suggestion.tt-cursor {
-  color: #333;
-  background-color: #eee;
-}
-
-#search .twitter-typeahead .tt-suggestion p {
-  margin: 0;
-}
-
-#search .twitter-typeahead .tt-suggestion p .small {
-  font-size: 12px;
-  color: #666;
-}
-
-#search {
-  float: right;
-}
-
-#search .twitter-typeahead .tt-dropdown-menu {
-  border: 1px solid rgba(0, 0, 0, 0.2);
-  padding: 0.5em;
-  max-height: 200px;
-  overflow-y: auto;
-  font-size: 1em;
-  line-height: 1.4em;
-}
-
-#search .twitter-typeahead .tt-suggestion {
-  padding: 3px 20px;
-  line-height: 24px;
-  cursor: pointer;
-}
-
-#search .twitter-typeahead .empty-message {
-  padding: 8px 20px 1px 20px;
-  font-size: 14px;
-  line-height: 24px;
-}
-
-#search_button {
-  float: right;
-}
 
 a.code.core {
   color: #333;
@@ -1805,6 +1725,55 @@ footer {
   height: 100%;
 }
 
+
+#search-wrapper {
+  position: absolute;
+  width: 200px;
+  top: 5.5em;
+  right: 1em;
+  font-size: 16px;
+}
+
+
+#docsearch{
+  width: 140px;
+}
+
+.algolia-autocomplete  a.algolia-docsearch-suggestion:hover {
+  border-bottom: none;
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion{
+  font-family: "Montserrat", sans-serif;;
+}
+
+.algolia-autocomplete .searchbox__input {
+  font-size: 15px;
+}
+
+.searchbox__reset {
+  display: none;
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--highlight{
+  color: #ed225d;
+  padding: 0 .05em;
+}
+
+.algolia-autocomplete .algolia-docsearch-suggestion--text .algolia-docsearch-suggestion--highlight {
+  box-shadow: inset 0 -2px 0 0  rgba(237, 34, 93, .4);
+  ;
+}
+
+@media (max-width: 719px) {
+  #search-wrapper {
+    position: absolute;
+    width: 200px;
+    top: .5em;
+    left: 1em;
+  }
+}
+
 /* ==========================================================================
    Helper classes
    ========================================================================== */
@@ -2111,16 +2080,6 @@ footer {
     position: absolute;
     top: 0.5em;
     right: 0.7em;
-  }
-
-  #search {
-    width: 100%;
-    float: left;
-    margin-bottom: 1em;
-  }
-
-  #search input[type=text] {
-    width: 100%;
   }
 
   #lockup {

--- a/src/assets/js/init.js
+++ b/src/assets/js/init.js
@@ -18,33 +18,6 @@ window.onload = function() {
     document.documentElement.className += ' pointerevents';
   }
 
-  var search_form = document.getElementById('search_form'),
-      search_field = document.getElementById('search_field');
-  if (search_form) {
-    var open_field = function() {
-      search_form.className = 'form__open';
-      search_field.focus();
-    };
-    var close_field = function(e) {
-      if (e.type === 'focusout') {
-        search_form.className = '';
-      } else {
-        if (search_field.value === '') {
-          search_form.className = '';
-        }
-      }
-    };
-    if (search_form.addEventListener) {
-      search_form.addEventListener('mouseover', open_field, false);
-      search_form.addEventListener('mouseout', close_field, false);
-      search_form.addEventListener('focusout', close_field, false);
-    } else { // IE
-      search_form.attachEvent('onmouseover', open_field);
-      search_form.attachEvent('onmouseout', close_field);
-      search_form.attachEvent('onfocusout', close_field);
-    }
-  }
-
   // =================================================
   // set language and tagline
   var path = window.location.pathname;

--- a/src/templates/layouts/default.hbs
+++ b/src/templates/layouts/default.hbs
@@ -6,12 +6,18 @@
     <meta name="viewport" content="width=device-width">
     <meta name="description" content="p5.js a JS client-side library for creating graphic and interactive experiences, based on the core principles of Processing.">
     <title tabindex="1">{{title}} | p5.js</title>
+    
+    <meta name="docsearch:language" content="{{language}}" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css"
+    />
+
     <link rel="stylesheet" href="/{{assets}}/css/all.css?v=1.0.0">
     <link href="https://fonts.googleapis.com/css?family=Montserrat&display=swap" rel="stylesheet">
 
     <link rel="shortcut icon" href="/{{assets}}/img/favicon.ico">
     <link rel="icon" href="/{{assets}}/img/favicon.ico">
-
 
     <script src="/{{assets}}/js/vendor/jquery-1.12.4.min.js"></script>
     <script src="/{{assets}}/js/vendor/ace-nc/ace.js"></script>
@@ -28,6 +34,12 @@
 
     <a href="#content" class="sr-only">{{#i18n "Skip-To-Content"}}{{/i18n}}</a>
     {{>i18n}}
+
+    <!-- docsearch  -->
+    <div id="search-wrapper">
+      <input type="text" id="search"/>
+    </div>
+
     <!-- .container -->
     <div class="container">
 
@@ -68,6 +80,14 @@
     });
     </script>
 
+    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+    <script type="text/javascript"> docsearch({
+      apiKey: '13d97314da48a00287f5193bf65face4',
+      indexName: 'processing',
+      inputSelector: '#search',
+      enhancedSearchInput: true,
+    });
+    </script>
 
   </body>
 </html>

--- a/src/templates/pages/index.hbs
+++ b/src/templates/pages/index.hbs
@@ -8,13 +8,6 @@ slug: /
   <div class="column-span">
     <main id="home">
 
-      <form id="search" method="get" action="https://www.google.com/search">
-        <input type="hidden" name="as_sitesearch" value="p5js.org" >
-        <input id="search_button" type="submit" aria-label="Search" class='sr-only'>
-        <input id='search_field' type="text" size="20" placeholder="Search p5js.org" name="q" >
-        <label class="sr-only" for="search_field">Search p5js.org</label>
-      </form>
-
       <h1>{{#i18n "p1xh1"}}{{/i18n}}</h1>
       <p style="margin-top:1em">{{#i18n "p1x1"}}{{/i18n}}</p>
       <p>{{#i18n "p1x2"}}{{/i18n}}</p>


### PR DESCRIPTION
Hello Processing team,

[Someone noticed](https://twitter.com/bobylito/status/1225025743698132992) that your documentation could take advantage of our DocSearch initiative.
So, we went on trying to improve the search and came up with this PR. \o/

DocSearch is crawling the website every 24h, extracting content from every page. Then this content is indexed by Algolia and exposed to the user with a searchbox and its custom dropdown.

You might have already used DocSearch on some popular documentations like Bootstrap, Vue, jQuery, React, Jest, Gitlab, Brew, Heroku, Stripe ...
So far, we are maintaining our crawler for 1500+ docs.

- [DocSearch](https://docsearch.algolia.com/) is fast, it handles typos and highlighting.
- Search results jump directly to the matching part of the page.
- Whenever your markup changes you can [customize the configuration](https://github.com/algolia/docsearch-configs/blob/master/configs/processing.json) on DocSearch repository.
- You'll also have access to a dashboard of the most queried terms, as well as those that yields no results. We found it to be a very good way of knowing how to improve our documentation.
- DocSearch is and will remain FREE

 Changes: 
- load docsearch js and css from cdn
- configure and init docsearch
- add meta for language support
- styling
- clean previous search code

 Screenshots of the change: 
![image](https://user-images.githubusercontent.com/976175/75877110-3c785800-5e17-11ea-8532-7b0542500053.png)
