### PR TITLE
Spanish translation of 'p5.js and wiki' paragraph translation and additional example translations

### DIFF
--- a/src/data/es.yml
+++ b/src/data/es.yml
@@ -238,7 +238,7 @@ learn:
   using-local-server-title: "Usando un servidor local"
   using-local-server: "Cómo configurar un servidor local en Mac OS X, Windows o Linux."
   p5js-wiki-title: "p5.js wiki"
-  p5js-wiki: "Additonal documentation and tutorials contributed by the community"
+  p5js-wiki: "Documentación adicional y tutoriales aportados por la comunidad."
   connecting-p5js-title: "Conectando p5.js"
   creating-libraries-title: "Crear bibliotecas"
   creating-libraries: "Creando bibliotecas adicionales para p5.js."

--- a/src/data/examples/es/09_Simulate/18_Koch.js
+++ b/src/data/examples/es/09_Simulate/18_Koch.js
@@ -1,7 +1,7 @@
 /*
- * @name Koch Curve
- * @description Renders a simple fractal, the Koch snowflake. Each recursive level is drawn in sequence.
- * By Daniel Shiffman
+ * @name Curva Koch
+ * @description Renderización de un fractal simple: el copo de nieve de Koch. Cada nivel recursivo se dibuja en secuencia.
+ * Por Daniel Shiffman.
  */
 
 let k;

--- a/src/data/examples/es/09_Simulate/19_Bubblesort.js
+++ b/src/data/examples/es/09_Simulate/19_Bubblesort.js
@@ -1,9 +1,9 @@
 /*
- * @name Bubble Sort
- * @description Sorts the randomly distributed bars 
- * according to their height in ascending order
- * while simulating the whole sorting process.
- * Took references from Coding Challenge by The Coding Train.
+ * @name Ordenamiento de Burbuja
+ * @description Ordena las barras distribuidas aleatoriamente
+ * según su altura en orden ascendente mientras simula todo el
+ * proceso de clasificación.
+ * Se usaron referencias del 'Coding Challenge' de 'The Coding Train'.
  */
 
 let values = [];
@@ -31,7 +31,7 @@ function draw() {
 }
 
 // The bubbleSort() function sorts taking 8 elements of the array
-// per frame. The algorithm behind this function is 
+// per frame. The algorithm behind this function is
 // bubble sort.
 function bubbleSort() {
   for(let k = 0;k<8;k++){
@@ -42,7 +42,7 @@ function bubbleSort() {
         values[j+1] = temp;
       }
       j++;
-      
+
       if(j>=values.length-i-1){
         j = 0;
         i++;

--- a/src/data/examples/es/09_Simulate/20_SteepingFeet.js
+++ b/src/data/examples/es/09_Simulate/20_SteepingFeet.js
@@ -1,11 +1,11 @@
 /*
- * @name Stepping Feet Illusion
- * @description Stepping feet illusion is a very famous psychological experiment
- * Both the bricks will appear to move at different speed
- * even though they are moving at the same speed.
- * Click the mouse inside Canvas to confirm that
- * they are moving at the same speed.
- * Contributed by Sagar Arora.
+ * @name Ilusión de los Pasos
+ * @description La ilusión de los pasos es un experimento
+ * psicológico muy famoso. Ambos bloques parecen moverse
+ * a velocidades diferentes, pero en realidad se mueven
+ * a la misma velocidad. Haga click con el ratón dentro
+ * del Canvas para confirmar que se mueven a la misma velocidad.
+ * Contribución de Sagar Arora.
  */
 
 // this class describes the structure
@@ -45,7 +45,7 @@ function setup() {
   createP("are moving at same speed or not").style('color','#ffffff');
 }
 
-// creating two bricks of 
+// creating two bricks of
 // colors white and black
 let brick1 = new Brick("white",100);
 let brick2 = new Brick("black",250);

--- a/src/data/examples/es/09_Simulate/20_SteepingFeet.js
+++ b/src/data/examples/es/09_Simulate/20_SteepingFeet.js
@@ -3,8 +3,8 @@
  * @description La ilusión de los pasos es un experimento
  * psicológico muy famoso. Ambos bloques parecen moverse
  * a velocidades diferentes, pero en realidad se mueven
- * a la misma velocidad. Haga click con el ratón dentro
- * del Canvas para confirmar que se mueven a la misma velocidad.
+ * a la misma velocidad. Haz click con el ratón dentro
+ * del lienzo para confirmar que se mueven a la misma velocidad.
  * Contribución de Sagar Arora.
  */
 


### PR DESCRIPTION
Fixes #625 #627 

 Changes: 
Added missing Spanish translation for 'p5.js and wiki' section in Learn and added new translated examples for the Spanish examples section.


 Screenshots of the change: 
![image](https://user-images.githubusercontent.com/33717014/77702414-60f7c800-6fb0-11ea-8222-b8c046ca8a73.png)
