### PR TITLE
Resolves #809, Removes codepen link from getting-started

### DIFF
--- a/src/data/en.yml
+++ b/src/data/en.yml
@@ -101,8 +101,6 @@ get started:
   download5: "Alternatively, you can link to a p5.js file hosted online. All versions of p5.js are stored in a CDN (Content Delivery Network). You can find a history of these versions in the "
   download6: ". In this case you can change the link to:"
   download7: "A sample HTML page might look like this:"
-  download8: "You can also start with this "
-  download9: " template."
   environment-title: "Environment"
   environment1: "To run p5.js in your computer you will need a text editor. You can use the "
   environmentlink: "http://en.wikipedia.org/wiki/Source_code_editor"

--- a/src/data/es.yml
+++ b/src/data/es.yml
@@ -99,8 +99,6 @@ get started:
   download5: "De forma alternativa, puedes enlazar a un archivo p5.js alojado en línea. Todas las versiones de p5.js están almacenadas en un CDN (Content Delivery Network). Puedes ver un historial de estas versiones aquí: "
   download6: ". En este caso, puedes cambiar el enlace a: "
   download7: "Una página HTML de ejemplo podría verse así:"
-  download8: "También puedes empezar con esta plantilla de "
-  download9: "."
   environment-title: "Ambiente"
   environment1: "Puedes usar el "
   environmentlink: "https://es.wikipedia.org/wiki/Editor_de_codigo_fuente"

--- a/src/data/zh-Hans.yml
+++ b/src/data/zh-Hans.yml
@@ -101,8 +101,6 @@ get started:
   download5: "另外，您也可以选择链接去网络上的 p5.js 文档。所有 p5.js 版本都被上载到多个 CDN (Content Delivery Network) 上，您可在此链接参考所有 p5.js 版本："
   download6: "。接下来您只需要将链接改为："
   download7: "一个极简但完整的 HTML 档案如下："
-  download8: "您也可以使用以下来自"
-  download9: "的模版。"
   environment-title: "编程环境"
   environment1: "您可以使用任何"
   environmentlink: "https://zh.wikipedia.org/wiki/%E6%BA%90%E4%BB%A3%E7%A0%81%E7%BC%96%E8%BE%91%E5%99%A8"

--- a/src/templates/pages/get-started/index.hbs
+++ b/src/templates/pages/get-started/index.hbs
@@ -152,7 +152,6 @@ function draw() {
 &lt;/html&gt;
         </code></pre>
 
-        <p>{{#i18n "download8"}}{{/i18n}} <a href='https://codepen.io/p5js/pen/wreBKy'>codepen</a>{{#i18n "download9"}}{{/i18n}}</p>
       </div>
       <h3 class="start-element tutorial-btn" id="environment">{{#i18n "environment-title"}}{{/i18n}}</h3>
       <div class="info">


### PR DESCRIPTION
To avoid outdated references in codepen examples, the link
was removed.
Along with the paragraph, i18n "download8" and "download9"
were also removed in all currently available languages.

Fixes #809 

 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 Screenshots of the change: 
<!-- Add screenshots depicting the changes. -->