### PR TITLE
Fix swap script for translation of the Reference pages

### DIFF
--- a/src/templates/pages/reference/index.hbs
+++ b/src/templates/pages/reference/index.hbs
@@ -120,14 +120,24 @@ slug: reference/
               // field
               $("[aria-labelledby='reference-fields']").children('li').each(function (i) {
                 var fieldName = $(this).children('.paramname').children('a').text();
-                $(this).children(':last').html('<p>' + entry[fieldName].description + '</p>');
+                let descr = '';
+                var paragraphs = entry[fieldName].description;
+                for (var i in paragraphs) {
+                  descr += '<p>' + paragraphs[i] + '</p> ';
+                }
+                $(this).children('.paramtype').html(descr);
               });
               // method
               $("[aria-labelledby='reference-methods']").children('li').each(function (i) {
-                var method = $(this).find(':first').children('a').text();
+                var method = $(this).children('.paramname').children('a').text();
                 // removes the brackets
                 var methodName = method.substring(0, method.length - 2);
-                $(this).find(':last').html('<p>' + entry[methodName].description + '</p>');
+                let descr = '';
+                var paragraphs = entry[methodName].description;
+                for (var i in paragraphs) {
+                  descr += '<p>' + paragraphs[i] + '</p> ';
+                }
+                $(this).children('.paramtype').html(descr);
               });
             }
           }


### PR DESCRIPTION
### Changes: 
**Fix a bug in the swap function for the translation of the Reference section.**
The changes I made to the [updateLanguage()](https://github.com/processing/p5.js-website/blob/main/src/templates/pages/reference/index.hbs#L61) function in PR #836 weren't complete: the script currently treats the description elements in Class pages of the Reference section as Strings instead of Arrays, so the description of Methods/Fields in Class pages are not properly rendered. (i.e. [p5.Image](https://p5js.org/ko/reference/#/p5.Image)).