### PR TITLE
Keyboard accessibility - Tabbing color inversion on focus

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1490,6 +1490,18 @@ p {
   user-select: none;
 }
 
+#menu li a{
+  padding: 10px;
+}
+
+#menu li a:focus{
+  background: #ED225D;
+  color: #FFFFFF;
+  padding: 0px;
+  text-decoration: none;
+  padding: 0.2em;
+}
+
 
 /* body links  */
 


### PR DESCRIPTION
Fixes #680 

 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Color inversion while tabbing through the menu elements for clear visibility for keyboard users.
Slight padding to change the text location on focus.
As per W3C guidelines for keyboard users.
 Screenshots of the change: 
![Hnet-image (9)](https://user-images.githubusercontent.com/30899040/79106767-bdb8f800-7d90-11ea-8877-78dcd0e68153.gif)

<!-- Add screenshots depicting the changes. -->