### PR TITLE
Removed unnecessary particles.slice() in Simulate Particles Example

### DIFF
--- a/src/data/examples/en/09_Simulate/21_Particle.js
+++ b/src/data/examples/en/09_Simulate/21_Particle.js
@@ -38,14 +38,15 @@ class Particle {
 
 // this function creates the connections(lines)
 // between particles which are less than a certain distance apart
-  joinParticles(paraticles) {
-    particles.forEach(element =>{
+  joinParticles(idx) {
+    for (let i = idx; i < particles.length; i++) {
+      let element = particles[i];
       let dis = dist(this.x,this.y,element.x,element.y);
       if(dis<85) {
-        stroke('rgba(255,255,255,0.04)');
+        stroke('rgba(255,255,255,0.08)');
         line(this.x,this.y,element.x,element.y);
       }
-    });
+    }
   }
 }
 
@@ -64,6 +65,6 @@ function draw() {
   for(let i = 0;i<particles.length;i++) {
     particles[i].createParticle();
     particles[i].moveParticle();
-    particles[i].joinParticles(particles.slice(i));
+    particles[i].joinParticles(i);
   }
 }


### PR DESCRIPTION
Hello! This change removes the `particles.slice()` call and replaces it with the index instead. And `joinParticles()` now uses a regular for loop that starts at the index. I also changed the alpha since it now only draws them once instead of twice.
I noticed the array created with `slice()` is not even used because of a typo (`paraticles` instead of `particles`), so it fixes that too.
Thanks and have a nice day!