### PR TITLE
150ms responsive flicker free highlight+transition to menu elements

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1484,6 +1484,23 @@ p {
   user-select: none;
 }
 
+#menu li a{
+  -webkit-transform: translateZ(0);
+  transition: background 0.15s;
+}
+#menu li a:hover{
+  background: #ED225D;
+  color: #FFFFFF;
+  text-decoration: none;
+  padding: 0.2em;
+}
+#menu li a:focus{
+  background: #ED225D;
+  color: #FFFFFF;
+  text-decoration: none;
+  padding: 0.2em;
+}
+
 
 /* body links  */
 


### PR DESCRIPTION
 Fixes #593 

 Changes: 
 Added 150ms transition to menu elements on hover. They look slow in the GIF below due to the 
 low FPS of the GIF.  These are enabled on both focus and hover states of the element. 
 This is a functionality that would allow keyboard users to notice the menu links they are focused on 
 efficiently.
 I have removed flickering and the transitions are clean and responsive with a time duration of 
 150ms.
 I am tabbing through the items in the below GIF.
 They make look slow below due to the low FPS of the GIF. They are 150ms fast transitions.
 Screenshots of the change: 
 
![keyboard](https://user-images.githubusercontent.com/30899040/79077059-0a162080-7d1c-11ea-8fc1-eddf310a7b2d.gif)
