### PR TITLE
[i18n] RTL support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -82,7 +82,8 @@ module.exports = function(grunt) {
       pages: {
         options: {
           rtl: function() {
-            var rtlLangs = ['ar', 'fa', 'he', 'ur'];
+            // Add needed right-to-left language codes in the array below
+            var rtlLangs = [];
             return rtlLangs.includes(this.language);
           },
           expand: true,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -81,6 +81,10 @@ module.exports = function(grunt) {
     assemble: {
       pages: {
         options: {
+          rtl: function() {
+            var rtlLangs = ['ar', 'fa', 'he', 'ur'];
+            return rtlLangs.includes(this.language);
+          },
           expand: true,
           flatten: true,
           helpers: ['<%= config.src %>/assets/js/translation.js'],

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1998,7 +1998,7 @@ footer {
     min-height: 100%;
     background-color: rgba(51, 51, 51, 0.0);
   }
-  #home-page {
+  .two-columns {
     display: flex;
     flex-wrap: row;
   }

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1168,7 +1168,6 @@ img.gallery-img {
 #showcase-page .showcase-intro h1 {
   font: italic 900 14.5vw "Montserrat", sans-serif;
   color: #ED225D;
-  text-align: left;
   text-transform: uppercase;
 }
 
@@ -2019,7 +2018,7 @@ footer {
   #i18n-btn {
     position: absolute;
     top: 2.5em; /* temp promo, 4.0em */
-    right: 1em;
+    margin: 0 1em;
   }
   #i18n-btn a {
     font-family: "Montserrat", sans-serif;
@@ -2167,7 +2166,6 @@ footer {
   .column-span {
     margin: 0 1em 0 1em;
     padding: 0;
-    float: left;
   }
   #menu.top_menu,
   #menu {
@@ -2470,5 +2468,23 @@ iframe {
     margin: 0;
     margin-left: 0.5em;
     display: inline;
+  }
+}
+
+/* ======= Right-to-left modifications ======== */
+
+html.rtl #lockup {
+  left: auto;
+  right: 1.25em;
+}
+
+html.rtl #home-page #asterisk-design-element {
+  right: auto;
+  left: 20%;
+}
+
+@media screen and (max-width: 719px) {
+  html.rtl .sidebar-menu-icon {
+    float: left
   }
 }

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -619,8 +619,9 @@ form {
   color: #666;
 }
 
-#search {
-  float: right;
+.hello {
+  display: flex;
+  justify-content: space-between;
 }
 
 #search .twitter-typeahead .tt-dropdown-menu {

--- a/src/data/examples/build_examples/all_examples_template.ejs
+++ b/src/data/examples/build_examples/all_examples_template.ejs
@@ -3,11 +3,9 @@ title: examples
 slug: examples/
 ---
 
-<div id="examples-page">
+<div class="column-span">
 
-  {{> sidebar}}
-
-  <div class="column-span">
+  <div id="examples-page">
 
     <main id="content" >
       <h1>{{#i18n "Examples"}}{{/i18n}}</h1>

--- a/src/data/examples/build_examples/example_template.ejs
+++ b/src/data/examples/build_examples/example_template.ejs
@@ -3,11 +3,9 @@ title: examples
 slug: examples/
 ---
 
-<div id="examples-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+  
+  <div id="examples-page">
 
     <main id="content" >
 

--- a/src/data/learn/learn.ejs
+++ b/src/data/learn/learn.ejs
@@ -3,11 +3,9 @@ title: learn
 slug: learn/
 ---
 
-<div id="learn-page">
+<div class="column-span">
 
-  {{> sidebar}}
-
-  <div class="column-span">
+  <div id="learn-page">
 
     <main id="content">
       <h1>{{#i18n "learn-title"}}{{/i18n}}</h1>

--- a/src/data/libraries/libraries.ejs
+++ b/src/data/libraries/libraries.ejs
@@ -3,11 +3,9 @@ title: libraries
 slug: libraries/
 ---
 
-<div id="libraries-page">
+<div class="column-span">
 
-  {{> sidebar}}
-
-  <div class="column-span">
+  <div id="libraries-page">
 
     <main id="content">
       <h1>{{#i18n "Libraries"}}{{/i18n}}</h1>

--- a/src/templates/layouts/default.hbs
+++ b/src/templates/layouts/default.hbs
@@ -45,8 +45,10 @@
         <p class='tagline'>{{#i18n "tagline6"}}{{/i18n}}</p>
       </header>
       <!-- close logo -->
-
-      {{> body }}
+      <div class="two-columns">
+        {{> sidebar}}
+        {{> body }}
+      </div>
 
     </div> <!-- close class='container'-->
 

--- a/src/templates/layouts/default.hbs
+++ b/src/templates/layouts/default.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="no-js" lang="{{language}}">
+<html class="no-js {{#if rtl}}rtl{{/if}}" lang="{{language}}" {{#if rtl}}dir="rtl"{{/if}}>
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/templates/pages/books/index.hbs
+++ b/src/templates/pages/books/index.hbs
@@ -3,11 +3,8 @@ title: books
 slug: books/
 ---
 
-<div id="books-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="books-page">
 
     <main id="content" >
       <h1>{{#i18n "books-title"}}{{/i18n}}</h1>

--- a/src/templates/pages/community/contributors-conference-2015.hbs
+++ b/src/templates/pages/community/contributors-conference-2015.hbs
@@ -3,11 +3,8 @@ title: community
 slug: community/
 ---
 
-<div id="community-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="community-page">
 
     <main id="content" >
       <h1>{{#i18n "2015contributors-conference-title"}}{{/i18n}}</h1>

--- a/src/templates/pages/community/contributors-conference-2019.hbs
+++ b/src/templates/pages/community/contributors-conference-2019.hbs
@@ -3,11 +3,8 @@ title: community
 slug: community/
 ---
 
-<div id="community-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="community-page">
 
     <main id="content" >
       <h1>{{#i18n "2019contributors-conference-title"}}{{/i18n}}</h1>

--- a/src/templates/pages/community/index.hbs
+++ b/src/templates/pages/community/index.hbs
@@ -3,11 +3,8 @@ title: community
 slug: community/
 ---
 
-<div id="community-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="community-page">
     <main id="content">
       <h1>{{#i18n "community-title"}}{{/i18n}}</h1>
       <div class="community-statement">

--- a/src/templates/pages/copyright.hbs
+++ b/src/templates/pages/copyright.hbs
@@ -3,11 +3,8 @@ title: copyright
 slug: /
 ---
 
-<div id="learn-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="learn-page">
 
     <main id="content" >
       <h1>{{#i18n "copyright-title"}}{{/i18n}}</h1>

--- a/src/templates/pages/download/index.hbs
+++ b/src/templates/pages/download/index.hbs
@@ -3,11 +3,8 @@ title: download
 slug: download/
 ---
 
-<div id="download-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="download-page">
 
     <main id="content" >
 

--- a/src/templates/pages/download/support.hbs
+++ b/src/templates/pages/download/support.hbs
@@ -3,11 +3,8 @@ title: download
 slug: download/
 ---
 
-<div id="download-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="download-page">
 
     <main id="content" >
 

--- a/src/templates/pages/get-started/index.hbs
+++ b/src/templates/pages/get-started/index.hbs
@@ -3,11 +3,8 @@ title: get started
 slug: get-started/
 ---
 
-<div id="get-started-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="get-started-page">
 
     <main id="content" >
 

--- a/src/templates/pages/index.hbs
+++ b/src/templates/pages/index.hbs
@@ -7,15 +7,15 @@ slug: /
 
   <div class="column-span">
     <main id="home">
-
-      <form id="search" method="get" action="https://www.google.com/search">
-        <input type="hidden" name="as_sitesearch" value="p5js.org" >
-        <input id="search_button" type="submit" aria-label="Search" class='sr-only'>
-        <input tabindex="1" id='search_field' type="text" size="20" placeholder="Search p5js.org" name="q" >
-        <label class="sr-only" for="search_field">Search p5js.org</label>
-      </form>
-
-      <h1>{{#i18n "p1xh1"}}{{/i18n}}</h1>
+      <div class="hello">
+        <h1>{{#i18n "p1xh1"}}{{/i18n}}</h1>
+        <form id="search" method="get" action="https://www.google.com/search">
+          <input type="hidden" name="as_sitesearch" value="p5js.org">
+          <input id="search_button" type="submit" aria-label="Search" class='sr-only'>
+          <input tabindex="1" id='search_field' type="text" size="20" placeholder="Search p5js.org" name="q">
+          <label class="sr-only" for="search_field">Search p5js.org</label>
+        </form>
+      </div>
       <p style="margin-top:1em">{{#i18n "p1x1"}}{{/i18n}}</p>
       <p>{{#i18n "p1x2"}}{{/i18n}}</p>
       <span class='button_box'><a href="https://editor.p5js.org">{{#i18n "start-creating"}}{{/i18n}}</a></span>

--- a/src/templates/pages/index.hbs
+++ b/src/templates/pages/index.hbs
@@ -2,10 +2,8 @@
 title: home
 slug: /
 ---
-<div id="home-page">
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="home-page">
     <main id="home">
       <div class="hello">
         <h1>{{#i18n "p1xh1"}}{{/i18n}}</h1>

--- a/src/templates/pages/learn/color.hbs
+++ b/src/templates/pages/learn/color.hbs
@@ -3,11 +3,8 @@ title: learn
 slug: learn/
 ---
 
-<div id="learn-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="learn-page">
 
     <main >
 

--- a/src/templates/pages/learn/coordinate-system-and-shapes.hbs
+++ b/src/templates/pages/learn/coordinate-system-and-shapes.hbs
@@ -3,11 +3,8 @@ title: learn
 slug: learn/
 ---
 
-<div id="learn-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="learn-page">
 
     <main >
       <div class="attribution">

--- a/src/templates/pages/learn/curves.hbs
+++ b/src/templates/pages/learn/curves.hbs
@@ -3,11 +3,8 @@ title: learn
 slug: learn/
 ---
 
-<div id="learn-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="learn-page">
 
     <main >
 

--- a/src/templates/pages/learn/debugging.hbs
+++ b/src/templates/pages/learn/debugging.hbs
@@ -3,11 +3,8 @@ title: learn
 slug: learn/
 ---
 
-<div id="learn-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="learn-page">
 
     <main >
 

--- a/src/templates/pages/learn/interactivity.hbs
+++ b/src/templates/pages/learn/interactivity.hbs
@@ -3,11 +3,8 @@ title: learn
 slug: learn/
 ---
 
-<div id="learn-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="learn-page">
 
     <main >
       <div class="attribution">

--- a/src/templates/pages/learn/p5-screen-reader.hbs
+++ b/src/templates/pages/learn/p5-screen-reader.hbs
@@ -3,11 +3,8 @@ title: learn
 slug: learn/
 ---
 
-<div id="learn-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="learn-page">
 
     <main >
 

--- a/src/templates/pages/learn/program-flow.hbs
+++ b/src/templates/pages/learn/program-flow.hbs
@@ -3,11 +3,8 @@ title: learn
 slug: learn/
 ---
 
-<div id="learn-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="learn-page">
 
     <main >
       <div class="attribution">

--- a/src/templates/pages/learn/tdd.hbs
+++ b/src/templates/pages/learn/tdd.hbs
@@ -3,11 +3,8 @@ title: learn
 slug: learn/
 ---
 
-<div id="learn-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="learn-page">
 
     <main >
 

--- a/src/templates/pages/learn/test-tutorial.hbs
+++ b/src/templates/pages/learn/test-tutorial.hbs
@@ -3,11 +3,8 @@ title: learn
 slug: learn/
 ---
 
-<div id="learn-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="learn-page">
 
     <main >
 

--- a/src/templates/pages/learn/transformations.hbs
+++ b/src/templates/pages/learn/transformations.hbs
@@ -3,11 +3,8 @@ title: learn
 slug: learn/
 ---
 
-<div id="learn-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="learn-page">
 
     <main >
 

--- a/src/templates/pages/learn/trigonometry.hbs
+++ b/src/templates/pages/learn/trigonometry.hbs
@@ -3,11 +3,8 @@ title: learn
 slug: learn/
 ---
 
-<div id="learn-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="learn-page">
 
     <main >
       <h2>Trigonometry Primer</h2>

--- a/src/templates/pages/learn/tutorial-guide.hbs
+++ b/src/templates/pages/learn/tutorial-guide.hbs
@@ -3,11 +3,8 @@ title: learn
 slug: learn/
 ---
 
-<div id="learn-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="learn-page">
 
     <main >
 

--- a/src/templates/pages/reference/index.hbs
+++ b/src/templates/pages/reference/index.hbs
@@ -3,11 +3,8 @@ title: reference
 slug: reference/
 ---
 
-<div id="reference-page">
-
-  {{> sidebar}}
-
-  <div class="column-span">
+<div class="column-span">
+	<div id="reference-page">
 
     <main id="content" >
       <h1>Reference</h1>

--- a/src/templates/pages/showcase/featuring/casey-louise.hbs
+++ b/src/templates/pages/showcase/featuring/casey-louise.hbs
@@ -3,11 +3,8 @@ title: showcase
 slug: showcase/featuring/
 ---
 
-<div id="showcase-page">
-
-  {{> sidebar}}
-
-  <main id="content" class="column-span project-page">
+<div class="column-span">
+	 <div id="content" class="column-span project-page">
     <h1>{{#i18n "project-casey-louise"}}{{/i18n}}</h1>
 
     <section class="project-info">
@@ -71,7 +68,7 @@ slug: showcase/featuring/
 
     {{> footer}}
 
-  </main>
+  </div>
 
   {{> asterisk}}
 

--- a/src/templates/pages/showcase/featuring/daein-chung.hbs
+++ b/src/templates/pages/showcase/featuring/daein-chung.hbs
@@ -3,11 +3,8 @@ title: showcase
 slug: showcase/featuring/
 ---
 
-<div id="showcase-page">
-
-  {{> sidebar}}
-
-  <main id="content" class="column-span project-page">
+<div class="column-span">
+	 <div id="content" class="column-span project-page">
     <h1>{{#i18n "project-daein"}}{{/i18n}}</h1>
 
     <section class="project-info">
@@ -66,7 +63,7 @@ slug: showcase/featuring/
 
     {{> footer}}
 
-  </main>
+  </div>
 
   {{> asterisk}}
 

--- a/src/templates/pages/showcase/featuring/moon-xin.hbs
+++ b/src/templates/pages/showcase/featuring/moon-xin.hbs
@@ -3,11 +3,8 @@ title: showcase
 slug: showcase/featuring/
 ---
 
-<div id="showcase-page">
-
-  {{> sidebar}}
-
-  <main id="content" class="column-span project-page">
+<div class="column-span">
+	 <div id="content" class="column-span project-page">
     <h1>{{#i18n "project-moon-xin"}}{{/i18n}}</h1>
 
     <section class="project-info">
@@ -68,7 +65,7 @@ slug: showcase/featuring/
 
     {{> footer}}
 
-  </main>
+  </div>
 
   {{> asterisk}}
 

--- a/src/templates/pages/showcase/featuring/phuong-ngo.hbs
+++ b/src/templates/pages/showcase/featuring/phuong-ngo.hbs
@@ -3,11 +3,8 @@ title: showcase
 slug: showcase/featuring/
 ---
 
-<div id="showcase-page">
-
-  {{> sidebar}}
-
-  <main id="content" class="column-span project-page">
+<div class="column-span">
+	 <div id="content" class="column-span project-page">
     <h1>{{#i18n "project-phuong"}}{{/i18n}}</h1>
 
     <section class="project-info">
@@ -68,7 +65,7 @@ slug: showcase/featuring/
 
     {{> footer}}
 
-  </main>
+  </div>
 
   {{> asterisk}}
 

--- a/src/templates/pages/showcase/featuring/qianqian-ye.hbs
+++ b/src/templates/pages/showcase/featuring/qianqian-ye.hbs
@@ -3,11 +3,8 @@ title: showcase
 slug: showcase/featuring/
 ---
 
-<div id="showcase-page">
-
-  {{> sidebar}}
-
-  <main id="content" class="column-span project-page">
+<div class="column-span">
+	 <div id="content" class="column-span project-page">
     <h1>{{#i18n "project-qianqian"}}{{/i18n}}</h1>
 
     <section class="project-info">
@@ -71,7 +68,7 @@ slug: showcase/featuring/
 
     {{> footer}}
 
-  </main>
+  </div>
 
   {{> asterisk}}
 

--- a/src/templates/pages/showcase/featuring/roni-cantor.hbs
+++ b/src/templates/pages/showcase/featuring/roni-cantor.hbs
@@ -3,11 +3,8 @@ title: showcase
 slug: showcase/featuring/
 ---
 
-<div id="showcase-page">
-
-  {{> sidebar}}
-
-  <main id="content" class="column-span project-page">
+<div class="column-span">
+	 <div id="content" class="column-span project-page">
     <h1>{{#i18n "project-roni"}}{{/i18n}}</h1>
     
     <section class="project-info">
@@ -64,7 +61,7 @@ slug: showcase/featuring/
 
     {{> footer}}
 
-  </main>
+  </div>
 
   {{> asterisk}}
 

--- a/src/templates/pages/showcase/index.hbs
+++ b/src/templates/pages/showcase/index.hbs
@@ -3,11 +3,8 @@ title: showcase
 slug: showcase/
 ---
 
-<div id="showcase-page">
-
-  {{> sidebar}}
-
-  <main  id="content" class="column-span">
+<div id="content" class="column-span">
+  <div id="showcase-page">
     <section class="showcase-intro">
       <h1>{{#i18n "showcase-title"}}{{/i18n}}</h1>
       
@@ -112,7 +109,7 @@ slug: showcase/
 
     {{> footer}}
 
-  </main>
+  </div>
 
   {{> asterisk}}
 


### PR DESCRIPTION
Fixes: Support for Right-to-left languages (Persian, Arabic, Hebrew, Urdu etc.)

 Changes (in 4 commits so review by commit is easier): 
* Adds `rtl` support: https://github.com/processing/p5.js-website/commit/b65a3738900ae9e3c62af84f27e61baa7768fb60 ([Mirrors](https://www.w3.org/International/questions/qa-html-dir) the page for right to left languages)
  * Adds `rtl` parameter to `Gruntfile`
  * Based on `rtl` adds [`dir='rtl'`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir) to `<html>` tag
  * Adds `.rtl` class to `<html>` tag (Not ideal but better than restructuring the entire page)
* Slightly restructures homepage 'Hello' and search bar to avoid `float: right` as it [breaks rtl](https://www.w3.org/International/geo/html-tech/tech-bidi.html#ri20030728.093644822): https://github.com/processing/p5.js-website/commit/73600727245956c83ebab251e650009c14fabcc1
* Some css overrides: https://github.com/processing/p5.js-website/commit/23d0c46bb6cae8ec5f8acf7d01e440025e8eac8a
* Moved `sidebar` to layout https://github.com/processing/p5.js-website/commit/6da4690b462c711b4c1448c5177521f5a57b752f
  The sidebar on the homepage was inside a `flex` container and it was working fine but on the other pages it was not. I had to add `flex` to the top container on every page but instead of that took the opportunity and moved the `{{> sidebar }}` to the layout and added `flex` to the container in the layout to make the templates dryer.
  The diff looks large but the change was mechanical running a regex like:
 ```regex
<div id="([a-z\-]+)">[\n\s]+\{\{> sidebar\}\}[\n\s]+<div class="column-span">
```
## Screenshots

![p5-rtl-desktop](https://user-images.githubusercontent.com/687513/79191691-cc34fd00-7dec-11ea-80ea-0ab3f12f44b8.gif)


<details>
  <summary>more screenshots</summary>
   
### Mobile

![p5-rtl-mobile](https://user-images.githubusercontent.com/687513/79191724-e078fa00-7dec-11ea-83ac-7f592914bbae.gif)

<img width="414" alt="Screen Shot 2020-04-14 at 12 23 36 AM" src="https://user-images.githubusercontent.com/687513/79191761-f5558d80-7dec-11ea-9cf5-8c29bfb52b77.png">

<img width="411" alt="Screen Shot 2020-04-14 at 12 23 45 AM" src="https://user-images.githubusercontent.com/687513/79191778-fd153200-7dec-11ea-95f0-714c1bf76f63.png">




</details>

**Note:**
I am also working on Persian translation but decided to do 2 separate PRs to make the review easier for you. So this PR does **not** include `fa.yml` etc and the screenshots above with Persian text in them are just for demonstration. This PR should not cause any change to the website.

**Testing:** I tried to check all the pages on different screen sizes and browsers but I might have missed a page since I don't know my way around the website very well.