### PR TITLE
Changes to the search bar

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -573,7 +573,7 @@ form {
 
 #search input[type="text"],
 #search input[type="search"] {
-  border: 1px solid rgba(200, 200, 200, .5);
+  border: 3px solid #ED225D;
   font-family: "Montserrat", sans-serif;
   font-size: 2.25em;
   width: 9.75em;
@@ -581,13 +581,13 @@ form {
 
 #search ::-webkit-input-placeholder,
 #search .twitter-typeahead .tt-hint {
-  color: #ccc;
+  color: #a3a199;
 }
 
 :-moz-placeholder,
  ::-moz-placeholder,
  :-ms-input-placeholder {
-  color: #ccc;
+  color: #a3a199;
 }
 
 #search input[type="text"]:focus {

--- a/src/templates/pages/index.hbs
+++ b/src/templates/pages/index.hbs
@@ -11,7 +11,7 @@ slug: /
       <form id="search" method="get" action="https://www.google.com/search">
         <input type="hidden" name="as_sitesearch" value="p5js.org" >
         <input id="search_button" type="submit" aria-label="Search" class='sr-only'>
-        <input tabindex="1" id='search_field' type="text" size="20" placeholder="Search p5js.org" name="q" >
+        <input tabindex="1" id='search_field' type="text" size="20" placeholder="&#x1f50d; Search p5js.org" name="q" >
         <label class="sr-only" for="search_field">Search p5js.org</label>
       </form>
 


### PR DESCRIPTION
Fixes #685 
Search bar is not recognizable for some students when they are new to the website according to
Mr. Raymond G McCord who has responded to my poll in the p5 forum on discourse. He said slight design changes would be helpful for the students.
 Changes: 
 Addition of a magnifying glass to the placeholder according to W3C standards for accessibility. 
 A 3px border for the input element.
 A darker font color for the the placeholder text.
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

 Screenshots of the change: 
![search](https://user-images.githubusercontent.com/30899040/79112551-6f115b00-7d9c-11ea-98fd-e45779751a30.PNG)
<!-- Add screenshots depicting the changes. -->