### PR TITLE
Fixed bug in translation of parameters of references in all languages

### DIFF
--- a/src/templates/pages/reference/index.hbs
+++ b/src/templates/pages/reference/index.hbs
@@ -110,9 +110,11 @@ slug: reference/
           var entry = translations[obj][name];
           $('.description-text').html('<p>'+entry.description+'</p>');
           $('.returns').html(entry.returns);
-          $('.params').find('tr').each(function(i) {
+          $('.params').find('ul').each(function(i) {
             if (i < entry.params.length) {
-              $(this).children('td').eq(1).html(entry.params[i])
+              $(this).children().each(function(j){
+                $(this).children().eq(1).children().eq(1).html(entry.params[i]);
+              })
             }
           });
         }


### PR DESCRIPTION
Fixes #594 

Changes: 
Updated the script that translated the parameters of references to the given language.

 Screenshots of the change: 

## Spanish
![p5trans6](https://user-images.githubusercontent.com/33171576/77236343-b2383e00-6be3-11ea-995c-89a1f626e618.png)
## Chinese
![p5trans7](https://user-images.githubusercontent.com/33171576/77236345-b6645b80-6be3-11ea-998c-0480bb2357cb.png)
