### PR TITLE
Fix reference footer link to use npm generated git tags

### DIFF
--- a/src/assets/js/reference.js
+++ b/src/assets/js/reference.js
@@ -2451,7 +2451,7 @@ define('text!tpl/item.html',[],function () { return '<h2><%=item.name%><% if (it
 define('text!tpl/class.html',[],function () { return '\n<% if (typeof constructor !== \'undefined\') { %>\n<div class="constructor">\n  <%=constructor%>\n</div>\n<% } %>\n\n<% let fields = _.filter(things, function(item) { return item.itemtype === \'property\' && item.access !== \'private\' }); %>\n<% if (fields.length > 0) { %>\n  <h3 id=\'reference-fields\'>Fields</h3>\n  <ul aria-labelledby=\'reference-fields\'>\n  <% _.each(fields, function(item) { %>\n    <li>\n      <div class=\'paramname\'><a href="<%=item.hash%>" <% if (item.module !== module) { %>class="addon"<% } %>><%=item.name%></a></div>\n      <div class=\'paramtype\'><%= item.description %></div>\n    </li>\n  <% }); %>\n  </ul>\n<% } %>\n\n<% let methods = _.filter(things, function(item) { return item.itemtype === \'method\' && item.access !== \'private\' }); %>\n<% if (methods.length > 0) { %>\n  <h3 id=\'reference-methods\'>Methods</h3>\n  <ul aria-labelledby=\'reference-methods\'>\n    <% _.each(methods, function(item) { %>\n      <li>\n        <div class=\'paramname\'><a href="<%=item.hash%>" <% if (item.module !== module) { %>class="addon"<% } %>><%=item.name%><% if (item.itemtype === \'method\') { %>()<%}%></a></div>\n        <div class=\'paramtype\'><%= item.description %></div>\n      </li>\n    <% }); %>\n  </ul>\n<% } %>\n';});
 
 
-define('text!tpl/itemEnd.html',[],function () { return '\n<br><br>\n\n<div>\n<% if (item.file && item.line) { %>\n<span id="reference-error1">Notice any errors or typos?</span> <a href="https://github.com/processing/p5.js/issues"><span id="reference-contribute2">Please let us know.</span></a> <span id="reference-error3">Please feel free to edit</span> <a href="https://github.com/processing/p5.js/blob/<%= appVersion %>/<%= item.file %>#L<%= item.line %>" target="_blank" ><%= item.file %></a> <span id="reference-error5">and issue a pull request!</span>\n<% } %>\n</div>\n\n<a style="border-bottom:none !important;" href="http://creativecommons.org/licenses/by-nc-sa/4.0/" target=_blank><img src="https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png" style="width:88px" alt="creative commons logo"/></a>\n<br><br>\n';});
+define('text!tpl/itemEnd.html',[],function () { return '\n<br><br>\n\n<div>\n<% if (item.file && item.line) { %>\n<span id="reference-error1">Notice any errors or typos?</span> <a href="https://github.com/processing/p5.js/issues"><span id="reference-contribute2">Please let us know.</span></a> <span id="reference-error3">Please feel free to edit</span> <a href="https://github.com/processing/p5.js/blob/v<%= appVersion %>/<%= item.file %>#L<%= item.line %>" target="_blank" ><%= item.file %></a> <span id="reference-error5">and issue a pull request!</span>\n<% } %>\n</div>\n\n<a style="border-bottom:none !important;" href="http://creativecommons.org/licenses/by-nc-sa/4.0/" target=_blank><img src="https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png" style="width:88px" alt="creative commons logo"/></a>\n<br><br>\n';});
 
 // Copyright (C) 2006 Google Inc.
 //
@@ -4122,7 +4122,7 @@ define('itemView',[
 ], function(App, itemTpl, classTpl, endTpl) {
   'use strict';
 
-  var appVersion = App.project.version ? 'v' + App.project.version : 'master';
+  var appVersion = App.project.version || 'master';
 
   var itemView = Backbone.View.extend({
     el: '#item',

--- a/src/assets/js/reference.js
+++ b/src/assets/js/reference.js
@@ -4122,7 +4122,7 @@ define('itemView',[
 ], function(App, itemTpl, classTpl, endTpl) {
   'use strict';
 
-  var appVersion = App.project.version || 'master';
+  var appVersion = App.project.version ? 'v' + App.project.version : 'master';
 
   var itemView = Backbone.View.extend({
     el: '#item',

--- a/src/yuidoc-p5-theme-src/scripts/tpl/itemEnd.html
+++ b/src/yuidoc-p5-theme-src/scripts/tpl/itemEnd.html
@@ -3,7 +3,7 @@
 
 <div>
 <% if (item.file && item.line) { %>
-<span id="reference-error1">Notice any errors or typos?</span> <a href="https://github.com/processing/p5.js/issues"><span id="reference-contribute2">Please let us know.</span></a> <span id="reference-error3">Please feel free to edit</span> <a href="https://github.com/processing/p5.js/blob/<%= appVersion %>/<%= item.file %>#L<%= item.line %>" target="_blank" ><%= item.file %></a> <span id="reference-error5">and issue a pull request!</span>
+<span id="reference-error1">Notice any errors or typos?</span> <a href="https://github.com/processing/p5.js/issues"><span id="reference-contribute2">Please let us know.</span></a> <span id="reference-error3">Please feel free to edit</span> <a href="https://github.com/processing/p5.js/blob/v<%= appVersion %>/<%= item.file %>#L<%= item.line %>" target="_blank" ><%= item.file %></a> <span id="reference-error5">and issue a pull request!</span>
 <% } %>
 </div>
 

--- a/src/yuidoc-p5-theme-src/scripts/views/itemView.js
+++ b/src/yuidoc-p5-theme-src/scripts/views/itemView.js
@@ -9,7 +9,7 @@ define([
 ], function(App, itemTpl, classTpl, endTpl) {
   'use strict';
 
-  var appVersion = App.project.version || 'master';
+  var appVersion = App.project.version ? 'v' + App.project.version : 'master';
 
   var itemView = Backbone.View.extend({
     el: '#item',

--- a/src/yuidoc-p5-theme-src/scripts/views/itemView.js
+++ b/src/yuidoc-p5-theme-src/scripts/views/itemView.js
@@ -9,7 +9,7 @@ define([
 ], function(App, itemTpl, classTpl, endTpl) {
   'use strict';
 
-  var appVersion = App.project.version ? 'v' + App.project.version : 'master';
+  var appVersion = App.project.version || 'master';
 
   var itemView = Backbone.View.extend({
     el: '#item',


### PR DESCRIPTION
Fixes #5344

 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Added the "v" prefix to the template footer containing links to where the source code are in the repository. Decided to add it to the template instead of changing the data in javascript in case that value is used elsewhere.