### PR TITLE
Fix some p5.js methods' descriptions in the translated Reference i18n files

### DIFF
--- a/src/data/reference/es.json
+++ b/src/data/reference/es.json
@@ -1472,7 +1472,7 @@
     },
     "createDiv": {
       "description": [
-        "Creates a <div></div> element in the DOM with given inner HTML."
+        "Creates a <code>&lt;div&gt;&lt;/div&gt;</code> element in the DOM with given inner HTML."
       ],
       "returns": "p5.Element: pointer to <a href=\"#/p5.Element\">p5.Element</a> holding created node",
       "params": {
@@ -1490,7 +1490,7 @@
     },
     "createSpan": {
       "description": [
-        "Creates a <span></span> element in the DOM with given inner HTML."
+        "Creates a <code>&lt;span&gt;&lt;/span&gt;</code> element in the DOM with given inner HTML."
       ],
       "returns": "p5.Element: pointer to <a href=\"#/p5.Element\">p5.Element</a> holding created node",
       "params": {
@@ -1499,7 +1499,7 @@
     },
     "createImg": {
       "description": [
-        "Creates an <img> element in the DOM with given src and alternate text."
+        "Creates an <code>&lt;img&gt;</code> element in the DOM with given src and alternate text."
       ],
       "returns": "p5.Element: pointer to <a href=\"#/p5.Element\">p5.Element</a> holding created node",
       "params": {
@@ -1511,7 +1511,7 @@
     },
     "createA": {
       "description": [
-        "Creates an <a></a> element in the DOM for including a hyperlink."
+        "Creates an <code>&lt;a&gt;&lt;/a&gt;</code> element in the DOM for including a hyperlink."
       ],
       "returns": "p5.Element: pointer to <a href=\"#/p5.Element\">p5.Element</a> holding created node",
       "params": {
@@ -1522,7 +1522,7 @@
     },
     "createSlider": {
       "description": [
-        "Creates a slider <input></input> element in the DOM. Use .size() to set the display length of the slider."
+        "Creates a slider <code>&lt;input&gt;&lt;/input&gt;</code> element in the DOM. Use .size() to set the display length of the slider."
       ],
       "returns": "p5.Element: pointer to <a href=\"#/p5.Element\">p5.Element</a> holding created node",
       "params": {
@@ -1534,7 +1534,7 @@
     },
     "createButton": {
       "description": [
-        "Creates a <button></button> element in the DOM. Use .size() to set the display size of the button. Use .mousePressed() to specify behavior on press."
+        "Creates a <code>&lt;button&gt;&lt;/button&gt;</code> element in the DOM. Use .size() to set the display size of the button. Use .mousePressed() to specify behavior on press."
       ],
       "returns": "p5.Element: pointer to <a href=\"#/p5.Element\">p5.Element</a> holding created node",
       "params": {
@@ -1544,7 +1544,7 @@
     },
     "createCheckbox": {
       "description": [
-        "Creates a checkbox <input></input> element in the DOM. Calling .checked() on a checkbox returns if it is checked or not"
+        "Creates a checkbox <code>&lt;input&gt;&lt;/input&gt;</code> element in the DOM. Calling .checked() on a checkbox returns if it is checked or not"
       ],
       "returns": "p5.Element: pointer to <a href=\"#/p5.Element\">p5.Element</a> holding created node",
       "params": {
@@ -1554,7 +1554,7 @@
     },
     "createSelect": {
       "description": [
-        "Creates a dropdown menu <select></select> element in the DOM. It also helps to assign select-box methods to <a href=\"#/p5.Element\">p5.Element</a> when selecting existing select box. <ul> <li><code>.option(name, [value])</code> can be used to set options for the select after it is created.</li> <li><code>.value()</code> will return the currently selected option.</li> <li><code>.selected()</code> will return current dropdown element which is an instance of <a href=\"#/p5.Element\">p5.Element</a></li> <li><code>.selected(value)</code> can be used to make given option selected by default when the page first loads.</li> <li><code>.disable()</code> marks whole of dropdown element as disabled.</li> <li><code>.disable(value)</code> marks given option as disabled</li> </ul>"
+        "Creates a dropdown menu <code>&lt;select&gt;&lt;/select&gt;</code>s element in the DOM. It also helps to assign select-box methods to <a href=\"#/p5.Element\">p5.Element</a> when selecting existing select box. <ul> <li><code>.option(name, [value])</code> can be used to set options for the select after it is created.</li> <li><code>.value()</code> will return the currently selected option.</li> <li><code>.selected()</code> will return current dropdown element which is an instance of <a href=\"#/p5.Element\">p5.Element</a></li> <li><code>.selected(value)</code> can be used to make given option selected by default when the page first loads.</li> <li><code>.disable()</code> marks whole of dropdown element as disabled.</li> <li><code>.disable(value)</code> marks given option as disabled</li> </ul>"
       ],
       "returns": "p5.Element: ",
       "params": {
@@ -1583,7 +1583,7 @@
     },
     "createInput": {
       "description": [
-        "Creates an <input></input> element in the DOM for text input. Use .<a href=\"#/p5.Element/size\">size()</a> to set the display length of the box."
+        "Creates an <code>&lt;input&gt;&lt;/input&gt;</code> element in the DOM for text input. Use .<a href=\"#/p5.Element/size\">size()</a> to set the display length of the box."
       ],
       "returns": "p5.Element: pointer to <a href=\"#/p5.Element\">p5.Element</a> holding created node",
       "params": {
@@ -1593,7 +1593,7 @@
     },
     "createFileInput": {
       "description": [
-        "Creates an <input></input> element in the DOM of type 'file'. This allows users to select local files for use in a sketch."
+        "Creates an <code>&lt;input&gt;&lt;/input&gt;</code> element in the DOM of type 'file'. This allows users to select local files for use in a sketch."
       ],
       "returns": "p5.Element: pointer to <a href=\"#/p5.Element\">p5.Element</a> holding created DOM element",
       "params": {
@@ -1603,7 +1603,7 @@
     },
     "createVideo": {
       "description": [
-        "Creates an HTML5 <video> element in the DOM for simple playback of audio/video. Shown by default, can be hidden with .<a href=\"#/p5.Element/hide\">hide()</a> and drawn into canvas using <a href=\"#/p5/image\">image()</a>. The first parameter can be either a single string path to a video file, or an array of string paths to different formats of the same video. This is useful for ensuring that your video can play across different browsers, as each supports different formats. See <a href='https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats'>this page</a> for further information about supported formats."
+        "Creates an HTML5 <code>&lt;video&gt;</code> element in the DOM for simple playback of audio/video. Shown by default, can be hidden with .<a href=\"#/p5.Element/hide\">hide()</a> and drawn into canvas using <a href=\"#/p5/image\">image()</a>. The first parameter can be either a single string path to a video file, or an array of string paths to different formats of the same video. This is useful for ensuring that your video can play across different browsers, as each supports different formats. See <a href='https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats'>this page</a> for further information about supported formats."
       ],
       "returns": "p5.MediaElement: pointer to video <a href=\"#/p5.Element\">p5.Element</a>",
       "params": {
@@ -1613,7 +1613,7 @@
     },
     "createAudio": {
       "description": [
-        "Creates a hidden HTML5 <audio> element in the DOM for simple audio playback. The first parameter can be either a single string path to a audio file, or an array of string paths to different formats of the same audio. This is useful for ensuring that your audio can play across different browsers, as each supports different formats. See <a href='https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats'>this page for further information about supported formats</a>."
+        "Creates a hidden HTML5 <code>&lt;audio&gt;</code> element in the DOM for simple audio playback. The first parameter can be either a single string path to a audio file, or an array of string paths to different formats of the same audio. This is useful for ensuring that your audio can play across different browsers, as each supports different formats. See <a href='https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats'>this page for further information about supported formats</a>."
       ],
       "returns": "p5.MediaElement: pointer to audio <a href=\"#/p5.Element\">p5.Element</a>",
       "params": {
@@ -1625,7 +1625,7 @@
     "AUDIO": {},
     "createCapture": {
       "description": [
-        "Creates a new HTML5 <video> element that contains the audio/video feed from a webcam. The element is separate from the canvas and is displayed by default. The element can be hidden using .<a href=\"#/p5.Element/hide\">hide()</a>. The feed can be drawn onto the canvas using <a href=\"#/p5/image\">image()</a>. The loadedmetadata property can be used to detect when the element has fully loaded (see second example). ",
+        "Creates a new HTML5 <code>&lt;video&gt;</code> element that contains the audio/video feed from a webcam. The element is separate from the canvas and is displayed by default. The element can be hidden using .<a href=\"#/p5.Element/hide\">hide()</a>. The feed can be drawn onto the canvas using <a href=\"#/p5/image\">image()</a>. The loadedmetadata property can be used to detect when the element has fully loaded (see second example). ",
         "More specific properties of the feed can be passing in a Constraints object. See the <a href='http://w3c.github.io/mediacapture-main/getusermedia.html#media-track-constraints'> W3C spec</a> for possible properties. Note that not all of these are supported by all browsers. ",
         "<em>Security note</em>: A new browser security specification requires that getUserMedia, which is behind <a href=\"#/p5/createCapture\">createCapture()</a>, only works when you're running the code locally, or on HTTPS. Learn more <a href='http://stackoverflow.com/questions/34197653/getusermedia-in-chrome-47-without-using-https'>here</a> and <a href='https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia'>here</a>."
       ],

--- a/src/data/reference/es.json
+++ b/src/data/reference/es.json
@@ -1481,7 +1481,7 @@
     },
     "createP": {
       "description": [
-        "Creates a "
+        "Creates a <code>&lt;p&gt;&lt;/p&gt;</code> element in the DOM with given inner HTML. Used for paragraph length text."
       ],
       "returns": "p5.Element: pointer to <a href=\"#/p5.Element\">p5.Element</a> holding created node",
       "params": {

--- a/src/data/reference/ko.json
+++ b/src/data/reference/ko.json
@@ -1472,7 +1472,7 @@
     },
     "createDiv": {
       "description": [
-        "주어진 내부 HTML을 사용하여 DOM에 <div></div> 요소를 생성합니다."
+        "주어진 내부 HTML을 사용하여 DOM에 <code>&lt;div&gt;&lt;/div&gt;</code> 요소를 생성합니다."
       ],
       "returns": "p5.Element: 생성된 노드를 담고있는 p5.Element에 대한 포인터",
       "params": {
@@ -1481,7 +1481,7 @@
     },
     "createP": {
       "description": [
-        "주어진 내부 HTML을 사용하여 DOM에 <p></p> 요소를 생성합니다. 문단형 텍스트 작성시 사용됩니다."
+        "주어진 내부 HTML을 사용하여 DOM에 <code>&lt;p&gt;&lt;/p&gt;</code> 요소를 생성합니다. 문단형 텍스트 작성시 사용됩니다."
       ],
       "returns": "p5.Element: 생성된 노드를 담고있는 p5.Element에 대한 포인터",
       "params": {
@@ -1490,7 +1490,7 @@
     },
     "createSpan": {
       "description": [
-        "주어진 내부 HTML을 사용하여 DOM에 <span></span> 요소를 생성합니다."
+        "주어진 내부 HTML을 사용하여 DOM에 <code>&lt;span&gt;&lt;/span&gt;</code> 요소를 생성합니다."
       ],
       "returns": "p5.Element: 생성된 노드를 담고있는 p5.Element에 대한 포인터",
       "params": {
@@ -1499,7 +1499,7 @@
     },
     "createImg": {
       "description": [
-        "주어진 src와 대체 텍스트(alt text)를 사용하여 DOM에 <img> 요소를 생성합니다."
+        "주어진 src와 대체 텍스트(alt text)를 사용하여 DOM에 <code>&lt;img&gt;</code> 요소를 생성합니다."
       ],
       "returns": "p5.Element: 생성된 노드를 담고있는 p5.Element에 대한 포인터",
       "params": {
@@ -1511,7 +1511,7 @@
     },
     "createA": {
       "description": [
-        "DOM에 하이퍼링크를 포함한 <a></a> 요소를 생성합니다."
+        "DOM에 하이퍼링크를 포함한 <code>&lt;a&gt;&lt;/a&gt;</code> 요소를 생성합니다."
       ],
       "returns": "p5.Element: 생성된 노드를 담고있는 p5.Element에 대한 포인터",
       "params": {
@@ -1522,7 +1522,7 @@
     },
     "createSlider": {
       "description": [
-        "DOM에 슬라이더<input></input> 요소를 생성합니다. .size() 함수로 슬라이더의 길이를 설정합니다."
+        "DOM에 슬라이더 <code>&lt;input&gt;&lt;/input&gt;</code> 요소를 생성합니다. .size() 함수로 슬라이더의 길이를 설정합니다."
       ],
       "returns": "p5.Element: 생성된 노드를 담고있는 p5.Element에 대한 포인터",
       "params": {
@@ -1534,7 +1534,7 @@
     },
     "createButton": {
       "description": [
-        "DOM에 <button></button> 요소를 생성합니다. .size() 함수로 버튼의 크기를 설정합니다. .mousePressed() 함수로 버튼이 클릭됐을 때의 행동을 지정합니다."
+        "DOM에 <code>&lt;button&gt;&lt;/button&gt;</code> 요소를 생성합니다. .size() 함수로 버튼의 크기를 설정합니다. .mousePressed() 함수로 버튼이 클릭됐을 때의 행동을 지정합니다."
       ],
       "returns": "p5.Element: 생성된 노드를 담고있는 p5.Element에 대한 포인터",
       "params": {
@@ -1544,7 +1544,7 @@
     },
     "createCheckbox": {
       "description": [
-        "DOM에 체크박스<input></input> 요소를 생성합니다. .checked() 함수를 통해 체크되었는지의 여부를 반환합니다."
+        "DOM에 체크박스 <code>&lt;input&gt;&lt;/input&gt;</code> 요소를 생성합니다. .checked() 함수를 통해 체크되었는지의 여부를 반환합니다."
       ],
       "returns": "p5.Element: 생성된 노드를 담고있는 p5.Element에 대한 포인터",
       "params": {
@@ -1554,7 +1554,7 @@
     },
     "createSelect": {
       "description": [
-        "DOM에 드롭다운 메뉴<select></select> 요소를 생성합니다. 이미 생성된 셀렉트 박스(select box)를 선택할 경우, p5.Element에 select-box 메소드를 지정하는 데에도 쓰입니다. 셀렉트 박스 생성 후, .option() 메소드로 선택지(option)를 설정할 수 있습니다. .selected() 메소드는 p5.Element 인스턴스인 현재 드롭다운 요소를 반환합니다. .selected() 메소드는 특정 선택지를 최초 페이지 로드시의 기본값으로서 설정할 수 있습니다. .disable() 메소드는 특정 선택지를 비활성화하고, 별도로 지정된 인수가 없는 경우엔 전체 드롭다운 요소를 비활성화 상태로 표시합니다."
+        "DOM에 드롭다운 메뉴<code>&lt;select&gt;&lt;/select&gt;</code> 요소를 생성합니다. 이미 생성된 셀렉트 박스(select box)를 선택할 경우, p5.Element에 select-box 메소드를 지정하는 데에도 쓰입니다. 셀렉트 박스 생성 후, .option() 메소드로 선택지(option)를 설정할 수 있습니다. .selected() 메소드는 p5.Element 인스턴스인 현재 드롭다운 요소를 반환합니다. .selected() 메소드는 특정 선택지를 최초 페이지 로드시의 기본값으로서 설정할 수 있습니다. .disable() 메소드는 특정 선택지를 비활성화하고, 별도로 지정된 인수가 없는 경우엔 전체 드롭다운 요소를 비활성화 상태로 표시합니다."
       ],
       "returns": "p5.Element",
       "params": {
@@ -1564,7 +1564,7 @@
     },
     "createRadio": {
       "description": [
-        "DOM에 라디오 버튼<input></input> 요소를 생성합니다. 라디오 버튼 생성 후, .option() 메소드로 옵션을 설정할 수 있습니다. .value() 메소드는 현재 선택된 옵션을 반환합니다."
+        "DOM에 라디오 버튼 <code>&lt;input&gt;&lt;/input&gt;</code> 요소를 생성합니다. 라디오 버튼 생성 후, .option() 메소드로 옵션을 설정할 수 있습니다. .value() 메소드는 현재 선택된 옵션을 반환합니다."
       ],
       "returns": "p5.Element: 생성된 노드를 담고있는 p5.Element에 대한 포인터",
       "params": {
@@ -1583,7 +1583,7 @@
     },
     "createInput": {
       "description": [
-        "DOM에 텍스트 입력을 위한 <input></input> 요소를 생성합니다. .size() 함수로 상자의 크기를 설정합니다."
+        "DOM에 텍스트 입력을 위한 <code>&lt;input&gt;&lt;/input&gt;</code> 요소를 생성합니다. .size() 함수로 상자의 크기를 설정합니다."
       ],
       "returns": "p5.Element: 생성된 노드를 담고있는 p5.Element에 대한 포인터",
       "params": {
@@ -1593,7 +1593,7 @@
     },
     "createFileInput": {
       "description": [
-        "'파일(file)' 유형의 DOM에 <input></input> 요소를 생성합니다. 스케치에 사용할 로컬 파일을 선택할 수 있게 됩니다."
+        "'파일(file)' 유형의 DOM에 <code>&lt;input&gt;&lt;/input&gt;</code> 요소를 생성합니다. 스케치에 사용할 로컬 파일을 선택할 수 있게 됩니다."
       ],
       "returns": "p5.Element: 생성된 DOM 요소를 담고있는 p5.Element에 대한 포인터",
       "params": {
@@ -1603,7 +1603,7 @@
     },
     "createVideo": {
       "description": [
-        "DOM에 간단한 오디오/비디오 재생을 위한 HTML5 <video> 요소를 생성합니다. 화면에 나타나기가 기본값이며, .hide()로 숨길 수 있습니다. video() 함수를 통해 캔버스에 그릴 수 있습니다. 1번째 매개변수는 비디오 파일에 대한 단일 문자열 경로이거나, 또는 동일한 비디오 파일이 여러 개의 형식을 갖는 경우, 문자열 경로들의 배열로 지정됩니다. 특히, 다양한 파일 형식을 지정하여 여러 종류의 브라우저에서 재생될 수 있도록 하는 데에 용이합니다. 지원되는 파일 형식에 대한 자세한 내용은 <a href = 'https://developer.mozilla.org/en-US/docs/Web/Media/Formats'>이 페이지</a>를 참고하세요. "
+        "DOM에 간단한 오디오/비디오 재생을 위한 HTML5 <code>&lt;video&gt;</code> 요소를 생성합니다. 화면에 나타나기가 기본값이며, .hide()로 숨길 수 있습니다. video() 함수를 통해 캔버스에 그릴 수 있습니다. 1번째 매개변수는 비디오 파일에 대한 단일 문자열 경로이거나, 또는 동일한 비디오 파일이 여러 개의 형식을 갖는 경우, 문자열 경로들의 배열로 지정됩니다. 특히, 다양한 파일 형식을 지정하여 여러 종류의 브라우저에서 재생될 수 있도록 하는 데에 용이합니다. 지원되는 파일 형식에 대한 자세한 내용은 <a href = 'https://developer.mozilla.org/en-US/docs/Web/Media/Formats'>이 페이지</a>를 참고하세요. "
       ],
       "returns": "p5.MediaElement: 비디오 p5.Element에 대한 포인터",
       "params": {
@@ -1613,7 +1613,7 @@
     },
     "createAudio": {
       "description": [
-        "DOM에 간단한 오디오 재생을 위한 HTML5 <audio> 요소를 생성합니다. 1번째 매개변수는 오디오 파일에 대한 단일 문자열 경로이거나, 또는 동일한 오디오 파일이 여러 개의 형식을 갖는 경우, 문자열 경로들의 배열로 지정됩니다. 특히, 다양한 파일 형식을 지정하여 여러 종류의 브라우저에서 재생될 수 있도록 하는 데에 용이합니다. 지원되는 파일 형식에 대한 자세한 내용은 <a href = 'https://developer.mozilla.org/en-US/docs/Web/Media/Formats'>이 페이지</a>를 참고하세요. "
+        "DOM에 간단한 오디오 재생을 위한 HTML5 <code>&lt;audio&gt;</code> 요소를 생성합니다. 1번째 매개변수는 오디오 파일에 대한 단일 문자열 경로이거나, 또는 동일한 오디오 파일이 여러 개의 형식을 갖는 경우, 문자열 경로들의 배열로 지정됩니다. 특히, 다양한 파일 형식을 지정하여 여러 종류의 브라우저에서 재생될 수 있도록 하는 데에 용이합니다. 지원되는 파일 형식에 대한 자세한 내용은 <a href = 'https://developer.mozilla.org/en-US/docs/Web/Media/Formats'>이 페이지</a>를 참고하세요. "
       ],
       "returns": "p5.MediaElement: 오디오 p5.Element에 대한 포인터",
       "params": {
@@ -1625,7 +1625,7 @@
     "AUDIO": {},
     "createCapture": {
       "description": [
-        "웹캠의 오디오/비디오 피드를 담는 <video> 요소를 생성합니다. 이 요소는 캔버스와는 별개로 작동합니다. '화면에 나타내기'가 기본값으로 주어지며, .hide()를 사용하여 화면으로부터 숨길 수 있습니다. image() 함수를 사용하여 피드를 캔버스에 그릴 수 있습니다. loadedmetadata 속성을 사용하여 요소가 완전히 로드된 시점을 감지할 수 있습니다. (2번째 예제 참고)<br><br> 피드의 구체적인 속성은 제약 조건(Constraints) 객체를 전달할 수 있습니다. 속성 및 제약 조건 객체와 관련해서는 <a href = 'https://w3c.github.io/mediacapture-main/getusermedia.html#media-track-constraints'>W3C 사양</a>을 참고하세요. 모든 브라우저가 이 기능을 지원하지 않는 점에 유의하세요.<br><br>보안 정보: 최신 브라우저 보안 사양은 createCapture() 이면의 getUserMedia() 메소드가 로컬 또는 HTTPS에서 코드 실행시에만 작동할 것을 요구합니다. 자세한 사항은 <a href = 'https://stackoverflow.com/questions/34197653/getusermedia-in-chrome-47-without-using-https'>여기</a>와 <a href = 'https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia'>여기</a>서 확인하세요. ",
+        "웹캠의 오디오/비디오 피드를 담는 <code>&lt;video&gt;</code> 요소를 생성합니다. 이 요소는 캔버스와는 별개로 작동합니다. '화면에 나타내기'가 기본값으로 주어지며, .hide()를 사용하여 화면으로부터 숨길 수 있습니다. image() 함수를 사용하여 피드를 캔버스에 그릴 수 있습니다. loadedmetadata 속성을 사용하여 요소가 완전히 로드된 시점을 감지할 수 있습니다. (2번째 예제 참고)<br><br> 피드의 구체적인 속성은 제약 조건(Constraints) 객체를 전달할 수 있습니다. 속성 및 제약 조건 객체와 관련해서는 <a href = 'https://w3c.github.io/mediacapture-main/getusermedia.html#media-track-constraints'>W3C 사양</a>을 참고하세요. 모든 브라우저가 이 기능을 지원하지 않는 점에 유의하세요.<br><br>보안 정보: 최신 브라우저 보안 사양은 createCapture() 이면의 getUserMedia() 메소드가 로컬 또는 HTTPS에서 코드 실행시에만 작동할 것을 요구합니다. 자세한 사항은 <a href = 'https://stackoverflow.com/questions/34197653/getusermedia-in-chrome-47-without-using-https'>여기</a>와 <a href = 'https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia'>여기</a>서 확인하세요. ",
         "",
         ""
       ],

--- a/src/data/reference/zh-Hans.json
+++ b/src/data/reference/zh-Hans.json
@@ -1481,7 +1481,7 @@
     },
     "createP": {
       "description": [
-        "Creates a "
+        "Creates a <code>&lt;p&gt;&lt;/p&gt;</code> element in the DOM with given inner HTML. Used for paragraph length text."
       ],
       "returns": "p5.Element: pointer to <a href=\"#/p5.Element\">p5.Element</a> holding created node",
       "params": {

--- a/src/data/reference/zh-Hans.json
+++ b/src/data/reference/zh-Hans.json
@@ -1472,7 +1472,7 @@
     },
     "createDiv": {
       "description": [
-        "Creates a <div></div> element in the DOM with given inner HTML."
+        "Creates a <code>&lt;div&gt;&lt;/div&gt;</code> element in the DOM with given inner HTML."
       ],
       "returns": "p5.Element: pointer to <a href=\"#/p5.Element\">p5.Element</a> holding created node",
       "params": {
@@ -1490,7 +1490,7 @@
     },
     "createSpan": {
       "description": [
-        "Creates a <span></span> element in the DOM with given inner HTML."
+        "Creates a <code>&lt;span&gt;&lt;/span&gt;</code> element in the DOM with given inner HTML."
       ],
       "returns": "p5.Element: pointer to <a href=\"#/p5.Element\">p5.Element</a> holding created node",
       "params": {
@@ -1499,7 +1499,7 @@
     },
     "createImg": {
       "description": [
-        "Creates an <img> element in the DOM with given src and alternate text."
+        "Creates an <code>&lt;img&gt;</code> element in the DOM with given src and alternate text."
       ],
       "returns": "p5.Element: pointer to <a href=\"#/p5.Element\">p5.Element</a> holding created node",
       "params": {
@@ -1511,7 +1511,7 @@
     },
     "createA": {
       "description": [
-        "Creates an <a></a> element in the DOM for including a hyperlink."
+        "Creates an <code>&lt;a&gt;&lt;/a&gt;</code> element in the DOM for including a hyperlink."
       ],
       "returns": "p5.Element: pointer to <a href=\"#/p5.Element\">p5.Element</a> holding created node",
       "params": {
@@ -1522,7 +1522,7 @@
     },
     "createSlider": {
       "description": [
-        "Creates a slider <input></input> element in the DOM. Use .size() to set the display length of the slider."
+        "Creates a slider <code>&lt;input&gt;&lt;/input&gt;</code> element in the DOM. Use .size() to set the display length of the slider."
       ],
       "returns": "p5.Element: pointer to <a href=\"#/p5.Element\">p5.Element</a> holding created node",
       "params": {
@@ -1534,7 +1534,7 @@
     },
     "createButton": {
       "description": [
-        "Creates a <button></button> element in the DOM. Use .size() to set the display size of the button. Use .mousePressed() to specify behavior on press."
+        "Creates a <code>&lt;button&gt;&lt;/button&gt;</code> element in the DOM. Use .size() to set the display size of the button. Use .mousePressed() to specify behavior on press."
       ],
       "returns": "p5.Element: pointer to <a href=\"#/p5.Element\">p5.Element</a> holding created node",
       "params": {
@@ -1544,7 +1544,7 @@
     },
     "createCheckbox": {
       "description": [
-        "Creates a checkbox <input></input> element in the DOM. Calling .checked() on a checkbox returns if it is checked or not"
+        "Creates a checkbox <code>&lt;input&gt;&lt;/input&gt;</code> element in the DOM. Calling .checked() on a checkbox returns if it is checked or not"
       ],
       "returns": "p5.Element: pointer to <a href=\"#/p5.Element\">p5.Element</a> holding created node",
       "params": {
@@ -1554,7 +1554,7 @@
     },
     "createSelect": {
       "description": [
-        "Creates a dropdown menu <select></select> element in the DOM. It also helps to assign select-box methods to <a href=\"#/p5.Element\">p5.Element</a> when selecting existing select box. <ul> <li><code>.option(name, [value])</code> can be used to set options for the select after it is created.</li> <li><code>.value()</code> will return the currently selected option.</li> <li><code>.selected()</code> will return current dropdown element which is an instance of <a href=\"#/p5.Element\">p5.Element</a></li> <li><code>.selected(value)</code> can be used to make given option selected by default when the page first loads.</li> <li><code>.disable()</code> marks whole of dropdown element as disabled.</li> <li><code>.disable(value)</code> marks given option as disabled</li> </ul>"
+        "Creates a dropdown menu <code>&lt;select&gt;&lt;/select&gt;</code> element in the DOM. It also helps to assign select-box methods to <a href=\"#/p5.Element\">p5.Element</a> when selecting existing select box. <ul> <li><code>.option(name, [value])</code> can be used to set options for the select after it is created.</li> <li><code>.value()</code> will return the currently selected option.</li> <li><code>.selected()</code> will return current dropdown element which is an instance of <a href=\"#/p5.Element\">p5.Element</a></li> <li><code>.selected(value)</code> can be used to make given option selected by default when the page first loads.</li> <li><code>.disable()</code> marks whole of dropdown element as disabled.</li> <li><code>.disable(value)</code> marks given option as disabled</li> </ul>"
       ],
       "returns": "p5.Element: ",
       "params": {
@@ -1583,7 +1583,7 @@
     },
     "createInput": {
       "description": [
-        "Creates an <input></input> element in the DOM for text input. Use .<a href=\"#/p5.Element/size\">size()</a> to set the display length of the box."
+        "Creates an <code>&lt;input&gt;&lt;/input&gt;</code> element in the DOM for text input. Use .<a href=\"#/p5.Element/size\">size()</a> to set the display length of the box."
       ],
       "returns": "p5.Element: pointer to <a href=\"#/p5.Element\">p5.Element</a> holding created node",
       "params": {
@@ -1593,7 +1593,7 @@
     },
     "createFileInput": {
       "description": [
-        "Creates an <input></input> element in the DOM of type 'file'. This allows users to select local files for use in a sketch."
+        "Creates an <code>&lt;input&gt;&lt;/input&gt;</code> element in the DOM of type 'file'. This allows users to select local files for use in a sketch."
       ],
       "returns": "p5.Element: pointer to <a href=\"#/p5.Element\">p5.Element</a> holding created DOM element",
       "params": {
@@ -1603,7 +1603,7 @@
     },
     "createVideo": {
       "description": [
-        "Creates an HTML5 <video> element in the DOM for simple playback of audio/video. Shown by default, can be hidden with .<a href=\"#/p5.Element/hide\">hide()</a> and drawn into canvas using <a href=\"#/p5/image\">image()</a>. The first parameter can be either a single string path to a video file, or an array of string paths to different formats of the same video. This is useful for ensuring that your video can play across different browsers, as each supports different formats. See <a href='https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats'>this page</a> for further information about supported formats."
+        "Creates an HTML5 <code>&lt;video&gt;</code> element in the DOM for simple playback of audio/video. Shown by default, can be hidden with .<a href=\"#/p5.Element/hide\">hide()</a> and drawn into canvas using <a href=\"#/p5/image\">image()</a>. The first parameter can be either a single string path to a video file, or an array of string paths to different formats of the same video. This is useful for ensuring that your video can play across different browsers, as each supports different formats. See <a href='https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats'>this page</a> for further information about supported formats."
       ],
       "returns": "p5.MediaElement: pointer to video <a href=\"#/p5.Element\">p5.Element</a>",
       "params": {
@@ -1613,7 +1613,7 @@
     },
     "createAudio": {
       "description": [
-        "Creates a hidden HTML5 <audio> element in the DOM for simple audio playback. The first parameter can be either a single string path to a audio file, or an array of string paths to different formats of the same audio. This is useful for ensuring that your audio can play across different browsers, as each supports different formats. See <a href='https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats'>this page for further information about supported formats</a>."
+        "Creates a hidden HTML5 <code>&lt;audio&gt;</code> element in the DOM for simple audio playback. The first parameter can be either a single string path to a audio file, or an array of string paths to different formats of the same audio. This is useful for ensuring that your audio can play across different browsers, as each supports different formats. See <a href='https://developer.mozilla.org/en-US/docs/Web/HTML/Supported_media_formats'>this page for further information about supported formats</a>."
       ],
       "returns": "p5.MediaElement: pointer to audio <a href=\"#/p5.Element\">p5.Element</a>",
       "params": {
@@ -1625,7 +1625,7 @@
     "AUDIO": {},
     "createCapture": {
       "description": [
-        "Creates a new HTML5 <video> element that contains the audio/video feed from a webcam. The element is separate from the canvas and is displayed by default. The element can be hidden using .<a href=\"#/p5.Element/hide\">hide()</a>. The feed can be drawn onto the canvas using <a href=\"#/p5/image\">image()</a>. The loadedmetadata property can be used to detect when the element has fully loaded (see second example). ",
+        "Creates a new HTML5 <code>&lt;video&gt;</code> element that contains the audio/video feed from a webcam. The element is separate from the canvas and is displayed by default. The element can be hidden using .<a href=\"#/p5.Element/hide\">hide()</a>. The feed can be drawn onto the canvas using <a href=\"#/p5/image\">image()</a>. The loadedmetadata property can be used to detect when the element has fully loaded (see second example). ",
         "More specific properties of the feed can be passing in a Constraints object. See the <a href='http://w3c.github.io/mediacapture-main/getusermedia.html#media-track-constraints'> W3C spec</a> for possible properties. Note that not all of these are supported by all browsers. ",
         "<em>Security note</em>: A new browser security specification requires that getUserMedia, which is behind <a href=\"#/p5/createCapture\">createCapture()</a>, only works when you're running the code locally, or on HTTPS. Learn more <a href='http://stackoverflow.com/questions/34197653/getusermedia-in-chrome-47-without-using-https'>here</a> and <a href='https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia'>here</a>."
       ],


### PR DESCRIPTION
### Problem:
The descriptions of some p5.js methods from the `p5` class (i.e. createDiv, createSpan) contain HTML tags that don't get properly rendered on the Reference section of the website. 

English page (expected behaviour):
<img src="https://user-images.githubusercontent.com/49163604/127691049-a6f39b72-f66a-4687-8898-dcc612a85384.png" width="400" height="200" />

Spanish page:
<img src="https://user-images.githubusercontent.com/49163604/127690734-895f93a8-2361-40fc-b550-d723dd572ab0.png" width="400" height="200" />


This happens because in the translated i18n files these HTML tags are not enclosed in `<code>` tags. 
The way the tags are written in the original documentation [has been changed](https://github.com/processing/p5.js/pull/4764), but this change was not applied to the translated i18n files.

In addition to that, as mentioned in Issue #1063, the `createP` method's description is incomplete in all the translated versions of the website.
<img src="https://user-images.githubusercontent.com/49163604/127691647-a0f35c31-591f-413d-bfc0-e47bbab53ee0.png" width="400" height="200" />


### Changes: 

- Modified the way HTML tags are written in some `p5` methods' descriptions.

- Added the complete description for the createP method.