### PR TITLE
Fixed restricted focus after tabbing through a page once

### DIFF
--- a/src/templates/pages/index.hbs
+++ b/src/templates/pages/index.hbs
@@ -50,6 +50,6 @@ slug: /
 
   <p class="clearfix">&nbsp;</p>
 
-  <object type="image/svg+xml" data="{{assets}}/img/thick-asterisk-alone.svg" id="asterisk-design-element" aria-hidden="true">*</object>
+  <object tabindex=-1 type="image/svg+xml" data="{{assets}}/img/thick-asterisk-alone.svg" id="asterisk-design-element" aria-hidden="true">*</object>
   <!-- <iframe tabindex='-1' id='home-sketch-frame' src='{{assets}}/p5_featured/Grace_Obergfell/'></iframe> -->
 </div> <!-- end home-page -->


### PR DESCRIPTION
Fixes #653 

 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
I performed a check on the active active element while tabbing through the page and found that the focus was getting stuck on the asterisk logo object and restricting it to go to the top of the browser window. After a discussion with @limzykenneth , made that object unreachable via sequential keyboard navigation to fix the issue.