### PR TITLE
changed the typo version of continuous to the correct version

### DIFF
--- a/src/data/data.yml
+++ b/src/data/data.yml
@@ -1,2 +1,2 @@
 title: p5.js
-version: 1.3.1
+version: 1.4.0

--- a/src/data/examples/en/17_Drawing/00_Continuous_Lines.js
+++ b/src/data/examples/en/17_Drawing/00_Continuous_Lines.js
@@ -1,5 +1,5 @@
 /*
- * @name Continous Lines
+ * @name Continuous Lines
  * @description Click and drag the mouse to draw a line.
  */
 function setup() {


### PR DESCRIPTION
Fixes #1049 

 Changes: 
added the missing "u" in continuous https://p5js.org/examples/drawing-continous-lines.html

<img width="982" alt="Screen Shot 2021-07-06 at 3 29 09 PM" src="https://user-images.githubusercontent.com/78124298/124674080-eaae6a80-de6e-11eb-8cc2-bf39dc6349b5.png">
<img width="1062" alt="Screen Shot 2021-07-06 at 3 29 20 PM" src="https://user-images.githubusercontent.com/78124298/124674099-f0a44b80-de6e-11eb-8ad2-67f7f7ed6b5a.png">



 