### PR TITLE
Simple transitions to images on donate page.

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -307,11 +307,29 @@
   margin: 1em 0;
 }
 
+#slideshow div {
+  -webkit-transition: opacity 1s linear;
+  -moz-transition: opacity 1s;
+  -ms-transition: opacity 1s;
+  -o-transition: opacity 1s;
+   transition: opacity 2s;
+}
+
 #slideshow p {
   font-size: 0.8em;
   color: #ABABAB;
   line-height: 1.2em;
   margin-top: 0.5em;
+}
+
+#below {
+  position: relative;
+  top: 625px;
+}
+
+#endb {
+  position: relative;
+  top: 700px;
 }
 
 .extra {

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -329,7 +329,7 @@
 
 #endb {
   position: relative;
-  top: 700px;
+  top: 620px;
 }
 
 .extra {

--- a/src/assets/js/slideshow.js
+++ b/src/assets/js/slideshow.js
@@ -2,12 +2,14 @@ var slideIndex = 0;
 carousel();
 
 function carousel() {
-  var x = $("#slideshow").children();
+  var x = $("#slideshow div");
   for (var i = 0; i < x.length; i++) {
-    x[i].style.display = "none"; 
+    x[i].style.height = "0";
+    x[i].style.opacity = "0";
   }
   slideIndex++;
   if (slideIndex > x.length) {slideIndex = 1} 
-  x[slideIndex-1].style.display = "block"; 
+  x[slideIndex-1].style.height = "400"; 
+  x[slideIndex-1].style.opacity = "1";
   setTimeout(carousel, 4000);
 }

--- a/src/templates/pages/download/support.hbs
+++ b/src/templates/pages/download/support.hbs
@@ -112,14 +112,15 @@ slug: download/
           <p>{{#i18n "support-31"}}{{/i18n}}</p>
         </div>
       </div>
-
-      <p><a href="https://processingfoundation.org">{{#i18n "support-32"}}{{/i18n}}</a>{{#i18n "support-33"}}{{/i18n}}</p>
-
+      
+      <div id="below">
+        <p><a href="https://processingfoundation.org">{{#i18n "support-32"}}{{/i18n}}</a>{{#i18n "support-33"}}{{/i18n}}</p>
+      </div>
 
     </main>
-
+    <div id="endb">
     {{> footer}}
-
+    </div>
   </div> <!-- end column-span -->
 
   {{> asterisk}}


### PR DESCRIPTION
 Changes: 
 Added simple transitions to the images on the donate page. I will be adding a screen reader 
 functionality to read the image descriptions depending on the user's preference in the near future. 

 Screenshots of the change: 
 
![Hnet-image (8)](https://user-images.githubusercontent.com/30899040/79071426-513eea00-7cf9-11ea-8565-a43f31c06445.gif)
