### PR TITLE
Added space between text and link in Get Started page

### DIFF
--- a/i18n-tracking.yml
+++ b/i18n-tracking.yml
@@ -1,6 +1,7 @@
 es:
   src/data/en.yml:
-    line 163: '  your-first-sketch7'
+    line 163: '    library in your html. To learn more visit '
+    line 164: '  your-first-sketch7'
     line 97: '  get-started-button'
     line 96: '  get-started7'
     line 114: '  environment15'
@@ -165,7 +166,6 @@ es:
     line 144: '  project-a-2-7-phuong'
     line 64: '  color-p3x3'
     line 70: '  color-rgb-p1x1'
-    line 164: '  teach-case1-content1-1'
     line 87: '  color-custom-ranges-p2x1'
     line 24: footer1
     line 25: footer2
@@ -1822,7 +1822,8 @@ es:
     line 604: '  color-custom-ranges-li3x2'
 ko:
   src/data/en.yml:
-    line 163: '  your-first-sketch7'
+    line 163: '    library in your html. To learn more visit '
+    line 164: '  your-first-sketch7'
     line 97: '  get-started-button'
     line 96: '  get-started7'
     line 114: '  environment15'
@@ -1988,7 +1989,6 @@ ko:
     line 144: '  project-a-2-7-phuong'
     line 64: '  color-p3x3'
     line 70: '  color-rgb-p1x1'
-    line 164: '  teach-case1-content1-1'
     line 87: '  color-custom-ranges-p2x1'
     line 24: footer1
     line 25: footer2
@@ -3644,7 +3644,8 @@ ko:
     line 604: '  color-custom-ranges-li3x2'
 zh-Hans:
   src/data/en.yml:
-    line 163: '  your-first-sketch7'
+    line 163: '    library in your html. To learn more visit '
+    line 164: '  your-first-sketch7'
     line 97: '  get-started-button'
     line 96: '  get-started7'
     line 114: '  environment15'
@@ -3809,7 +3810,6 @@ zh-Hans:
     line 144: '  project-a-2-7-phuong'
     line 64: '  color-p3x3'
     line 70: '  color-rgb-p1x1'
-    line 164: '  teach-case1-content1-1'
     line 87: '  color-custom-ranges-p2x1'
     line 24: footer1
     line 25: footer2

--- a/i18n-tracking.yml
+++ b/i18n-tracking.yml
@@ -1,5 +1,6 @@
 es:
   src/data/en.yml:
+    line 163: '  your-first-sketch7'
     line 97: '  get-started-button'
     line 96: '  get-started7'
     line 114: '  environment15'
@@ -162,7 +163,6 @@ es:
     line 134: '  p4xp4'
     line 141: '  project-a-2-5-phuong'
     line 144: '  project-a-2-7-phuong'
-    line 163: '  teach-case1-content1'
     line 64: '  color-p3x3'
     line 70: '  color-rgb-p1x1'
     line 164: '  teach-case1-content1-1'
@@ -1822,6 +1822,7 @@ es:
     line 604: '  color-custom-ranges-li3x2'
 ko:
   src/data/en.yml:
+    line 163: '  your-first-sketch7'
     line 97: '  get-started-button'
     line 96: '  get-started7'
     line 114: '  environment15'
@@ -1985,7 +1986,6 @@ ko:
     line 134: '  p4xp4'
     line 141: '  project-a-2-5-phuong'
     line 144: '  project-a-2-7-phuong'
-    line 163: '  teach-case1-content1'
     line 64: '  color-p3x3'
     line 70: '  color-rgb-p1x1'
     line 164: '  teach-case1-content1-1'
@@ -3644,6 +3644,7 @@ ko:
     line 604: '  color-custom-ranges-li3x2'
 zh-Hans:
   src/data/en.yml:
+    line 163: '  your-first-sketch7'
     line 97: '  get-started-button'
     line 96: '  get-started7'
     line 114: '  environment15'
@@ -3806,7 +3807,6 @@ zh-Hans:
     line 134: '  p4xp4'
     line 141: '  project-a-2-5-phuong'
     line 144: '  project-a-2-7-phuong'
-    line 163: '  teach-case1-content1'
     line 64: '  color-p3x3'
     line 70: '  color-rgb-p1x1'
     line 164: '  teach-case1-content1-1'

--- a/i18n-tracking.yml
+++ b/i18n-tracking.yml
@@ -1,5 +1,6 @@
 es:
   src/data/en.yml:
+    line 162: '    library in your html. To learn more visit&#32;'
     line 163: '    library in your html. To learn more visit '
     line 164: '  your-first-sketch7'
     line 97: '  get-started-button'
@@ -185,7 +186,6 @@ es:
     line 159: '  processing-transition1'
     line 160: '  processing-transition2'
     line 161: '  processing-transition3'
-    line 162: '  processing-transition4'
     line 357: '  link-2-chung'
     line 358: '  link-3-chung'
     line 359: '  project-a-1-1-chung'
@@ -1822,6 +1822,7 @@ es:
     line 604: '  color-custom-ranges-li3x2'
 ko:
   src/data/en.yml:
+    line 162: '    library in your html. To learn more visit&#32;'
     line 163: '    library in your html. To learn more visit '
     line 164: '  your-first-sketch7'
     line 97: '  get-started-button'
