### PR TITLE
feat: added links to showcase images - I610

### DIFF
--- a/src/templates/pages/showcase/index.hbs
+++ b/src/templates/pages/showcase/index.hbs
@@ -25,9 +25,10 @@ slug: showcase/
         <div>
         <h3 class="title"><a href="./featuring/roni-cantor.html">{{#i18n "project-roni"}}{{/i18n}}</a></h3>
           <p class="credit">{{#i18n "credit-roni"}}{{/i18n}}</p>
-          <img src="{{assets}}/img/showcase/roni-cantor/roni-cantor_plotter-white.jpg" 
+          <a href="./featuring/roni-cantor.html">
+            <img src="{{assets}}/img/showcase/roni-cantor/roni-cantor_plotter-white.jpg" 
             alt="A drawing of a sine wave lerp plotted on black paper using an AxiDraw V3 and a white gel pen.">
-          
+          </a>
           <p class="description">{{#i18n "description-roni"}}{{/i18n}}</p>
           <ul class="project-tags">
             <li><span class="tag">{{#i18n "project-tag-art"}}{{/i18n}}</span></li>
@@ -38,10 +39,11 @@ slug: showcase/
         <div>
         <h3 class="title"><a href="./featuring/daein-chung.html">{{#i18n "project-daein"}}{{/i18n}}</a></h3>
           <p class="credit">{{#i18n "credit-daein"}}{{/i18n}}</p>
-          <img src="{{assets}}/img/showcase/daein-chung/daein-chung_chillin.png" 
-            alt="A screenshot of a poster with red and yellow circles of letters from the word chillin against a blue tile background that changes perspective on a mobile device. 
-            At the top, there is a text input box to enter a message and download your own poster">
-          
+          <a href="./featuring/daein-chung.html">
+            <img src="{{assets}}/img/showcase/daein-chung/daein-chung_chillin.png" 
+              alt="A screenshot of a poster with red and yellow circles of letters from the word chillin against a blue tile background that changes perspective on a mobile device. 
+              At the top, there is a text input box to enter a message and download your own poster">
+          </a>
           <p class="description">{{#i18n "description-daein"}}{{/i18n}}</p>
           <ul class="project-tags">
             <li><span class="tag">{{#i18n "project-tag-design"}}{{/i18n}}</span></li>
@@ -51,9 +53,10 @@ slug: showcase/
         <div>
         <h3 class="title"><a href="./featuring/casey-louise.html">{{#i18n "project-casey-louise"}}{{/i18n}}</a></h3>
           <p class="credit">{{#i18n "credit-casey-louise"}}{{/i18n}}</p>
-          <img src="{{assets}}/img/showcase/casey-louise/casey-louise_p5js-shaders.png" 
-            alt="A screenshot of the Introduction page of the p5.js Shaders guide website">
-          
+          <a href="./featuring/casey-louise.html">
+            <img src="{{assets}}/img/showcase/casey-louise/casey-louise_p5js-shaders.png" 
+              alt="A screenshot of the Introduction page of the p5.js Shaders guide website">
+          </a>
           <p class="description">{{#i18n "description-casey-louise"}}{{/i18n}}</p>
           <ul class="project-tags">
             <li><span class="tag">{{#i18n "project-tag-documentation"}}{{/i18n}}</span></li>
@@ -66,9 +69,10 @@ slug: showcase/
         <div>
         <h3 class="title"><a href="./featuring/phuong-ngo.html">{{#i18n "project-phuong"}}{{/i18n}}</a></h3>
           <p class="credit">{{#i18n "credit-phuong"}}{{/i18n}}</p>
-          <img src="{{assets}}/img/showcase/phuong-ngo/phuong-ngo_airi-flies.png" 
-            alt="A screenshot of the instructions and scoreboard for the online game Airi Flies">
-          
+          <a href="./featuring/phuong-ngo.html">
+            <img src="{{assets}}/img/showcase/phuong-ngo/phuong-ngo_airi-flies.png" 
+              alt="A screenshot of the instructions and scoreboard for the online game Airi Flies">
+          </a>
           <p class="description">{{#i18n "description-phuong"}}{{/i18n}}</p>
           <ul class="project-tags">
             <li><span class="tag">{{#i18n "project-tag-art"}}{{/i18n}}</span></li>
@@ -80,9 +84,10 @@ slug: showcase/
         <div>
           <h3 class="title"><a href="./featuring/qianqian-ye.html">{{#i18n "project-qianqian"}}{{/i18n}}</a></h3>
           <p class="credit">{{#i18n "credit-qianqian"}}{{/i18n}}</p>
-          <img src="{{assets}}/img/showcase/qianqian-ye/qianqian-ye_qtv.png" 
-            alt="A screenshot of a Qtv video (Guest Talk #1) featuring Chinese womxn designers and artists Kaikai and Cheng Xu">
-          
+          <a href="./featuring/qianqian-ye.html">
+            <img src="{{assets}}/img/showcase/qianqian-ye/qianqian-ye_qtv.png" 
+              alt="A screenshot of a Qtv video (Guest Talk #1) featuring Chinese womxn designers and artists Kaikai and Cheng Xu">
+          </a>
           <p class="description">{{#i18n "description-qianqian"}}{{/i18n}}</p>
           <ul class="project-tags">
             <li><span class="tag">{{#i18n "project-tag-tutorial"}}{{/i18n}}</span></li>
@@ -92,9 +97,10 @@ slug: showcase/
         <div>
         <h3 class="title"><a href="./featuring/moon-xin.html">{{#i18n "project-moon-xin"}}{{/i18n}}</a></h3>
           <p class="credit">{{#i18n "credit-moon-xin"}}{{/i18n}}</p>
-          <img src="{{assets}}/img/showcase/moon-xin/moon-xin_poster-carlee.png" 
-            alt="A screenshot of student Carlee Wooddell's poster that interprets the word zigzag using letters that bounce left and right">
-          
+          <a href="./featuring/moon-xin.html">
+            <img src="{{assets}}/img/showcase/moon-xin/moon-xin_poster-carlee.png" 
+              alt="A screenshot of student Carlee Wooddell's poster that interprets the word zigzag using letters that bounce left and right">
+          </a>
           <p class="description">{{#i18n "description-moon-xin"}}{{/i18n}}</p>
           <ul class="project-tags">
             <li><span class="tag">{{#i18n "project-tag-design"}}{{/i18n}}</span></li>


### PR DESCRIPTION
Fixes #610 

 Changes: 
- Showcase images are now clickable and link to the project details.

 Screenshots of the change: 
![image-link-after](https://user-images.githubusercontent.com/41413622/77235593-46eb6d80-6bdd-11ea-9633-4000e3f9b165.gif)
