### PR TITLE
Fix alpha scale in background() and color() in Spanish Doc

### DIFF
--- a/src/data/reference/es.json
+++ b/src/data/reference/es.json
@@ -109,7 +109,7 @@
       "returns": "Arreglo: color resultante",
       "params": {
         "gray": "Número|String: número especificando el valor entre blanco y negro.",
-        "alpha": "Número: valor de alpha relativo al rango de color actual (por defecto es 0-100)",
+        "alpha": "Número: valor de alpha relativo al rango de color actual (por defecto es 0-255)",
         "v1": "Número|String: valor de rojo o tinte relativo al rango de color actual, o un string de color",
         "v2": "Número: valor de verde o saturación relativo al rango de color actual",
         "v3": "Número: valor de azul o brillo relativo al rango de color actual",
@@ -188,7 +188,7 @@
       "params": {
         "color": "Color: cualquier valor creado con la función color()",
         "colorstring": "colorstring: string de color, formatos posibles: enteros rgb() o rgba(), porcentajes rgb() o rgba(), hex 3 dígitos, hex 6 dígitos",
-        "a": "Número: opacidad del fondo relativo al rango de color actual (por defecto es 0-100)",
+        "a": "Número: opacidad del fondo relativo al rango de color actual (por defecto es 0-255)",
         "gray": "Número: especifica un valor entre blanco y negro",
         "v1": "Número: valor de rojo o hue (dependiendo del modo de color actual)",
         "v2": "Número: valor de verde o saturación (dependiendo del modo de color actual)",


### PR DESCRIPTION
Changes: 

The scale for alpha value are wrong in the Spanish doc.

