### PR TITLE
Change canvas width in example Math/Map

### DIFF
--- a/src/data/examples/en/08_Math/18_Map.js
+++ b/src/data/examples/en/08_Math/18_Map.js
@@ -7,15 +7,15 @@
  * to define the color and size of a circle.
  */
 function setup() {
-  createCanvas(640, 400);
+  createCanvas(720, 400);
   noStroke();
 }
 
 function draw() {
   background(0);
-  // Scale the mouseX value from 0 to 640 to a range between 0 and 175
+  // Scale the mouseX value from 0 to 720 to a range between 0 and 175
   let c = map(mouseX, 0, width, 0, 175);
-  // Scale the mouseX value from 0 to 640 to a range between 40 and 300
+  // Scale the mouseX value from 0 to 720 to a range between 40 and 300
   let d = map(mouseX, 0, width, 40, 300);
   fill(255, c, 0);
   ellipse(width/2, height/2, d, d);

--- a/src/data/examples/es/08_Math/18_Map.js
+++ b/src/data/examples/es/08_Math/18_Map.js
@@ -7,15 +7,15 @@
  * para definir el color y el tamaño de un círculo.
  */
 function setup() {
-  createCanvas(640, 400);
+  createCanvas(720, 400);
   noStroke();
 }
 
 function draw() {
   background(0);
-  // Escala el valor de mouseX de 0 a 640 a un rango entre 0 y 175
+  // Escala el valor de mouseX de 0 a 720 a un rango entre 0 y 175
   let c = map(mouseX, 0, width, 0, 175);
-  // Escala el valor de mouseX de 0 a 640 a un rango entre 40 y 300
+  // Escala el valor de mouseX de 0 a 720 a un rango entre 40 y 300
   let d = map(mouseX, 0, width, 40, 300);
   fill(255, c, 0);
   ellipse(width/2, height/2, d, d);

--- a/src/data/examples/ko/08_Math/18_Map.js
+++ b/src/data/examples/ko/08_Math/18_Map.js
@@ -6,15 +6,15 @@
  * 이 예제에서는 마우스의 x 좌표(0과 360사이의 숫자)가 원형의 색상과 크기를 정의하는 새로운 숫자들로 처리됩니다.
  */
 function setup() {
-  createCanvas(640, 400);
+  createCanvas(720, 400);
   noStroke();
 }
 
 function draw() {
   background(0);
-  // 0부터 640에 이르는 mouseX 값을 0부터 175의 범위로 조정
+  // 0부터 720에 이르는 mouseX 값을 0부터 175의 범위로 조정
   let c = map(mouseX, 0, width, 0, 175);
-  // 0부터 640에 이르는 mouseX 값을 40부터 300의 범위로 조정
+  // 0부터 720에 이르는 mouseX 값을 40부터 300의 범위로 조정
   let d = map(mouseX, 0, width, 40, 300);
   fill(255, c, 0);
   ellipse(width/2, height/2, d, d);

--- a/src/data/examples/zh-Hans/08_Math/18_Map.js
+++ b/src/data/examples/zh-Hans/08_Math/18_Map.js
@@ -5,15 +5,15 @@
  * 此范例中，鼠标的 x 坐标（ 0-360 之间的数字）将被缩放为新数值，用于设定圆的颜色和大小。
  */
 function setup() {
-  createCanvas(640, 400);
+  createCanvas(720, 400);
   noStroke();
 }
 
 function draw() {
   background(0);
-  // 将 mouseX 的数值从 0-640 缩放至 0-175 的范围内
+  // 将 mouseX 的数值从 0-720 缩放至 0-175 的范围内
   let c = map(mouseX, 0, width, 0, 175);
-  // 将 mouseX 的数值从 0-640 to 缩放至 40-300 的范围内
+  // 将 mouseX 的数值从 0-720 to 缩放至 40-300 的范围内
   let d = map(mouseX, 0, width, 40, 300);
   fill(255, c, 0);
   ellipse(width/2, height/2, d, d);


### PR DESCRIPTION

Fixes #880 

 Changes: 
Changed canvas width from 640 to 720.


 Screenshots of the change: 
![image](https://user-images.githubusercontent.com/56646605/95021197-329e2800-0678-11eb-8291-8fec1073c5b2.png)

