### PR TITLE
Removed broken script file

### DIFF
--- a/src/templates/pages/reference/index.hbs
+++ b/src/templates/pages/reference/index.hbs
@@ -26,7 +26,6 @@ slug: reference/
 
   </div> <!-- end column-span -->
 
-  <script src="//fast.fonts.net/jsapi/5ace315e-3b19-4568-9e85-5bfcb29004c0.js"></script>
   <script src='{{#versionedAsset}}assets/js/p5.min.js{{/versionedAsset}}'></script>
   <script src='{{#versionedAsset}}assets/js/p5.sound.min.js{{/versionedAsset}}'></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>


### PR DESCRIPTION
### Issue:
 Visit the [reference web page](https://p5js.org/reference/). and in console this warning pops up:
This script is broken: https://fast.fonts.net/jsapi/5ace315e-3b19-4568-9e85-5bfcb29004c0.js

![image](https://user-images.githubusercontent.com/53327173/102361303-1bb17580-3fd9-11eb-8182-8ba6645d5258.png)

This is the script file, I can confirm that in `Chrome` and `Firefox`, this script is broken

![image](https://user-images.githubusercontent.com/53327173/102360984-b493c100-3fd8-11eb-9154-5a780a7d72cf.png)


###  Changes: 
Removed the broken script tag