### PR TITLE
Detecting default language preference of user & translating

### DIFF
--- a/src/assets/js/init.js
+++ b/src/assets/js/init.js
@@ -88,7 +88,7 @@ window.onload = function() {
     var tmp = w.navigator.languages && w.navigator.languages[0]
       || w.navigator.language || w.navigator.userLanguage;
     tmp = tmp.split('-')[0];
-    for (var i=0, l=langs; i < l; i++) {
+    for (var i=0, l=langs.length; i < l; i++) {
       if (tmp == langs[i]) {
         return langs[i];
       }

--- a/src/assets/js/init.js
+++ b/src/assets/js/init.js
@@ -88,7 +88,7 @@ window.onload = function() {
     var tmp = w.navigator.languages && w.navigator.languages[0]
       || w.navigator.language || w.navigator.userLanguage;
     tmp = tmp.split('-')[0];
-    for (var i=0, l=langs.length; i < l; i++) {
+    for (var i = 0; i < langs.length; i++) {
       if (tmp == langs[i]) {
         return langs[i];
       }
@@ -99,7 +99,7 @@ window.onload = function() {
 
   var get_loc_lang = function(w) {
     if ((w.location.pathname == '/') === false) {
-      for (var i=0, l=langs.length; i < l; i++) {
+      for (var i = 0; i < langs.length; i++) {
         if (w.location.pathname.indexOf('/' + langs[i] + '/') !== -1) {
           if (can_store) {
             window.localStorage.setItem('lang', langs[i]);
@@ -149,7 +149,7 @@ window.onload = function() {
   var els = document.getElementsByClassName('js-lang');
   var el = null;
   if (window.lang != 'en') {
-    for (var i=0, l=els.length; i < l; i++) {
+    for (var i = 0; i < els.length; i++) {
       el = els[i];
       el.innerHTML = el.getAttribute('data-' + window.lang);
     }
@@ -164,13 +164,13 @@ window.onload = function() {
   var click_action = function(e) {
     var new_lang = this.getAttribute('data-lang');
     if (new_lang == 'en') {
-      for (var j=0, l=langs.length; j < l; j++) {
+      for (var j = 0; j < langs.length; j++) {
         if (langs[j] != 'en') {
           loc = loc.replace('\/' + langs[j] + '\/', '/');
         }
       }
     } else {
-      for (var j=0, l=langs.length; j < l; j++) {
+      for (var j = 0; j < langs.length; j++) {
         loc = loc.replace('\/' + langs[j] + '\/', '/');
       }
       loc = '/' + new_lang + loc;
@@ -180,7 +180,7 @@ window.onload = function() {
     }
     window.location = loc;
   };
-  for (var i=0, l=btns.length; i < l; i++) {
+  for (var i = 0; i < btns.length; i++) {
     var btn_lang = btns[i].getAttribute('data-lang');
     if (loc_lang == btn_lang) {
       $(btns[i]).addClass('disabled');


### PR DESCRIPTION
Fixes #897 

 Changes: 
The function was already present, but was not working

`langs=["en", "es", "ko", "zh-Hans"]`
While debugging found that, it was not going inside the for loop and due to which it could not return the `langs[i]`

 Screenshots of the change:
Now as shown below, if the language preference will be present.
It will show in the set browser's language only, unless manually updated.
![p5js](https://user-images.githubusercontent.com/53327173/100602624-25c14c00-332a-11eb-9d5d-665a523abee9.gif)