### PR TITLE
add Korean name of 2019 showcase curator

### DIFF
--- a/src/data/ko.yml
+++ b/src/data/ko.yml
@@ -687,10 +687,10 @@ reference:
 
 showcase:
   showcase-title: "쇼케이스"
-  showcase-intro1: "쇼케이스는 2019년 애슐리 강 " 
+  showcase-intro1: "쇼케이스는 2019년 강예은 " 
   showcase-intro2: "이 제작, 기획하였으며, 2020년에는 코니 리우 "
   showcase-intro3: "가 새로운 기획을 선보입니다. 쇼케이스는 p5.js를 보다 흥미진진하고 포용적으로 만든 창작물, 학습물, 오픈 소스 사례들을 기쁘게 소개합니다. 이렇게 우리는 함께 커뮤니티를 만들어 나가는게 아닐까요?:) 2019년 여름, 우리는 p5.js 기반의 다양한 프로젝트들을 소개한 바 있습니다."
-  showcase-intro4: "현재 2020년 여름 쇼케이스를 위한 모집을 진행중입니다. 아래의 버튼을 눌러 자신 또는 타인의 p5.js 작업을 추천해주세요!"
+  showcase-intro4: "현재 2020년 여름 쇼케이스를 모집중입니다. 아래의 버튼을 눌러 자신 또는 타인의 p5.js 작업을 추천해주세요!"
   nominate-project: "프로젝트 추천하기"
   showcase-featuring: "선정 프로젝트"
   project-tag-art: "예술"


### PR DESCRIPTION
Hi, Moira @mcturner1995  :) Could we make one last edit on the showcase page?
I wanted to add proper Korean name of our 2019 showcase curator, Ashley Kang, upon her request.

I'd appreciate your merging and yet, pls let me know if you'd prefer to have me pull this request directly to the main branch!
Thank you :) 