### PR TITLE
Taglines removed from default layout file 

### DIFF
--- a/src/templates/layouts/default.hbs
+++ b/src/templates/layouts/default.hbs
@@ -37,12 +37,7 @@
           <img src="/{{assets}}/img/p5js.svg" alt="p5 homepage" id="logo_image" class="logo" />
           <div id="p5_logo"></div>
         </a>
-        <p class='tagline'>{{#i18n "tagline1"}}{{/i18n}}</p>
-        <p class='tagline'>{{#i18n "tagline2"}}{{/i18n}}</p>
-        <p class='tagline'>{{#i18n "tagline3"}}{{/i18n}}</p>
-        <p class='tagline'>{{#i18n "tagline4"}}{{/i18n}}</p>
-        <p class='tagline'>{{#i18n "tagline5"}}{{/i18n}}</p>
-        <p class='tagline'>{{#i18n "tagline6"}}{{/i18n}}</p>
+        {{!-- <p class='tagline'>{{#i18n "tagline1"}}{{/i18n}}</p> --}}
       </header>
       <!-- close logo -->
 


### PR DESCRIPTION
Fixes #1007 

 Changes: 
Removed the taglines from the `default.hbs` file. Every page of the site used the same layout file due to this taglines were appearing on every page of the website(Hindi). I have removed all the taglines and commented one for reference. 


 Screenshots of the change: 
![image](https://user-images.githubusercontent.com/67458417/115853648-0779fb00-a447-11eb-8e40-06cc303a1956.png)
![randomblockofCode](https://user-images.githubusercontent.com/67458417/115854226-a7d01f80-a447-11eb-8b85-7e14ec770c5f.png)
![Screenshot 2021-04-18 134718](https://user-images.githubusercontent.com/67458417/115854261-b1f21e00-a447-11eb-8726-c469d82804f1.png)



Thanks 