### PR TITLE
Search bar tabbing priority fix

### DIFF
--- a/src/templates/pages/index.hbs
+++ b/src/templates/pages/index.hbs
@@ -11,7 +11,7 @@ slug: /
       <form id="search" method="get" action="https://www.google.com/search">
         <input type="hidden" name="as_sitesearch" value="p5js.org" >
         <input id="search_button" type="submit" aria-label="Search" class='sr-only'>
-        <input id='search_field' type="text" size="20" placeholder="Search p5js.org" name="q" >
+        <input tabindex="1" id='search_field' type="text" size="20" placeholder="Search p5js.org" name="q" >
         <label class="sr-only" for="search_field">Search p5js.org</label>
       </form>
 


### PR DESCRIPTION
Fixed tabbing through the search bar. Now it has been given the highest priority in the tab list.

Fixes #634 

 Changes: 
 Users can now reach the search bar in a single tab.