### PR TITLE
Differing group names in p5.sound references

### DIFF
--- a/src/yuidoc-p5-theme-src/scripts/tpl/library.html
+++ b/src/yuidoc-p5-theme-src/scripts/tpl/library.html
@@ -12,7 +12,7 @@
   <% } %>
   <% if (group.name !== module.name && group.name !== 'p5') { %>
     <% if (group.hash) { %> <a href="<%=group.hash%>" <% if (group.module !== module.name) { %>class="core"<% } %>><% } %>  
-    <h4 class="group-name <% if (t == 0) { %> first<%}%>"><%=group.name%></h4>
+    <h2 class="group-name <% if (t == 0) { %> first<%}%>"><%=group.name%></h2>
     <% if (group.hash) { %> </a><br> <% } %>
   <% } %>
   <% _.each(group.items.filter(function(item) {return item.access !== 'private'}), function(item) { %>


### PR DESCRIPTION
Fixes #895 

 Changes: 
Did not changed the color, as these were also hyperlinks.
With color change, they seemed static and unclickable


 Screenshots of the change: 
<!-- Add screenshots depicting the changes. -->
![image](https://user-images.githubusercontent.com/53327173/100534717-f16d6300-3237-11eb-9a12-59f1a5a3c65e.png)
