### PR TITLE
fixed the ordered list font size on p5-screen-reader page

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1702,6 +1702,10 @@ ul {
   list-style: none;
 }
 
+ol {
+  font-size: 1.2em;
+}
+
 li {
   margin: 0;
   padding: 0;
@@ -1713,6 +1717,10 @@ ul.list_view {
   list-style: disc;
   list-style-position: outside;
   font-size: 1.2em;
+}
+
+ol ul.list_view {
+  font-size: 1em;
 }
 
 ul.inside {


### PR DESCRIPTION
Fixes #691 

 **Before Changes:** 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

![p5listerror](https://user-images.githubusercontent.com/54268438/79194920-07661900-7e4b-11ea-8719-ccbddbf835f5.gif)




**After Changes:**
<!-- Add screenshots depicting the changes. -->

![p5listsizesolve](https://user-images.githubusercontent.com/54268438/79194681-99215680-7e4a-11ea-8e2d-96d892624adb.JPG)
