### PR TITLE
Fixed the issue of skip-to-content button overlapping the header links

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -294,7 +294,7 @@ textarea {
 #skip-to-content {
   position: absolute;
   left: 0px;
-  top: 0px;
+  top: 40px;
   z-index: 5;
   background-color: #ed225d;
   color: white;


### PR DESCRIPTION
Fixes #879 

 Changes: 
The skip-to-main-content button was initially present at the top left corner of the page, and hence it overlapped the header links. I have changed the 'top' property for the button and pushed it downwards, and now the links are easily accessible.

 Screenshots of the change: 
![fix#879](https://user-images.githubusercontent.com/63252510/97204094-aba62080-17db-11eb-8dc1-6a68e9fe2a4f.gif)
