### PR TITLE
Spanish translation

### DIFF
--- a/src/data/examples/es/09_Simulate/11_SmokeParticleSystem.js
+++ b/src/data/examples/es/09_Simulate/11_SmokeParticleSystem.js
@@ -1,6 +1,6 @@
 /*
  * @name Partículas de humo
- * @description un puerto del ejemplo de sistema de partículas de humo de Dan Shiffman, originalmente para Processing. Crea partículas de humo :p
+ * @description Un puerto del ejemplo de sistema de partículas de humo de Dan Shiffman, originalmente para Processing. Crea partículas de humo :p
  */
 
 // textura de la partícula

--- a/src/data/examples/es/09_Simulate/14_SnowflakeParticleSystem.js
+++ b/src/data/examples/es/09_Simulate/14_SnowflakeParticleSystem.js
@@ -1,8 +1,8 @@
 /*
- * @name Snowflakes
- * @description Particle system simulating the motion of falling snowflakes.
- * Uses an array of objects to hold the snowflake particles.
- * Contributed by Aatish Bhatia.
+ * @name Copos de Nieve
+ * @description Sistema de partículas que simula el movimiento de copos de nieve cayendo.
+ * Utiliza un arreglo de objetos para almacenar las particulas de copos de nieve.
+ * Contribución de Aatish Bhatia.
  */
 
 let snowflakes = []; // array to hold snowflake objects

--- a/src/data/examples/es/09_Simulate/15_penrose_tiles.js
+++ b/src/data/examples/es/09_Simulate/15_penrose_tiles.js
@@ -1,7 +1,7 @@
 /*
- * @name Penrose Tiles
+ * @name Baldosas de Penrose
  * @frame 710,400
- * @description This is a port by David Blitz of the "Penrose Tile" example from processing.org/examples
+ * @description Este es un puerto de David Blitz del ejemplo "Baldosa de Penrose" de processing.org/examples
  */
 
 let ds;
@@ -121,5 +121,3 @@ PenroseLSystem.prototype.render = function () {
     }
   }
 }
-
-

--- a/src/data/examples/es/09_Simulate/16_Recursive_Tree.js
+++ b/src/data/examples/es/09_Simulate/16_Recursive_Tree.js
@@ -1,9 +1,9 @@
 /*
- * @name Recursive Tree
- * @description Renders a simple tree-like structure via recursion.
- * The branching angle is calculated as a function of the horizontal mouse
- * location. Move the mouse left and right to change the angle.
- * Based on Daniel Shiffman's <a href="https://processing.org/examples/tree.html">Recursive Tree Example</a> for Processing.
+ * @name Árbol Recursivo
+ * @description Representa una estructura simple en forma de árbol a través de la recursión.
+ * El ángulo de ramificación se calcula en función de la posición horizontal del ratón.
+ * Mueve el ratón hacia la izquierda y la derecha para cambiar el ángulo.
+ * Basado en el <a href="https://processing.org/examples/tree.html">Ejemplo de Árbol Recursivo</a> de Daniel Shiffman para Processing.
  */
 let theta;
 

--- a/src/data/examples/es/09_Simulate/21_Particle.js
+++ b/src/data/examples/es/09_Simulate/21_Particle.js
@@ -1,9 +1,9 @@
 /*
- * @name Particles
- * @description There is a light-weight JavaScript library named
- * particle.js which creates a very pleasing particle system.
- * This is an attempt to recreate that particle system using p5.js.
- * Inspired by Particle.js, contributed by Sagar Arora.
+ * @name Partículas
+ * @description Hay una biblioteca ligera de JavaScript llamada particle.js
+ * que crea un sistema de partículas muy agradable.
+ * Este es un intento de recrear ese sistema de partículas usando p5.js.
+ * Inspirado en Particle.js, contribuido por Sagar Arora. 
  */
 
 


### PR DESCRIPTION
Fixes #705 

 Changes: 
Spanish translations provided for examples in Simulate section

- Penrose Tiles
- Particles
- Snowflakes
- Recursive Tree

Correction for SmokeParticles
@montoyamoraga 

Note: I have used the word "arreglo" for array (in Snowflakes example) as this is the most common translation known to me, but if an alternative translation is preferred please let me know. Thanks