### PR TITLE
Fix reference example cannot run doubleClicked function

### DIFF
--- a/src/assets/js/render.js
+++ b/src/assets/js/render.js
@@ -184,8 +184,8 @@ var renderCode = function(exampleName) {
       var s = function(p) {
         var fxns = [
           'setup', 'draw', 'preload', 'mousePressed', 'mouseReleased',
-          'mouseMoved', 'mouseDragged', 'mouseClicked', 'mouseWheel',
-          'touchStarted', 'touchMoved', 'touchEnded',
+          'mouseMoved', 'mouseDragged', 'mouseClicked', 'doubleClicked',
+          'mouseWheel', 'touchStarted', 'touchMoved', 'touchEnded',
           'keyPressed', 'keyReleased', 'keyTyped'
         ];
         var _found = [];


### PR DESCRIPTION
Fixes #1078

 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
`doubleClicked` was not added to the list of possible p5 function that is used as part of the reference example rendering logic. This PR added it in and the `doubleClicked` reference example should work now.