### PR TITLE
Replaced broken iframe with corresponding showcase cover image

### DIFF
--- a/src/templates/pages/showcase/featuring/phuong-ngo.hbs
+++ b/src/templates/pages/showcase/featuring/phuong-ngo.hbs
@@ -12,10 +12,7 @@ slug: showcase/featuring/
 
     <section class="project-info">
       <h2 class='sr-only'>Project Info</h2>
-      <div class='iframe-container' style='padding-top: 56.25%'>
-        <iframe title="A video of Phuong Ngo demoing Airi Flies, a game to help Airi fly by saying pew."
-          src="https://embed-bud.glitch.me/iframe/G8OvtVaWb10" allow="fullscreen"></iframe>
-      </div>
+      <img src="{{assets}}/img/showcase/phuong-ngo/phuong-ngo_airi-flies.png" alt="A screenshot of a poster of Airi Flies, a game to help Airi fly by saying pew.">
     </section>
 
     <section class="project-metadata">


### PR DESCRIPTION
Fixes #893 

 **Changes:** 
Replaced broken iframe with corresponding showcase cover image
The showcase can be cross-checked by visiting https://showcase.p5js.org/#/2019/airi-flies/
The similar will be achieved in https://p5js.org/showcase/featuring/phuong-ngo.html

 **Screenshots of the change:** 
<!-- Add screenshots depicting the changes. -->
![image](https://user-images.githubusercontent.com/53327173/99880122-71dc0480-2c37-11eb-902a-c6ebb779ff57.png)

**At small viewport**

![image](https://user-images.githubusercontent.com/53327173/99880245-4e658980-2c38-11eb-8b3c-7b874b5f4cd4.png)

Kindly review it 🙂
