### PR TITLE
Fix spacing typo on downloads page

### DIFF
--- a/src/templates/pages/download/index.hbs
+++ b/src/templates/pages/download/index.hbs
@@ -36,7 +36,7 @@ slug: download/
       <!-- COMPLETE LIBRARY -->
       <div class="link_group">
         <h2>{{#i18n "complete-library-title"}}{{/i18n}}</h2>
-        <p>{{#i18n "complete-library-intro1"}}{{/i18n}}<a href="{{root}}/get-started/">{{#i18n "complete-library-intro2"}}{{/i18n}}</a>{{#i18n "complete-library-intro3"}}{{/i18n}}</p>
+        <p>{{#i18n "complete-library-intro1"}}{{/i18n}} <a href="{{root}}/get-started/">{{#i18n "complete-library-intro2"}}{{/i18n}}</a>{{#i18n "complete-library-intro3"}}{{/i18n}}</p>
 
         <a  class='support_link p5_link' href="https://github.com/processing/p5.js/releases/download/[p5_version]/p5.zip">
           <div class="download_box">


### PR DESCRIPTION
Fixes #903 

 Changes: 
Add space between "Visit" and the permalink "Get Started" in the "Complete Library" section of the downloads page.

 Screenshots of the change: 

<img width="737" alt="Screen Shot 2020-12-09 at 2 56 21 PM" src="https://user-images.githubusercontent.com/48612525/101698655-bb499380-3a2e-11eb-835e-2b307a393044.png">