### PR TITLE
Search bar design changes for accessibility

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -581,7 +581,7 @@ form {
 
 #search input[type="text"],
 #search input[type="search"] {
-  border: 3px solid #ED225D;
+  border: 2px solid rgb(128,128,128);
   font-family: "Montserrat", sans-serif;
   font-size: 2.25em;
   width: 9.75em;
@@ -599,13 +599,13 @@ form {
 
 #search ::-webkit-input-placeholder,
 #search .twitter-typeahead .tt-hint {
-  color: #a3a199;
+  color: rgb(180,180,180);
 }
 
 :-moz-placeholder,
  ::-moz-placeholder,
  :-ms-input-placeholder {
-  color: #a3a199;
+  color: rgb(180,180,180);
 }
 
 #search input[type="text"]:focus {

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -581,7 +581,7 @@ form {
 
 #search input[type="text"],
 #search input[type="search"] {
-  border: 1px solid rgba(200, 200, 200, .5);
+  border: 3px solid #ED225D;
   font-family: "Montserrat", sans-serif;
   font-size: 2.25em;
   width: 9.75em;
@@ -599,13 +599,13 @@ form {
 
 #search ::-webkit-input-placeholder,
 #search .twitter-typeahead .tt-hint {
-  color: #ccc;
+  color: #a3a199;
 }
 
 :-moz-placeholder,
  ::-moz-placeholder,
  :-ms-input-placeholder {
-  color: #ccc;
+  color: #a3a199;
 }
 
 #search input[type="text"]:focus {

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -590,11 +590,15 @@ form {
 #search::after {
   content: "\26B2";
   font-size: 50px;
-  position: absolute; left: 830px; top: 58px;
+  position: absolute; left: 835px; top: 56px;
   -webkit-transform: rotate(45deg); 
   -moz-transform: rotate(45deg); 
   -o-transform: rotate(45deg);
   transform: rotate(45deg);
+}
+
+#search_reference_field {
+  padding: 0px;
 }
 
 #search ::-webkit-input-placeholder,

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -587,6 +587,16 @@ form {
   width: 9.75em;
 }
 
+#search::after {
+  content: "\26B2";
+  font-size: 50px;
+  position: absolute; left: 830px; top: 58px;
+  -webkit-transform: rotate(45deg); 
+  -moz-transform: rotate(45deg); 
+  -o-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
 #search ::-webkit-input-placeholder,
 #search .twitter-typeahead .tt-hint {
   color: #ccc;


### PR DESCRIPTION
Fixes #685 

 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Search bar is not recognizable for some students when they are new to the website according to
Mr. Raymond G McCord who has responded to my poll in the p5 forum on discourse. He said slight design changes would be helpful for the students.
Changes:
Addition of a magnifying glass to the search bar, according to W3C standards for accessibility.
A 2px border for the input element.
A darker shade of gray for the the placeholder text.

As per suggestions from @limzykenneth and @lmccart , the appearance and the position of the magnifying glass and the border have been changed.

 Screenshots of the change: 
<!-- Add screenshots depicting the changes. -->
![newsearch](https://user-images.githubusercontent.com/30899040/79427669-ad985700-7fe2-11ea-8b73-31637362c1c4.PNG)