### PR TITLE
Fixed typo in 21_Particle.js

### DIFF
--- a/src/data/examples/en/09_Simulate/21_Particle.js
+++ b/src/data/examples/en/09_Simulate/21_Particle.js
@@ -38,7 +38,7 @@ class Particle {
 
 // this function creates the connections(lines)
 // between particles which are less than a certain distance apart
-  joinParticles(paraticles) {
+  joinParticles(particles) {
     particles.forEach(element =>{
       let dis = dist(this.x,this.y,element.x,element.y);
       if(dis<85) {


### PR DESCRIPTION
Fixed typo in the example. The code worked because particule is a global variable.

Changes: 

`paraticle` -> `particle`


 Screenshots of the change: 
![image](https://user-images.githubusercontent.com/48289861/87849120-573efb00-c8e6-11ea-8287-02effbdc2899.png)
