### PR TITLE
Page now returns to correct scroll Position

### DIFF
--- a/src/assets/js/init.js
+++ b/src/assets/js/init.js
@@ -199,6 +199,16 @@ window.onload = function() {
   }
 
   // =================================================
+  // Checking hash in URL
+  // this function runs when the DOM is ready, i.e. when the document has been parsed
+  setTimeout(function() {
+    if (location.hash) {
+      location.href = location.hash;
+    }
+  }, 1000);
+  
+
+  // =================================================
   // Chinese spacing
   if (window.pangu) {
     pangu.spacingPage();


### PR DESCRIPTION
Fixes #374 
Issue was: While visiting any sub heading like [this](https://p5js.org/reference/#group-Foundation), the scroll position was not correct

 Changes: 
1. Tried various methods like checking when DOM is ready with: `document.readyState === "complete"`
2. Tried adding defer in `<script src="./js/init.js"></script>`.
3. Also with `document.querySelector(target).offsetTop`, `document.querySelector(target)` showed null because DOM was not loaded till that time. Like shown below

![image](https://user-images.githubusercontent.com/53327173/102318667-b7be8b00-3f9f-11eb-9a24-9fbd60f0c2ea.png)

But the above steps were not working as it's expected. 
So it only worked by adding a `setTimeout()` function

Also thanks to @ffd8, for the suggestions