### PR TITLE
Fix showcase image hovers

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1241,6 +1241,22 @@ img.gallery-img {
 	content: " →";
 }
 
+#showcase-page .showcase-featured #no-arrow-link::after {
+	content: " ";
+}
+
+#showcase-page .showcase-featured #no-arrow-link:hover {
+  text-decoration: none;
+  padding: none;
+  border: none;
+}
+
+#showcase-page .showcase-featured #no-arrow-link img:hover {
+  transform: scale(1.03);
+  transition: all 0.2s ease-in-out;
+}
+
+
 .project-info {
   margin-top: 1em;
 }

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1251,12 +1251,6 @@ img.gallery-img {
   border: none;
 }
 
-#showcase-page .showcase-featured .no-arrow-link img:hover {
-  transform: scale(1.03);
-  transition: all 0.2s ease;
-}
-
-
 .project-info {
   margin-top: 1em;
 }

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1241,19 +1241,19 @@ img.gallery-img {
 	content: " →";
 }
 
-#showcase-page .showcase-featured #no-arrow-link::after {
+#showcase-page .showcase-featured .no-arrow-link::after {
 	content: " ";
 }
 
-#showcase-page .showcase-featured #no-arrow-link:hover {
+#showcase-page .showcase-featured .no-arrow-link:hover {
   text-decoration: none;
   padding: none;
   border: none;
 }
 
-#showcase-page .showcase-featured #no-arrow-link img:hover {
+#showcase-page .showcase-featured .no-arrow-link img:hover {
   transform: scale(1.03);
-  transition: all 0.2s ease-in-out;
+  transition: all 0.2s ease;
 }
 
 

