### PR TITLE
Noise2d update

### DIFF
--- a/src/data/examples/en/08_Math/15_Noise2D.js
+++ b/src/data/examples/en/08_Math/15_Noise2D.js
@@ -11,31 +11,41 @@ function setup() {
   createCanvas(640, 360);
 }
 
+function drawNoise(x, y, w, h) {
+  for (let yp = y; yp < y + h; yp++) {
+    let yindex = yp * width;
+    for (let xp = x; xp < x + w; xp++) {
+      let noiseVal =
+        noise((mouseX + xp) * noiseScale, (mouseY + yp) * noiseScale) * 255;
+
+      let xindex = xp;
+      let index = 4 * (yindex + xindex);
+      pixels[index] = noiseVal;
+      pixels[index + 1] = noiseVal;
+      pixels[index + 2] = noiseVal;
+      pixels[index + 3] = 255;
+    }
+  }
+}
+
 function draw() {
   background(0);
+
+  loadPixels();
+
   // Draw the left half of image
-  for (let y = 0; y < height - 30; y++) {
-    for (let x = 0; x < width / 2; x++) {
-      // noiseDetail of the pixels octave count and falloff value
-      noiseDetail(2, 0.2);
-      noiseVal = noise((mouseX + x) * noiseScale, (mouseY + y) * noiseScale);
-      stroke(noiseVal * 255);
-      point(x, y);
-    }
-  }
+  noiseDetail(2, 0.2);
+  drawNoise(0, 0, width / 2, height - 30);
+
   // Draw the right half of image
-  for (let y = 0; y < height - 30; y++) {
-    for (let x = width / 2; x < width; x++) {
-      // noiseDetail of the pixels octave count and falloff value
-      noiseDetail(5, 0.5);
-      noiseVal = noise((mouseX + x) * noiseScale, (mouseY + y) * noiseScale);
-      stroke(noiseVal * 255);
-      point(x, y);
-    }
-  }
+  noiseDetail(5, 0.5);
+  drawNoise(width / 2, 0, width / 2, height - 30);
+
+  updatePixels();
+
   //Show the details of two partitions
   textSize(18);
   fill(255, 255, 255);
-  text('Noise2D with 2 octaves and 0.2 falloff', 10, 350);
-  text('Noise2D with 5 octaves and 0.5 falloff', 330, 350);
+  text("Noise2D with 2 octaves and 0.2 falloff", 10, 350);
+  text("Noise2D with 5 octaves and 0.5 falloff", 330, 350);
 }

--- a/src/data/examples/en/08_Math/15_Noise2D.js
+++ b/src/data/examples/en/08_Math/15_Noise2D.js
@@ -2,7 +2,6 @@
  * @name Noise2D
  * @frame 710,400 (optional)
  * @description Create a 2D noise with different parameters.
- *
  */
 
 let noiseVal;
@@ -38,5 +37,5 @@ function draw() {
   textSize(18);
   fill(255, 255, 255);
   text('Noise2D with 2 octaves and 0.2 falloff', 10, 350);
-  text('Noise2D with 1 octaves and 0.7 falloff', 330, 350);
+  text('Noise2D with 5 octaves and 0.5 falloff', 330, 350);
 }

--- a/src/data/examples/en/08_Math/15_Noise2D.js
+++ b/src/data/examples/en/08_Math/15_Noise2D.js
@@ -43,7 +43,7 @@ function draw() {
 
   updatePixels();
 
-  //Show the details of two partitions
+  //Show the details of each partition
   textSize(18);
   fill(255, 255, 255);
   text("Noise2D with 2 octaves and 0.2 falloff", 10, 350);

--- a/src/data/examples/en/08_Math/15_Noise2D.js
+++ b/src/data/examples/en/08_Math/15_Noise2D.js
@@ -4,25 +4,24 @@
  * @description Create a 2D noise with different parameters.
  */
 
-let noiseVal;
-let noiseScale = 0.02;
+let noise_val;
+let noise_scale = 0.02;
 
 function setup() {
   createCanvas(640, 360);
 }
 
 function drawNoise(x, y, w, h) {
-  for (let yp = y; yp < y + h; yp++) {
-    let yindex = yp * width;
-    for (let xp = x; xp < x + w; xp++) {
-      let noiseVal =
-        noise((mouseX + xp) * noiseScale, (mouseY + yp) * noiseScale) * 255;
+  for (let pixel_y = y; pixel_y < y + h; pixel_y++) {
+    for (let pixel_x = x; pixel_x < x + w; pixel_x++) {
+      let noise_val =
+        noise((mouseX + pixel_x) * noise_scale, (mouseY + pixel_y) * noise_scale) * 255;
 
-      let xindex = xp;
-      let index = 4 * (yindex + xindex);
-      pixels[index] = noiseVal;
-      pixels[index + 1] = noiseVal;
-      pixels[index + 2] = noiseVal;
+      let index = 4 * (pixel_y * width + pixel_x);
+
+      pixels[index]     = noise_val;
+      pixels[index + 1] = noise_val;
+      pixels[index + 2] = noise_val;
       pixels[index + 3] = 255;
     }
   }
@@ -43,7 +42,7 @@ function draw() {
 
   updatePixels();
 
-  //Show the details of each partition
+  //Show the details of two partitions
   textSize(18);
   fill(255, 255, 255);
   text("Noise2D with 2 octaves and 0.2 falloff", 10, 350);

--- a/src/data/examples/en/08_Math/15_Noise2D.js
+++ b/src/data/examples/en/08_Math/15_Noise2D.js
@@ -4,24 +4,24 @@
  * @description Create a 2D noise with different parameters.
  */
 
-let noise_val;
-let noise_scale = 0.02;
+let noiseVal;
+let noiseScale = 0.02;
 
 function setup() {
   createCanvas(640, 360);
 }
 
 function drawNoise(x, y, w, h) {
-  for (let pixel_y = y; pixel_y < y + h; pixel_y++) {
-    for (let pixel_x = x; pixel_x < x + w; pixel_x++) {
-      let noise_val =
-        noise((mouseX + pixel_x) * noise_scale, (mouseY + pixel_y) * noise_scale) * 255;
+  for (let pixelY = y; pixelY < y + h; pixelY++) {
+    for (let pixelX = x; pixelX < x + w; pixelX++) {
+      let noiseVal =
+        noise((mouseX + pixelX) * noiseScale, (mouseY + pixelY) * noiseScale) * 255;
 
-      let index = 4 * (pixel_y * width + pixel_x);
+      let index = 4 * (pixelY * width + pixelX);
 
-      pixels[index]     = noise_val;
-      pixels[index + 1] = noise_val;
-      pixels[index + 2] = noise_val;
+      pixels[index]     = noiseVal;
+      pixels[index + 1] = noiseVal;
+      pixels[index + 2] = noiseVal;
       pixels[index + 3] = 255;
     }
   }


### PR DESCRIPTION
Fixes #1047

 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
* Remove extra * (asterisk) in description comment
* Change text description for second noise example matches actual parameters used.
* Increase framerate of example by writing to the pixels array.

The original version:
[Noise2D Example at 2 SPF (Seconds Per Frame)](https://editor.p5js.org/TakeshiYano/sketches/ZbAcvtNdJ)

The faster version:
[Noise2d Pull](https://editor.p5js.org/TakeshiYano/sketches/ZbAcvtNdJ)

 Screenshots of the change: 
<!-- Add screenshots depicting the changes. -->
It should look the same, just faster.