### PR TITLE
added p5 logo in contributor-docs page

### DIFF
--- a/src/assets/contributor-docs/index.html
+++ b/src/assets/contributor-docs/index.html
@@ -6,6 +6,8 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="description" content="p5.js Contributor Docs">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="shortcut icon" href="/assets/img/favicon.ico">
+  <link rel="icon" href="/assets/img/favicon.ico">
   <link rel="stylesheet" href="https://unpkg.com/docsify/lib/themes/buble.css">
 </head>
 <body>


### PR DESCRIPTION
Fixes #1101 

 Changes: 
This PR fixes the icon of the `contributor-docs`. Official p5 logo has been added as an icon on this page.

Screenshots of the change: 
![Screenshot from 2022-01-07 18-12-31](https://user-images.githubusercontent.com/76521428/148546143-408d1ec5-f447-4d23-9b88-10d3761c85c9.png)

@Qianqianye @limzykenneth Kindly review this PR and inform me if certain changes are needed.