### PR TITLE
added symbols in description of math examples

### DIFF
--- a/src/data/examples/en/08_Math/05_sincosine.js
+++ b/src/data/examples/en/08_Math/05_sincosine.js
@@ -1,7 +1,7 @@
 /*
  * @name Sine Cosine
  * @description Linear movement with sin() and cos().
- * Numbers between 0 and PI*2 (TWO_PI which angles roughly 6.28)
+ * Numbers between 0 and 2π (2π which angles roughly 6.28)
  * are put into these functions and numbers between -1 and 1 are returned.
  * These values are then scaled to produce larger movements.
  */

--- a/src/data/examples/en/08_Math/08_polartocartesian.js
+++ b/src/data/examples/en/08_Math/08_polartocartesian.js
@@ -1,7 +1,7 @@
 /*
  * @name PolarToCartesian
- * @description Convert a polar coordinate (r,theta)
- * to cartesian (x,y): x = rcos(theta) y = rsin(theta)
+ * @description Convert a polar coordinate (r,θ)
+ * to cartesian (x,y): x = r cos(θ), y = r sin(θ)
  * Original by Daniel Shiffman.
  */
 let r;

--- a/src/data/examples/en/08_Math/20_Graphing2DEquations.js
+++ b/src/data/examples/en/08_Math/20_Graphing2DEquations.js
@@ -1,7 +1,7 @@
 /**
  * @name Graphing 2D Equations
  * @frame 710, 400
- * @description Graphics the following equation: sin(n*cos(r) + 5*theta) where n is a function of horizontal mouse location. Original by Daniel Shiffman
+ * @description Graphics the following equation: sin(n cos(r) + 5θ) where n is a function of horizontal mouse location. Original by Daniel Shiffman
  */
 function setup() {
   createCanvas(710, 400);
@@ -43,6 +43,7 @@ function draw() {
       pixels[index + 1] = green(bw);
       pixels[index + 2] = blue(bw);
       pixels[index + 3] = alpha(bw);
+
       y += dy;
     }
     x += dx;


### PR DESCRIPTION
Fixes #955

 Changes: 
Used mathematical unicode symbols in description of math examples (such as θ and π) 


 Screenshots of the change: 

![image](https://user-images.githubusercontent.com/68433541/111218591-f266ac80-85fc-11eb-9bc1-be15c03d246c.png)

