### PR TITLE
Quick fix for cache busting problem

### DIFF
--- a/src/templates/layouts/default.hbs
+++ b/src/templates/layouts/default.hbs
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="description" content="p5.js a JS client-side library for creating graphic and interactive experiences, based on the core principles of Processing.">
     <title tabindex="1">{{title}} | p5.js</title>
-    <link rel="stylesheet" href="/{{assets}}/css/all.css?v=1.0.0">
+    <link rel="stylesheet" href="/{{assets}}/css/all.css?v=1.0.1">
     <link href="https://fonts.googleapis.com/css?family=Montserrat&display=swap" rel="stylesheet">
 
     <link rel="shortcut icon" href="/{{assets}}/img/favicon.ico">

--- a/src/templates/layouts/default.hbs
+++ b/src/templates/layouts/default.hbs
@@ -17,7 +17,7 @@
     <script src="/{{assets}}/js/vendor/ace-nc/ace.js"></script>
     <script src="/{{assets}}/js/vendor/ace-nc/mode-javascript.js"></script>
     <script src="/{{assets}}/js/vendor/prism.js"></script>
-    <script src="/{{assets}}/js/init.js?v=1.0.0"></script>
+    <script src="/{{assets}}/js/init.js?v=1.0.1"></script>
 
     {{#ifLowerCaseEquals language "zh-Hans"}}
     <script src="/{{assets}}/js/vendor/pangu.min.js"></script>


### PR DESCRIPTION
Fixes #670

Changes: 
Added a quick fix for the cache busting problem. This is not a final fix, just a short term solution to make sure that the browsers cache the latest version of the CSS file of the website. I will be working on a more sophisticated solution so that the version string updates automatically during the build if there are any modifications to the CSS file.