### PR TITLE
Quick fix to dom-video examples. Fixes #1103

### DIFF
--- a/src/data/examples/en/16_Dom/08_Video.js
+++ b/src/data/examples/en/16_Dom/08_Video.js
@@ -10,6 +10,7 @@ let fingers;
 let button;
 
 function setup() {
+  noCanvas();
   // specify multiple formats for different browsers
   fingers = createVideo(['assets/fingers.mov', 'assets/fingers.webm']);
   button = createButton('play');

--- a/src/data/examples/es/16_Dom/08_Video.js
+++ b/src/data/examples/es/16_Dom/08_Video.js
@@ -8,6 +8,7 @@ let fingers;
 let button;
 
 function setup() {
+  noCanvas();
   // especificar múltiples formatos para distintos navegadores
   fingers = createVideo(['assets/fingers.mov', 'assets/fingers.webm']);
   button = createButton('play');

--- a/src/data/examples/hi/16_Dom/08_Video.js
+++ b/src/data/examples/hi/16_Dom/08_Video.js
@@ -12,6 +12,7 @@ let fingers;
 let button;
 
 function setup() {
+  noCanvas();
   // specify multiple formats for different browsers
   fingers = createVideo(['assets/fingers.mov', 'assets/fingers.webm']);
   button = createButton('play');

--- a/src/data/examples/ko/16_Dom/08_Video.js
+++ b/src/data/examples/ko/16_Dom/08_Video.js
@@ -10,6 +10,7 @@ let fingers;
 let button;
 
 function setup() {
+  noCanvas();
   // 여러 브라우저 지원을 위해 다양한 비디오 형식 지정
   fingers = createVideo(['assets/fingers.mov', 'assets/fingers.webm']);
   button = createButton('play');

--- a/src/data/examples/zh-Hans/16_Dom/08_Video.js
+++ b/src/data/examples/zh-Hans/16_Dom/08_Video.js
@@ -9,6 +9,7 @@ let fingers;
 let button;
 
 function setup() {
+  noCanvas();
   // specify multiple formats for different browsers
   fingers = createVideo(['assets/fingers.mov', 'assets/fingers.webm']);
   button = createButton('play');


### PR DESCRIPTION
Fixes #1103

Changes:

Added single `noCanvas();` line to `setup()` in each language's `examples/dom-video.html` example.

Modified files:
```
        modified:   src/data/examples/en/16_Dom/08_Video.js
        modified:   src/data/examples/es/16_Dom/08_Video.js
        modified:   src/data/examples/hi/16_Dom/08_Video.js
        modified:   src/data/examples/ko/16_Dom/08_Video.js
        modified:   src/data/examples/zh-Hans/16_Dom/08_Video.js
```

Single `noCanvas();` line added to each:
```
let button;

function setup() {
 noCanvas();
  // specify multiple formats for different browsers
  fingers = createVideo(['assets/fingers.mov', 'assets/fingers.webm']);
  button = createButton('play');
```

Buttons are now visible.

<img width="845" alt="Screen Shot 2021-12-09 at 7 08 25 PM" src="https://user-images.githubusercontent.com/115194/145495244-0b8de9a6-13f7-4ddc-8c51-137f753fc1ba.png">

