### PR TITLE
Get Started page: Remove Extra the

### DIFF
--- a/src/data/en.yml
+++ b/src/data/en.yml
@@ -91,7 +91,7 @@ get started:
   get-started4: ', you can open the web editor and can scroll down to '
   get-started5: Your First Sketch
   get-started6: >-
-    . If you would like to work on the the desktop version of p5.js you can
+    . If you would like to work on the desktop version of p5.js you can
     scroll down to
   get-started7: downloading instructions
   get-started-button: 'Copy'


### PR DESCRIPTION
This PR removes an extra 'the' in the opening paragraph of the Get Started page’s English text.

<img width="858" alt="Screenshot 2021-12-31 181846" src="https://user-images.githubusercontent.com/76220055/147824236-563ddb8a-40ef-41cb-b721-7a150e9da6ae.png">
