### PR TITLE
Add aria label 1056

### DIFF
--- a/contributor_docs/Adding_examples.md
+++ b/contributor_docs/Adding_examples.md
@@ -35,6 +35,7 @@ Examples help demonstrate different programming concepts and functionality of th
    /*
     * @name Your Example Name Here (This shows up on the examples page as well.)
     * @frame 710,400 (optional)
+    * @arialabel If there is a frame, add more context to its relation to the description and code for users interacting with your example with a screen reader. 
     * @description Write a description of your example here. This gets displayed
     * on the page underneath your example. You can use <br><br> to add a line
     * break. Please limit lines to 80 columns (total characters) long.

--- a/src/assets/js/examples.js
+++ b/src/assets/js/examples.js
@@ -68,7 +68,7 @@ var examples = {
       // render?
       var norender = data.indexOf('@norender') !== -1;
 
-      // parse and set name and description
+      // parse and set name, aria label, and description
       var metaReg = new RegExp('\\* ', 'g');
       var spaceReg = new RegExp(' ', 'g');
 
@@ -76,6 +76,11 @@ var examples = {
       var endName = data.indexOf("\n", startName);
 
       var name = startName !== 5 ? data.substring(startName, endName) : '';
+
+      var startAriaLabel = data.indexOf("@arialabel")+11;
+      var endAriaLabel = data.indexOf("\n", startAriaLabel);
+
+      var ariaLabel = startAriaLabel !== 10 ? data.substring(startAriaLabel, endAriaLabel) : '';
 
       var startDesc = data.indexOf("@description")+13;
       var endDesc = data.indexOf("*/", startDesc);
@@ -85,6 +90,7 @@ var examples = {
 
       $('#example-name').html(name);
       $('#example-desc').html(desc);
+      $('#exampleFrame').attr("aria-label", ariaLabel);
 
       // strip description and set code
       var ind = data.indexOf('*/');

--- a/src/data/examples/build_examples/example_template.ejs
+++ b/src/data/examples/build_examples/example_template.ejs
@@ -34,7 +34,7 @@ slug: examples/
         <div id="exampleEditor"></div>
 
 
-        <iframe id="exampleFrame" src="{{assets}}/examples/example.html" ></iframe>
+        <iframe id="exampleFrame" src="{{assets}}/examples/example.html" aria-label="example arialabel placeholder" ></iframe>
       </div>
 
       <p><a style="border-bottom:none !important;" href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target=_blank><img src="https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png" alt="creative commons license" style="width:88px"/></a></p>


### PR DESCRIPTION
Fixes #1056 

 Changes: 
Adding the ability to add an aria label to the iFrame within the Examples pages 


 Screenshots of the change: 
![Screen Shot 2021-07-13 at 11 12 17 AM](https://user-images.githubusercontent.com/43053081/125477455-8a83b976-ef99-4170-9593-1960d417424e.png)
<img width="1326" alt="recursion examples page with the developer console open. The iframe is labeled with an aria label tag. " src="https://user-images.githubusercontent.com/43053081/125477468-10902aea-21f0-419a-9588-2c87cd9754f1.png">
