### PR TITLE
Fixed the skipping of download links by screen reader

### DIFF
--- a/src/templates/pages/download/index.hbs
+++ b/src/templates/pages/download/index.hbs
@@ -57,7 +57,7 @@ slug: download/
 
         <h2 id="single-files">{{#i18n "single-files-title"}}{{/i18n}}</h2>
         <p>{{#i18n "single-files-intro"}}{{/i18n}}</p>
-        <ul aria-labelledby="single-files">
+        <ul>
           <li>
             <a class='support_link p5_link' href="https://github.com/processing/p5.js/releases/download/v[p5_version]/p5.js">
               <div class="download_box half_box">
@@ -96,7 +96,7 @@ slug: download/
       <!-- Github resources -->
       <div class="link_group">
         <h2 id="etc">{{#i18n "etc-title"}}{{/i18n}}</h2>
-        <ul aria-labelledby="etc" id='etc_list' class="list_view bullets">
+        <ul id='etc_list' class="list_view bullets">
           <li><a href="https://github.com/processing/p5.js/releases">{{#i18n "older-releases"}}{{/i18n}}</a></li>
           <li><a href="https://github.com/processing/p5.js">{{#i18n "github-repository"}}{{/i18n}}</a></li>
           <li><a href="https://github.com/processing/p5.js/issues">{{#i18n "report-bugs"}}{{/i18n}}</a></li>


### PR DESCRIPTION
Fixes #1015 

 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
I think `aria-labelledby` is supported for interactive content elements such as links and buttons by a screen reader but skipped for static elements. So, I removed the `aria-labelledby` attribute from the unordered lists which makes the screen reader works fine now.

 Screenshots of the change: 
<!-- Add screenshots depicting the changes. -->
NA