### PR TITLE
Remove parenthesis from example URL

### DIFF
--- a/src/data/examples/build_examples/build.js
+++ b/src/data/examples/build_examples/build.js
@@ -112,6 +112,7 @@ function buildFolder(lang, inputRoot, outputRoot, folder) {
         var shortName = name.replace(' and ', '/');
         name = name.replace(spaceReg, '-');
         var outName = (folderName + '-' + name).toLowerCase().replace('_', '-');
+        outName = outName.replace(/[()]/g, '');
         var outputFile = outputRoot + outName + '.hbs';
         if (verbose) {
           console.log('outputFile', outputFile);

--- a/src/data/examples/zh-Hans/05_Image/10_Copy_Method.js
+++ b/src/data/examples/zh-Hans/05_Image/10_Copy_Method.js
@@ -1,7 +1,7 @@
 /*
- * @name Copy() method
+ * @name Copy() 函数
  * @frame 600,400
- * @description 一个如何使用copy（）方法模拟为图像着色的示例。
+ * @description 一个如何使用 copy() 函数模拟为图像着色的范例。
  */
 let draft, ready;
 function preload() {


### PR DESCRIPTION
Fixes #797

 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Added a regex replace rule that removes all parenthesis from example file name and URL.

Fixed Chinese translation of the example as well.