@@ -2008,7 +2009,6 @@ ko:
     line 159: '  processing-transition1'
     line 160: '  processing-transition2'
     line 161: '  processing-transition3'
-    line 162: '  processing-transition4'
     line 357: '  link-2-chung'
     line 358: '  link-3-chung'
     line 359: '  project-a-1-1-chung'
@@ -3644,6 +3644,7 @@ ko:
     line 604: '  color-custom-ranges-li3x2'
 zh-Hans:
   src/data/en.yml:
+    line 162: '    library in your html. To learn more visit&#32;'
     line 163: '    library in your html. To learn more visit '
     line 164: '  your-first-sketch7'
     line 97: '  get-started-button'
@@ -3829,7 +3830,6 @@ zh-Hans:
     line 159: '  processing-transition1'
     line 160: '  processing-transition2'
     line 161: '  processing-transition3'
-    line 162: '  processing-transition4'
     line 357: '  link-2-chung'
     line 358: '  link-3-chung'
     line 359: '  project-a-1-1-chung'

--- a/src/data/en.yml
+++ b/src/data/en.yml
@@ -159,7 +159,7 @@ get started:
     If you are using a screen reader, you must turn on the accessible outputs in
     the p5 online editor, outside the editor you must add the accessibility
     library in your html. To learn more visit
-  your-first-sketch7: using p5 with a screen reader tutorial
+  your-first-sketch7: ' using p5 with a screen reader tutorial'
   your-first-sketch8: >-
     If you've typed everything correctly, this will appear in the display
     window:

--- a/src/data/en.yml
+++ b/src/data/en.yml
@@ -158,7 +158,7 @@ get started:
   your-first-sketch6: >-
     If you are using a screen reader, you must turn on the accessible outputs in
     the p5 online editor, outside the editor you must add the accessibility
-    library in your html. To learn more visit 
+    library in your html. To learn more visit&#32;
   your-first-sketch7: 'using p5 with a screen reader tutorial'
   your-first-sketch8: >-
     If you've typed everything correctly, this will appear in the display

--- a/src/data/en.yml
+++ b/src/data/en.yml
@@ -158,8 +158,8 @@ get started:
   your-first-sketch6: >-
     If you are using a screen reader, you must turn on the accessible outputs in
     the p5 online editor, outside the editor you must add the accessibility
-    library in your html. To learn more visit
-  your-first-sketch7: ' using p5 with a screen reader tutorial'
+    library in your html. To learn more visit 
+  your-first-sketch7: 'using p5 with a screen reader tutorial'
   your-first-sketch8: >-
     If you've typed everything correctly, this will appear in the display
     window:

--- a/src/templates/pages/get-started/index.hbs
+++ b/src/templates/pages/get-started/index.hbs
@@ -59,7 +59,7 @@ function draw() {
         <p style="margin-top: 1.5em;">{{#i18n "your-first-sketch4"}}{{/i18n}}</p>
         <p>{{#i18n "your-first-sketch5"}}{{/i18n}}</p>
         <h3 class="sr-only">{{#i18n "first-sketch-heading2"}}{{/i18n}}</h3>
-        <p>{{#i18n "your-first-sketch6"}}{{/i18n}} <a href="../learn/p5-screen-reader.html" target="_blank">{{#i18n "your-first-sketch7"}}{{/i18n}}.</a>
+        <p>{{#i18n "your-first-sketch6"}}{{/i18n}}<a href="../learn/p5-screen-reader.html" target="_blank">{{#i18n "your-first-sketch7"}}{{/i18n}}.</a>
         </p>
         <p>{{#i18n "your-first-sketch8"}}{{/i18n}}</p>
 

--- a/src/templates/pages/get-started/index.hbs
+++ b/src/templates/pages/get-started/index.hbs
@@ -59,7 +59,7 @@ function draw() {
         <p style="margin-top: 1.5em;">{{#i18n "your-first-sketch4"}}{{/i18n}}</p>
         <p>{{#i18n "your-first-sketch5"}}{{/i18n}}</p>
         <h3 class="sr-only">{{#i18n "first-sketch-heading2"}}{{/i18n}}</h3>
-        <p>{{#i18n "your-first-sketch6"}}{{/i18n}}<a href="../learn/p5-screen-reader.html" target="_blank">{{#i18n "your-first-sketch7"}}{{/i18n}}.</a>
+        <p>{{#i18n "your-first-sketch6"}}{{/i18n}} <a href="../learn/p5-screen-reader.html" target="_blank">{{#i18n "your-first-sketch7"}}{{/i18n}}.</a>
         </p>
         <p>{{#i18n "your-first-sketch8"}}{{/i18n}}</p>
 


### PR DESCRIPTION
Fixes #926

 Changes: 
There was no space between text and link, which was making it difficult to read.

 Screenshots of the change: 
Previously:
![image](https://user-images.githubusercontent.com/47415702/105179458-62057180-5b4f-11eb-9a52-0a5b19dbaf2a.png)

After Fix:
![image](https://user-images.githubusercontent.com/47415702/105179532-76496e80-5b4f-11eb-8e7a-6768f16106ce.png)

