### PR TITLE
Fix #1063

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3108,6 +3108,12 @@
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
           "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
           "dev": true
+        },
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
         }
       }
     },
@@ -12290,9 +12296,9 @@
       }
     },
     "map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
+      "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
       "dev": true
     },
     "map-schema": {
@@ -12510,6 +12516,14 @@
         "read-pkg-up": "^1.0.1",
         "redent": "^1.0.0",
         "trim-newlines": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
+        }
       }
     },
     "merge-deep": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "lint-staged": "^9.5.0",
     "load-grunt-tasks": "^5.1.0",
     "lodash": "^4.17.21",
+    "map-obj": "^4.2.1",
     "marked": "^0.8.2",
     "moment": "^2.29.1",
     "ms": "^0.7.3",


### PR DESCRIPTION
Fixes #1063

 Changes: 
Add workaround to the [function](https://github.com/processing/p5.js-website/blob/main/updatei18nFiles.js#L7) that updates the translated i18n files for the website's Reference section.

As mentioned in Issue #1063, the function failed to include the `toString()` methods from the `p5.Vector` and `p5.Color` classes in the translated i18n files when it compared them to the English version.
This was caused by a conflict between the name of the p5.js method and the homonym JavaScript native method, that happens when applying the [`unflatten`](https://github.com/processing/p5.js-website/blob/main/updatei18nFiles.js#L26) method.

I added a prefix (`_`) to each key in the i18n files before flattening them, and then removed it after unflattering them. This way the `unflatten()` method does not get confused by the `toString` key (because it's transformed to `_toString`).
I used the `map-obj` library to remove the prefix from all the keys after the unflattening.

