### PR TITLE
Corrected code for Inheritance which was not implementing inheritance using extends keyword

### DIFF
--- a/src/data/examples/en/11_Objects/04_Inheritance.js
+++ b/src/data/examples/en/11_Objects/04_Inheritance.js
@@ -22,7 +22,7 @@ function draw() {
 }
 
 class Spin {
-  constructor(x,y,s) {
+  constructor(x, y, s) {
     this.x = x;
     this.y = y;
     this.speed = s;
@@ -36,7 +36,7 @@ class Spin {
 
 class SpinArm extends Spin {
   constructor(x, y, s) {
-    super(x,y,s)
+    super(x, y, s)
   }
 
   display() {
@@ -53,7 +53,7 @@ class SpinArm extends Spin {
 
 class SpinSpots extends Spin {
   constructor(x, y, s, d) {
-    super(x,y,s)
+    super(x, y, s)
     this.dim = d;
   }
 

--- a/src/data/examples/en/11_Objects/04_Inheritance.js
+++ b/src/data/examples/en/11_Objects/04_Inheritance.js
@@ -21,16 +21,22 @@ function draw() {
   spots.display();
 }
 
-class SpinArm {
-  constructor(x, y, s) {
+class Spin {
+  constructor(x,y,s) {
     this.x = x;
     this.y = y;
     this.speed = s;
     this.angle = 0.0;
   }
-
+  
   update() {
     this.angle += this.speed;
+  }
+}
+
+class SpinArm extends Spin {
+  constructor(x, y, s) {
+    super(x,y,s)
   }
 
   display() {
@@ -45,17 +51,10 @@ class SpinArm {
   }
 }
 
-class SpinSpots {
+class SpinSpots extends Spin {
   constructor(x, y, s, d) {
-    this.x = x;
-    this.y = y;
-    this.speed = s;
+    super(x,y,s)
     this.dim = d;
-    this.angle = 0.0;
-  }
-
-  update() {
-    this.angle += this.speed;
   }
 
   display() {

--- a/src/data/examples/en/11_Objects/04_Inheritance.js
+++ b/src/data/examples/en/11_Objects/04_Inheritance.js
@@ -28,7 +28,7 @@ class Spin {
     this.speed = s;
     this.angle = 0.0;
   }
-  
+
   update() {
     this.angle += this.speed;
   }

--- a/src/data/examples/es/11_Objects/04_Inheritance.js
+++ b/src/data/examples/es/11_Objects/04_Inheritance.js
@@ -22,7 +22,7 @@ function draw() {
 }
 
 class Spin {
-  constructor(x,y,s) {
+  constructor(x, y, s) {
     this.x = x;
     this.y = y;
     this.speed = s;
@@ -36,7 +36,7 @@ class Spin {
 
 class SpinArm extends Spin {
   constructor(x, y, s) {
-    super(x,y,s)
+    super(x, y, s)
   }
 
   display() {
@@ -53,7 +53,7 @@ class SpinArm extends Spin {
 
 class SpinSpots extends Spin {
   constructor(x, y, s, d) {
-    super(x,y,s)
+    super(x, y, s)
     this.dim = d;
   }
 

--- a/src/data/examples/es/11_Objects/04_Inheritance.js
+++ b/src/data/examples/es/11_Objects/04_Inheritance.js
@@ -21,16 +21,22 @@ function draw() {
   spots.display();
 }
 
-class SpinArm {
-  constructor(x, y, s) {
+class Spin {
+  constructor(x,y,s) {
     this.x = x;
     this.y = y;
     this.speed = s;
     this.angle = 0.0;
   }
-
+  
   update() {
     this.angle += this.speed;
+  }
+}
+
+class SpinArm extends Spin {
+  constructor(x, y, s) {
+    super(x,y,s)
   }
 
   display() {
@@ -45,17 +51,10 @@ class SpinArm {
   }
 }
 
-class SpinSpots {
+class SpinSpots extends Spin {
   constructor(x, y, s, d) {
-    this.x = x;
-    this.y = y;
-    this.speed = s;
+    super(x,y,s)
     this.dim = d;
-    this.angle = 0.0;
-  }
-
-  update() {
-    this.angle += this.speed;
   }
 
   display() {

--- a/src/data/examples/es/11_Objects/04_Inheritance.js
+++ b/src/data/examples/es/11_Objects/04_Inheritance.js
@@ -28,7 +28,7 @@ class Spin {
     this.speed = s;
     this.angle = 0.0;
   }
-  
+
   update() {
     this.angle += this.speed;
   }

--- a/src/data/examples/ko/11_Objects/04_Inheritance.js
+++ b/src/data/examples/ko/11_Objects/04_Inheritance.js
@@ -22,7 +22,7 @@ function draw() {
 }
 
 class Spin {
-  constructor(x,y,s) {
+  constructor(x, y, s) {
     this.x = x;
     this.y = y;
     this.speed = s;
@@ -36,7 +36,7 @@ class Spin {
 
 class SpinArm extends Spin {
   constructor(x, y, s) {
-    super(x,y,s)
+    super(x, y, s)
   }
 
   display() {
@@ -53,7 +53,7 @@ class SpinArm extends Spin {
 
 class SpinSpots extends Spin {
   constructor(x, y, s, d) {
-    super(x,y,s)
+    super(x, y, s)
     this.dim = d;
   }
 

--- a/src/data/examples/ko/11_Objects/04_Inheritance.js
+++ b/src/data/examples/ko/11_Objects/04_Inheritance.js
@@ -21,16 +21,22 @@ function draw() {
   spots.display();
 }
 
-class SpinArm {
-  constructor(x, y, s) {
+class Spin {
+  constructor(x,y,s) {
     this.x = x;
     this.y = y;
     this.speed = s;
     this.angle = 0.0;
   }
-
+  
   update() {
     this.angle += this.speed;
+  }
+}
+
+class SpinArm extends Spin {
+  constructor(x, y, s) {
+    super(x,y,s)
   }
 
   display() {
@@ -45,17 +51,10 @@ class SpinArm {
   }
 }
 
-class SpinSpots {
+class SpinSpots extends Spin {
   constructor(x, y, s, d) {
-    this.x = x;
-    this.y = y;
-    this.speed = s;
+    super(x,y,s)
     this.dim = d;
-    this.angle = 0.0;
-  }
-
-  update() {
-    this.angle += this.speed;
   }
 
   display() {

--- a/src/data/examples/ko/11_Objects/04_Inheritance.js
+++ b/src/data/examples/ko/11_Objects/04_Inheritance.js
@@ -28,7 +28,7 @@ class Spin {
     this.speed = s;
     this.angle = 0.0;
   }
-  
+
   update() {
     this.angle += this.speed;
   }

--- a/src/data/examples/zh-Hans/11_Objects/04_Inheritance.js
+++ b/src/data/examples/zh-Hans/11_Objects/04_Inheritance.js
@@ -21,7 +21,7 @@ function draw() {
 }
 
 class Spin {
-  constructor(x,y,s) {
+  constructor(x, y, s) {
     this.x = x;
     this.y = y;
     this.speed = s;
@@ -35,7 +35,7 @@ class Spin {
 
 class SpinArm extends Spin {
   constructor(x, y, s) {
-    super(x,y,s)
+    super(x, y, s)
   }
 
   display() {
@@ -52,7 +52,7 @@ class SpinArm extends Spin {
 
 class SpinSpots extends Spin {
   constructor(x, y, s, d) {
-    super(x,y,s)
+    super(x, y, s)
     this.dim = d;
   }
 

--- a/src/data/examples/zh-Hans/11_Objects/04_Inheritance.js
+++ b/src/data/examples/zh-Hans/11_Objects/04_Inheritance.js
@@ -27,7 +27,7 @@ class Spin {
     this.speed = s;
     this.angle = 0.0;
   }
-  
+
   update() {
     this.angle += this.speed;
   }

--- a/src/data/examples/zh-Hans/11_Objects/04_Inheritance.js
+++ b/src/data/examples/zh-Hans/11_Objects/04_Inheritance.js
@@ -20,16 +20,22 @@ function draw() {
   spots.display();
 }
 
-class SpinArm {
-  constructor(x, y, s) {
+class Spin {
+  constructor(x,y,s) {
     this.x = x;
     this.y = y;
     this.speed = s;
     this.angle = 0.0;
   }
-
+  
   update() {
     this.angle += this.speed;
+  }
+}
+
+class SpinArm extends Spin {
+  constructor(x, y, s) {
+    super(x,y,s)
   }
 
   display() {
@@ -44,17 +50,10 @@ class SpinArm {
   }
 }
 
-class SpinSpots {
+class SpinSpots extends Spin {
   constructor(x, y, s, d) {
-    this.x = x;
-    this.y = y;
-    this.speed = s;
+    super(x,y,s)
     this.dim = d;
-    this.angle = 0.0;
-  }
-
-  update() {
-    this.angle += this.speed;
   }
 
   display() {


### PR DESCRIPTION

Fixes #921

 Changes: 
Changes Inheritance code such that both the classes SpinArms and SpinSpots extend the Spin class. As initially in [Inheritance](https://p5js.org/examples/objects-inheritance.html), two separate classes are defined, which are defining their own spin classes and not using extends keyword.

Changed code:

```
let spots, arm;

function setup() {
  createCanvas(640, 360);
  arm = new SpinArm(width/2, height/2, 0.01);
  spots = new SpinSpots(width/2, height/2, -0.02, 90.0);
}

function draw() {
  background(204);
  arm.update();
  arm.display();
  spots.update();
  spots.display();
}

class Spin {
  constructor(x,y,s) {
    this.x = x;
    this.y = y;
    this.speed = s;
    this.angle = 0.0;
  }
  
  update() {
    this.angle += this.speed;
  }
}

class SpinArm extends Spin {
  constructor(x, y, s) {
    super(x,y,s)
  }

  display() {
    strokeWeight(1);
    stroke(0);
    push();
    translate(this.x, this.y);
    this.angle += this.speed;
    rotate(this.angle);
    line(0, 0, 165, 0);
    pop();
  }
}

class SpinSpots extends Spin {
  constructor(x, y, s, d) {
    super(x,y,s)
    this.dim = d;
  }

  display() {
    noStroke();
    push();
    translate(this.x, this.y);
    this.angle += this.speed;
    rotate(this.angle);
    ellipse(-this.dim/2, 0, this.dim, this.dim);
    ellipse(this.dim/2, 0, this.dim, this.dim);
    pop();
  }
}
```

 Screenshots of the change: 

Intially:
![image](https://user-images.githubusercontent.com/47415702/105992235-dea5cc00-60ca-11eb-8bb2-8324311db6d6.png)


After change:
![image](https://user-images.githubusercontent.com/47415702/105992350-0301a880-60cb-11eb-8a0f-8e5c826b7555.png)

