### PR TITLE
Fix broken link in the first line of File Structure section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Once you've setup the site, type `npm run watch` to run the website. This should
 
 ## File structure
 
-* __See note about what to include in pull requests [here](https://github.com/processing/p5.js-website/wiki/Pull-requests).__
+* __See note about what to include in pull requests [here](https://github.com/processing/p5.js/blob/main/contributor_docs/preparing_a_pull_request.md).__
 * `src/` – All the pieces for generating the built site. __Edits should be made here.__
   * `assets/` – All static files (imgs, css, fonts, js, p5_featured homepage sketches)
     * Note: if you make edits here you must restart the server to see your changes. To see changes immediately, you can edit the assets files in the dist directory, but need to copy and paste your updated work here for it to be saved.


### PR DESCRIPTION
Fixes #891 

 Changes: 
Earlier the link in the first line (mentioned in the issue #891 ) of **File Structure** was broken. Now it is fixed and it redirects [here](https://github.com/processing/p5.js/blob/main/contributor_docs/preparing_a_pull_request.md).

