### PR TITLE
Get Started page: remove errant comma

### DIFF
--- a/src/data/en.yml
+++ b/src/data/en.yml
@@ -93,7 +93,7 @@ get started:
   get-started6: >-
     . If you would like to work on the the desktop version of p5.js you can
     scroll down to
-  get-started7: downloading instructions,
+  get-started7: downloading instructions
   get-started-button: 'Copy'
   settingUp-title: Setting up p5.js with an editor on your own computer
   download-title: Downloading a copy of the p5.js library


### PR DESCRIPTION
This PR removes an errant comma in the opening paragraph of the [Get Started page](https://p5js.org/get-started)’s English text.

<img width="987" alt="Screen Shot 2021-10-15 at 1 58 36 PM" src="https://user-images.githubusercontent.com/221550/137532095-6545b143-b3f4-4ac3-8eaf-b96029df5af0.png">