### PR TITLE
Updated "Sound effect" example.

### DIFF
--- a/src/data/examples/en/33_Sound/05_Sound_Effect.js
+++ b/src/data/examples/en/33_Sound/05_Sound_Effect.js
@@ -32,6 +32,7 @@ class Doorbell {
     }
     stroke(0);
     strokeWeight(4);
+    ellipseMode(RADIUS);
     ellipse(this.x, this.y, this.r, this.r);
   }
 }
@@ -51,7 +52,7 @@ function setup() {
   dingdong = loadSound('assets/doorbell.mp3');
 
   // Create a new doorbell
-  doorbell = new Doorbell(width / 2, height / 2, 64);
+  doorbell = new Doorbell(width / 2, height / 2, 32);
 }
 
 function draw() {

--- a/src/data/examples/es/33_Sound/05_Sound_Effect.js
+++ b/src/data/examples/es/33_Sound/05_Sound_Effect.js
@@ -33,6 +33,7 @@ class Doorbell {
     }
     stroke(0);
     strokeWeight(4);
+    ellipseMode(RADIUS);
     ellipse(this.x, this.y, this.r, this.r);
   }
 }
@@ -52,7 +53,7 @@ function setup() {
   dingdong = loadSound('assets/doorbell.mp3');
 
   // crear un nuevo timbre
-  doorbell = new Doorbell(width / 2, height / 2, 64);
+  doorbell = new Doorbell(width / 2, height / 2, 32);
 }
 
 function draw() {

--- a/src/data/examples/zh-Hans/33_Sound/05_Sound_Effect.js
+++ b/src/data/examples/zh-Hans/33_Sound/05_Sound_Effect.js
@@ -32,6 +32,7 @@ class Doorbell {
     }
     stroke(0);
     strokeWeight(4);
+    ellipseMode(RADIUS);
     ellipse(this.x, this.y, this.r, this.r);
   }
 }
@@ -51,7 +52,7 @@ function setup() {
   dingdong = loadSound('assets/doorbell.mp3');
 
   // Create a new doorbell
-  doorbell = new Doorbell(width / 2, height / 2, 64);
+  doorbell = new Doorbell(width / 2, height / 2, 32);
 }
 
 function draw() {


### PR DESCRIPTION
The `ellipseMode` when not set to `RADIUS` would consider the third parameter as `DIAMETER`.

Fixes #597 
Changes: 
The `ellipseMode` is now set to `RADIUS` so that  `contains()` return true if and only if mouse was clicked inside the circle. The third parameter to `ellipse` was changed from `64` to `32` to account for the radius of the circle.
