### PR TITLE
Fix #285 Change max-width parameter to 767px

### DIFF
--- a/src/data/examples/build_examples/example_template.ejs
+++ b/src/data/examples/build_examples/example_template.ejs
@@ -54,7 +54,8 @@ slug: examples/
     window.addEventListener('load', function() {
       // examples.init('{{assets}}/examples/{{language}}/<%=file%>');
       if (<%=mobileEx%>) {
-        var isMobile = window.matchMedia("only screen and (max-width: 480px)");
+        var isMobile = window.matchMedia("only screen and (max-width: 767px)");
+        // isMobile is true if viewport is less than 768 pixels wide
         document.getElementById('exampleFrame').style.display = 'none';
         if (isMobile.matches) {
           document.getElementById('notMobile-message').style.display = 'none';


### PR DESCRIPTION
Tablets are upto `768`px wide. Hence `max-width` should be less than `768`px when checking for mobile devices, since tablets are included in this category.

Fixes #285 
@lmccart 

 Changes: 
Changed `max-width` parameter to `window.matchMedia` when checking for a mobile device to `768`px from `480`px.