--- a/src/templates/pages/showcase/index.hbs
+++ b/src/templates/pages/showcase/index.hbs
@@ -25,7 +25,7 @@ slug: showcase/
         <div>
         <h3 class="title"><a href="./featuring/roni-cantor.html">{{#i18n "project-roni"}}{{/i18n}}</a></h3>
           <p class="credit">{{#i18n "credit-roni"}}{{/i18n}}</p>
-          <a href="./featuring/roni-cantor.html" id="no-arrow-link">
+          <a href="./featuring/roni-cantor.html" class="no-arrow-link">
             <img src="{{assets}}/img/showcase/roni-cantor/roni-cantor_plotter-white.jpg" 
             alt="A drawing of a sine wave lerp plotted on black paper using an AxiDraw V3 and a white gel pen.">
           </a>
@@ -39,7 +39,7 @@ slug: showcase/
         <div>
         <h3 class="title"><a href="./featuring/daein-chung.html">{{#i18n "project-daein"}}{{/i18n}}</a></h3>
           <p class="credit">{{#i18n "credit-daein"}}{{/i18n}}</p>
-          <a href="./featuring/daein-chung.html" id="no-arrow-link">
+          <a href="./featuring/daein-chung.html" class="no-arrow-link">
             <img src="{{assets}}/img/showcase/daein-chung/daein-chung_chillin.png" 
               alt="A screenshot of a poster with red and yellow circles of letters from the word chillin against a blue tile background that changes perspective on a mobile device. 
               At the top, there is a text input box to enter a message and download your own poster">
@@ -53,7 +53,7 @@ slug: showcase/
         <div>
         <h3 class="title"><a href="./featuring/casey-louise.html">{{#i18n "project-casey-louise"}}{{/i18n}}</a></h3>
           <p class="credit">{{#i18n "credit-casey-louise"}}{{/i18n}}</p>
-          <a href="./featuring/casey-louise.html" id="no-arrow-link">
+          <a href="./featuring/casey-louise.html" class="no-arrow-link">
             <img src="{{assets}}/img/showcase/casey-louise/casey-louise_p5js-shaders.png" 
               alt="A screenshot of the Introduction page of the p5.js Shaders guide website">
           </a>
@@ -69,7 +69,7 @@ slug: showcase/
         <div>
         <h3 class="title"><a href="./featuring/phuong-ngo.html">{{#i18n "project-phuong"}}{{/i18n}}</a></h3>
           <p class="credit">{{#i18n "credit-phuong"}}{{/i18n}}</p>
-          <a href="./featuring/phuong-ngo.html" id="no-arrow-link">
+          <a href="./featuring/phuong-ngo.html" class="no-arrow-link">
             <img src="{{assets}}/img/showcase/phuong-ngo/phuong-ngo_airi-flies.png" 
               alt="A screenshot of the instructions and scoreboard for the online game Airi Flies">
           </a>
@@ -84,7 +84,7 @@ slug: showcase/
         <div>
           <h3 class="title"><a href="./featuring/qianqian-ye.html">{{#i18n "project-qianqian"}}{{/i18n}}</a></h3>
           <p class="credit">{{#i18n "credit-qianqian"}}{{/i18n}}</p>
-          <a href="./featuring/qianqian-ye.html" id="no-arrow-link">
+          <a href="./featuring/qianqian-ye.html" class="no-arrow-link">
             <img src="{{assets}}/img/showcase/qianqian-ye/qianqian-ye_qtv.png" 
               alt="A screenshot of a Qtv video (Guest Talk #1) featuring Chinese womxn designers and artists Kaikai and Cheng Xu">
           </a>
@@ -97,7 +97,7 @@ slug: showcase/
         <div>
         <h3 class="title"><a href="./featuring/moon-xin.html">{{#i18n "project-moon-xin"}}{{/i18n}}</a></h3>
           <p class="credit">{{#i18n "credit-moon-xin"}}{{/i18n}}</p>
-          <a href="./featuring/moon-xin.html" id="no-arrow-link">
+          <a href="./featuring/moon-xin.html" class="no-arrow-link">
             <img src="{{assets}}/img/showcase/moon-xin/moon-xin_poster-carlee.png" 
               alt="A screenshot of student Carlee Wooddell's poster that interprets the word zigzag using letters that bounce left and right">
           </a>

--- a/src/templates/pages/showcase/index.hbs
+++ b/src/templates/pages/showcase/index.hbs
@@ -25,7 +25,7 @@ slug: showcase/
         <div>
         <h3 class="title"><a href="./featuring/roni-cantor.html">{{#i18n "project-roni"}}{{/i18n}}</a></h3>
           <p class="credit">{{#i18n "credit-roni"}}{{/i18n}}</p>
-          <a href="./featuring/roni-cantor.html">
+          <a href="./featuring/roni-cantor.html" id="no-arrow-link">
             <img src="{{assets}}/img/showcase/roni-cantor/roni-cantor_plotter-white.jpg" 
             alt="A drawing of a sine wave lerp plotted on black paper using an AxiDraw V3 and a white gel pen.">
           </a>
@@ -39,7 +39,7 @@ slug: showcase/
         <div>
         <h3 class="title"><a href="./featuring/daein-chung.html">{{#i18n "project-daein"}}{{/i18n}}</a></h3>
           <p class="credit">{{#i18n "credit-daein"}}{{/i18n}}</p>
-          <a href="./featuring/daein-chung.html">
+          <a href="./featuring/daein-chung.html" id="no-arrow-link">
             <img src="{{assets}}/img/showcase/daein-chung/daein-chung_chillin.png" 
               alt="A screenshot of a poster with red and yellow circles of letters from the word chillin against a blue tile background that changes perspective on a mobile device. 
               At the top, there is a text input box to enter a message and download your own poster">
@@ -53,7 +53,7 @@ slug: showcase/
         <div>
         <h3 class="title"><a href="./featuring/casey-louise.html">{{#i18n "project-casey-louise"}}{{/i18n}}</a></h3>
           <p class="credit">{{#i18n "credit-casey-louise"}}{{/i18n}}</p>
-          <a href="./featuring/casey-louise.html">
+          <a href="./featuring/casey-louise.html" id="no-arrow-link">
             <img src="{{assets}}/img/showcase/casey-louise/casey-louise_p5js-shaders.png" 
               alt="A screenshot of the Introduction page of the p5.js Shaders guide website">
           </a>
@@ -69,7 +69,7 @@ slug: showcase/
         <div>
         <h3 class="title"><a href="./featuring/phuong-ngo.html">{{#i18n "project-phuong"}}{{/i18n}}</a></h3>
           <p class="credit">{{#i18n "credit-phuong"}}{{/i18n}}</p>
-          <a href="./featuring/phuong-ngo.html">
+          <a href="./featuring/phuong-ngo.html" id="no-arrow-link">
             <img src="{{assets}}/img/showcase/phuong-ngo/phuong-ngo_airi-flies.png" 
               alt="A screenshot of the instructions and scoreboard for the online game Airi Flies">
           </a>
@@ -84,7 +84,7 @@ slug: showcase/
         <div>
           <h3 class="title"><a href="./featuring/qianqian-ye.html">{{#i18n "project-qianqian"}}{{/i18n}}</a></h3>
           <p class="credit">{{#i18n "credit-qianqian"}}{{/i18n}}</p>
-          <a href="./featuring/qianqian-ye.html">
+          <a href="./featuring/qianqian-ye.html" id="no-arrow-link">
             <img src="{{assets}}/img/showcase/qianqian-ye/qianqian-ye_qtv.png" 
               alt="A screenshot of a Qtv video (Guest Talk #1) featuring Chinese womxn designers and artists Kaikai and Cheng Xu">
           </a>
@@ -97,7 +97,7 @@ slug: showcase/
         <div>
         <h3 class="title"><a href="./featuring/moon-xin.html">{{#i18n "project-moon-xin"}}{{/i18n}}</a></h3>
           <p class="credit">{{#i18n "credit-moon-xin"}}{{/i18n}}</p>
-          <a href="./featuring/moon-xin.html">
+          <a href="./featuring/moon-xin.html" id="no-arrow-link">
             <img src="{{assets}}/img/showcase/moon-xin/moon-xin_poster-carlee.png" 
               alt="A screenshot of student Carlee Wooddell's poster that interprets the word zigzag using letters that bounce left and right">
           </a>


### PR DESCRIPTION
Fixes #619 

 Changes: 
Adds a separate class on image links to disable standard hover features.


 Screenshots before the change: 
![image-link-hover-issue](https://user-images.githubusercontent.com/41413622/77457149-4b549800-6e22-11ea-8636-f3b6a73961bc.gif)

