### PR TITLE
Add language abbreviation examples folder as a step at "Start a new translation" section

### DIFF
--- a/contributor_docs/i18n_contribution.md
+++ b/contributor_docs/i18n_contribution.md
@@ -136,7 +136,8 @@ p5.js-website/
     ```
 4. Duplicate `en.yml` - stored under `src/data/` - and name it `language_abbreviation.yml`. For example, when the Spanish version was created it was named `es.yml`. Check [How the website works](#how-the-website-works) and [File Structure](#file-structure) for further information.
 5. Duplicate `es.json` - stored under `src/data/reference/` - and name it `[language_abbreviation].json`.
-6. Add a new menu entry in [`src/templates/partials/i18n.hbs`](https://github.com/processing/p5.js-website/blob/master/src/templates/partials/i18n.hbs#L8) like so `<li><a href='#' lang='[language_abbreviation]' data-lang='[language_abbreviation]'>[language_name]</a></li>`.
+6. Duplicate `en` folder - stored under `src/data/examples` - and name it `language_abbreviation`.
+7. Add a new menu entry in [`src/templates/partials/i18n.hbs`](https://github.com/processing/p5.js-website/blob/master/src/templates/partials/i18n.hbs#L8) like so `<li><a href='#' lang='[language_abbreviation]' data-lang='[language_abbreviation]'>[language_name]</a></li>`.
 
 ## Working on existing translations
 


### PR DESCRIPTION
The language abbreviation folder at examples (src/data/examples/lang_abbr) is a required step when we start a new translation and execute `npm run watch`. I'm working on the pt-BR translation, the src/data/examples/pt-BR folder (and files) was a required step to run the project in the browser.