### PR TITLE
Added background animation back

### DIFF
--- a/src/templates/pages/index.hbs
+++ b/src/templates/pages/index.hbs
@@ -60,5 +60,5 @@ slug: /
 
   <object tabindex=-1 type="image/svg+xml" data="{{assets}}/img/thick-asterisk-alone.svg" id="asterisk-design-element"
     aria-hidden="true">*</object>
-  {{!-- <iframe tabindex='-1' id='home-sketch-frame' src='{{assets}}/p5_featured/KD_2020_08_08_22_21_27/'></iframe> --}}
+  <iframe tabindex='-1' id='home-sketch-frame' src='{{assets}}/p5_featured/KD_2020_08_08_22_21_27/'></iframe>
 </div> <!-- end home-page -->


### PR DESCRIPTION
I guess with the Pull request #902 , background animation iframe was removed for adding fundraiser.
But was not added back!

**Changes:** 
Added the animation back
![image](https://user-images.githubusercontent.com/53327173/104621393-13bb2300-56b6-11eb-9d22-4617e4f62650.png)

@limzykenneth can you please review it!
