### PR TITLE
Fix #604 Changed canvas height in recursion example

### DIFF
--- a/src/data/examples/en/00_Structure/07_Recursion.js
+++ b/src/data/examples/en/00_Structure/07_Recursion.js
@@ -6,7 +6,7 @@
  */
 
 function setup() {
-  createCanvas(720, 400);
+  createCanvas(720, 560);
   noStroke();
   noLoop();
 }

--- a/src/data/examples/es/00_Structure/07_Recursion.js
+++ b/src/data/examples/es/00_Structure/07_Recursion.js
@@ -6,7 +6,7 @@
  */
 
 function setup() {
-  createCanvas(720, 400);
+  createCanvas(720, 560);
   noStroke();
   noLoop();
 }

--- a/src/data/examples/zh-Hans/00_Structure/07_Recursion.js
+++ b/src/data/examples/zh-Hans/00_Structure/07_Recursion.js
@@ -6,7 +6,7 @@
  */
 
 function setup() {
-  createCanvas(720, 400);
+  createCanvas(720, 560);
   noStroke();
   noLoop();
 }


### PR DESCRIPTION
Fixes #604 

 Changes: 

Changed canvas height in `en`,`es` and `zh-Hans` version examples to `560` from `400` to accommodate the complete sketch.

 Screenshots of the change: 
<!-- Add screenshots depicting the changes. -->

![Screenshot_2020-03-21 examples p5 js(1)](https://user-images.githubusercontent.com/28699912/77226884-b04d8b00-6ba1-11ea-8ad6-e9fa337b57d9.png)

