### PR TITLE
Improving the contrast for library names

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -919,6 +919,11 @@ h3 {
   list-style: disc;
 }
 
+#libraries-page .label h3{
+  background-color: black;
+  padding:0px 5px;
+}
+
 #learn-page .label .nounderline img {
   height: fit-content;
 }


### PR DESCRIPTION
Fixes #1005 

 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Added a dark background to library name labels to increase the contrast so that it is readable to visually impaired or people with low vision.

 Screenshots of the change: 
<!-- Add screenshots depicting the changes. -->
#### Before:
![image](https://user-images.githubusercontent.com/54268438/115008485-cc1c8100-9ec8-11eb-9c6a-6e91637589eb.png)
![image](https://user-images.githubusercontent.com/54268438/115008564-e2c2d800-9ec8-11eb-85a0-0cfce5d19a64.png)
 
#### After:
![image](https://user-images.githubusercontent.com/54268438/115357063-dfd22b00-a1d9-11eb-8cac-d6a1e6b7eb7d.png)
![image](https://user-images.githubusercontent.com/54268438/115357149-f37d9180-a1d9-11eb-9bda-ca8af197bae9.png)
