### PR TITLE
Correct behaviour while toggling of languages

### DIFF
--- a/src/assets/js/init.js
+++ b/src/assets/js/init.js
@@ -163,6 +163,10 @@ window.onload = function() {
   var evt_type = typeof document.addEventListener !== 'undefined' ? 'click' : 'onclick';
   var click_action = function(e) {
     var new_lang = this.getAttribute('data-lang');
+    //loc is defined second time below because while navigating from /reference/ to /reference/#/p5/displayWidth
+    //the page is not refreshing, so even if the page navigates properly to /reference/#/p5/displayWidth
+    //the window.location.hash remains empty
+    loc = String(window.location.pathname + window.location.hash);
     if (new_lang == 'en') {
       for (var j = 0; j < langs.length; j++) {
         if (langs[j] != 'en') {

--- a/src/data/examples/build_examples/build.js
+++ b/src/data/examples/build_examples/build.js
@@ -3,7 +3,7 @@ var verbose = false;
 // now load the modules we need
 var ejs = require('ejs'); // library for turning .ejs templates into .html files
 var fs = require('fs'); // node.js library for reading and writing files
-var path = require('upath'); // platform indepedent file paths
+var path = require('upath'); // platform independent file paths
 
 // make sure EJS is configured to use curly braces for templates
 // ejs.open = '<%';


### PR DESCRIPTION
Fixes #899 

 Changes: 

In case of toggling language buttons on examples page
It redirects successfully from https://p5js.org/es/examples/3d-geometries.html to https://p5js.org/examples/3d-geometries.html 
But it does not happen on References
The reason is because of the `#` in address

While staying on https://p5js.org/es/reference/#/p5/pixels
Earlier only `window.location.pathname` was taken care of
Below is the difference

![image](https://user-images.githubusercontent.com/53327173/100848396-0bf94380-34a7-11eb-8adf-5ff5b28907de.png)


 Screenshots of the change: 
<!-- Add screenshots depicting the changes. -->