### PR TITLE
fix community email

### DIFF
--- a/src/templates/pages/community/index.hbs
+++ b/src/templates/pages/community/index.hbs
@@ -59,7 +59,7 @@ slug: community/
 
       <p><b>{{#i18n "teach-title"}}{{/i18n}}</b>{{#i18n "teach1"}}{{/i18n}}</p>
 
-      <p><b>{{#i18n "create-title"}}{{/i18n}}</b>{{#i18n "create1"}}{{/i18n}}<a href="mailto:feature@p5js.org">{{#i18n "create2"}}{{/i18n}}</a>{{#i18n "create3"}}{{/i18n}}</p>
+      <p><b>{{#i18n "create-title"}}{{/i18n}}</b>{{#i18n "create1"}}{{/i18n}}<a href="mailto:hello@p5js.org">{{#i18n "create2"}}{{/i18n}}</a>{{#i18n "create3"}}{{/i18n}}</p>
 
       <p><b>{{#i18n "donate-title"}}{{/i18n}}</b>{{#i18n "donate1"}}{{/i18n}}<a href="https://processingfoundation.org/support">{{#i18n "donate2"}}{{/i18n}}</a>{{#i18n "donate3"}}{{/i18n}}</p>
 


### PR DESCRIPTION
Fixes #912 

Changes: 
Replace `feature@p5js.org` to `hello@p5js.org` on community page.

Screenshots of the change: 
[![https://imgur.com/tDoQXF8.png](https://imgur.com/tDoQXF8.png)](https://imgur.com/tDoQXF8.png)