### PR TITLE
Added Prof Harris's example | Open@RIT

### DIFF
--- a/src/data/data.yml
+++ b/src/data/data.yml
@@ -1,2 +1,2 @@
 title: p5.js
-version: 1.2.0
+version: 1.1.9

--- a/src/data/data.yml
+++ b/src/data/data.yml
@@ -1,2 +1,2 @@
 title: p5.js
-version: 1.1.9
+version: 1.2.0

--- a/src/data/examples/en/10_Interaction/11_WeightLine.js
+++ b/src/data/examples/en/10_Interaction/11_WeightLine.js
@@ -4,7 +4,7 @@
  * @description contributed by <a href="https://www.rit.edu/directory/wmhics-w-michelle-harris">
    <b>Prof WM Harris,</b></a> using the random function with events to color/weight a line<br/>
   <b>How</b> to use the random function with events to color/ weight a line
-	dependent on mouse location, lmb clicks, character key types, and
+	dependent on mouse location, left mouse button clicks, character key types, and
 	random key releases.<br/>
   <b>Functions</b> are created for both the canvas set up as well as the creation of
 	the line. Depending on the action taken by the user the line can

--- a/src/data/examples/en/10_Interaction/11_WeightLine.js
+++ b/src/data/examples/en/10_Interaction/11_WeightLine.js
@@ -1,7 +1,8 @@
 /* 
  * @name Weight Line
  * @frame 710,400
- * @description contributed by <b>Prof WM Harris</b> using the random function with events to color/weight a line<br/>
+ * @description contributed by <a href="https://www.rit.edu/directory/wmhics-w-michelle-harris">
+   <b>Prof WM Harris,</b></a> using the random function with events to color/weight a line<br/>
   <b>How</b> to use the random function with events to color/ weight a line
 	dependent on mouse location, lmb clicks, character key types, and
 	random key releases.<br/>

--- a/src/data/examples/en/10_Interaction/11_WeightLine.js
+++ b/src/data/examples/en/10_Interaction/11_WeightLine.js
@@ -1,0 +1,54 @@
+/* 
+ * @name Weight Line
+ * @frame 710,400
+ * @description contributed by <b>Prof WM Harris</b> using the random function with events to color/weight a line<br/>
+  <b>How</b> to use the random function with events to color/ weight a line
+	dependent on mouse location, lmb clicks, character key types, and
+	random key releases.<br/>
+  <b>Functions</b> are created for both the canvas set up as well as the creation of
+	the line. Depending on the action taken by the user the line can
+	vary in width and color. Left mouse button clicks result in a color
+	change to blue, while the typing of any character key will change
+	the color to turquoise, each resulting in a variable stroke weight;
+	the width of the former will be between 0 – 1 while the width of
+	the latter will be 0 – 5. The release of any key will result in a
+  random hue, saturation, and brightness change to the line.
+ */
+
+
+function setup() {
+    createCanvas(400, 400);
+    background("beige");
+    colorMode(HSB);
+  }
+  
+  function draw() {
+    //Line from prev pt to current pt
+    //of mouse position
+    line(mouseX, mouseY, pmouseX, pmouseY);
+  }
+  
+  //listen when we click the mouse
+  function mouseClicked() {
+    //weights 0 to 1
+    stroke("slateBlue");
+    strokeWeight(random());
+  
+    //what if want weights 0 to .4?
+    //strokeWeight( random(.4) );
+  }
+  
+  //listen when we release *any* key
+  function keyReleased() {
+    //color hue values between 20 and 145
+    //saturation 0 to 100
+    //brightness 80 to 100
+    stroke(random(20, 145), random(100), random(80, 100));
+  }
+  
+  //listen for only character keys
+  function keyTyped() {
+    //weights 0 to 5
+    stroke("turquoise");
+    strokeWeight(random(5));
+  }


### PR DESCRIPTION
Fixes [#959 ]

 Changes: 
added an example **Weight Line** under section [interaction](https://p5js.org/examples/).
This example is provided by [Prof WM Harris](https://www.rit.edu/directory/wmhics-w-michelle-harris).
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 Screenshots of the change: 
<!-- Add screenshots depicting the changes. -->
![Screenshot from 2021-03-16 11-09-43](https://user-images.githubusercontent.com/43292181/111332776-742ff780-8648-11eb-843f-ef92091f8f3e.png)
![Screenshot from 2021-03-16 11-07-33](https://user-images.githubusercontent.com/43292181/111332784-75f9bb00-8648-11eb-9c9d-275730d61ca6.png)
