### PR TITLE
Fixed typo in reference of Image's updatePixels function

### DIFF
--- a/src/data/reference/en.json
+++ b/src/data/reference/en.json
@@ -4449,7 +4449,7 @@
       "params": {
         "x": "Integer: x-offset of the target update area for the  underlying canvas",
         "y": "Integer: y-offset of the target update area for the  underlying canvas",
-        "w": "Integer: height of the target update area for the  underlying canvas",
+        "w": "Integer: width of the target update area for the  underlying canvas",
         "h": "Integer: height of the target update area for the  underlying canvas"
       }
     },

--- a/src/data/reference/es.json
+++ b/src/data/reference/es.json
@@ -4440,7 +4440,7 @@
       "params": {
         "x": "Integer: x-offset of the target update area for the  underlying canvas",
         "y": "Integer: y-offset of the target update area for the  underlying canvas",
-        "w": "Integer: height of the target update area for the  underlying canvas",
+        "w": "Integer: width of the target update area for the  underlying canvas",
         "h": "Integer: height of the target update area for the  underlying canvas"
       }
     },

--- a/src/data/reference/ko.json
+++ b/src/data/reference/ko.json
@@ -4440,7 +4440,7 @@
       "params": {
         "x": "Integer: x-offset of the target update area for the  underlying canvas",
         "y": "Integer: y-offset of the target update area for the  underlying canvas",
-        "w": "Integer: height of the target update area for the  underlying canvas",
+        "w": "Integer: width of the target update area for the  underlying canvas",
         "h": "Integer: height of the target update area for the  underlying canvas"
       }
     },

--- a/src/data/reference/zh-Hans.json
+++ b/src/data/reference/zh-Hans.json
@@ -4440,7 +4440,7 @@
       "params": {
         "x": "Integer: x-offset of the target update area for the  underlying canvas",
         "y": "Integer: y-offset of the target update area for the  underlying canvas",
-        "w": "Integer: height of the target update area for the  underlying canvas",
+        "w": "Integer: width of the target update area for the  underlying canvas",
         "h": "Integer: height of the target update area for the  underlying canvas"
       }
     },


### PR DESCRIPTION
Fixes #1065

 Changes: 
Change the part described as 'height' to 'width'

 Screenshots of the change: 
![image](https://user-images.githubusercontent.com/12081386/127791879-1031cbfa-fcae-49d8-aeec-b2bb554071a0.png)
