### PR TITLE
Fixing translation swapping of parameters and returns

### DIFF
--- a/src/templates/pages/reference/index.hbs
+++ b/src/templates/pages/reference/index.hbs
@@ -109,12 +109,12 @@ slug: reference/
         if (translations[obj] && translations[obj][name]) {
           var entry = translations[obj][name];
           $('.description-text').html('<p>'+entry.description+'</p>');
-          $('.returns').html($('.returns').contents()[0].innerHTML + ": " + entry.returns);
+          $('.returns').html(entry.returns);
           $('.params').find('ul').each(function(i) {
             if (i < entry.params.length) {
-              $(this).children().each(function(j){
-                $(this).children().eq(1).children().eq(1).html(entry.params[i]);
-              })
+              $(this).children('li').each(function(j){
+                $(this).children('.paramtype').html(entry.params[j]);
+              });
             }
           });
         }


### PR DESCRIPTION
Fixes #645, fixes #617, addresses #613

 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Reverted #617 as the returned types should be translated in the translation file itself. Fixed a bug in #613 and simplified its implementation so it should give the correct list of parameters now.

 Screenshots of the change: 
<!-- Add screenshots depicting the changes. -->
<img width="844" alt="Screenshot 2020-04-01 at 9 23 47 pm" src="https://user-images.githubusercontent.com/7543950/78182993-16b69100-745f-11ea-9ed5-ea6b250ca783.png">
