### PR TITLE
Corrected creative common message in hindi 

### DIFF
--- a/src/data/hi.yml
+++ b/src/data/hi.yml
@@ -846,11 +846,11 @@ community:
   in-the-future-title: 'भविष्य में:'
   in-the-future1: भविष्य आज है।
   notes-title: नोट्स
-  notes1: 'Please also visit our '
+  notes1: 'कृपया हमारे '
   notes2: p5.js Code of Conduct
-  notes3: '. The p5.js Community Statement is licensed under a '
+  notes3: ' पर भी जाएं। P5.js समुदाय कथन एक '
   notes4: Creative Commons license
-  notes5: . Please feel free to share and remix with attribution.
+  notes5: ' के तहत लाइसेंस प्राप्त है। एट्रिब्यूशन के साथ साझा करने और रीमिक्स करने के लिए स्वतंत्र महसूस करें। '
   contribute-title: योगदान
   contribute1: हमारा समुदाय हमेशा उत्साही लोगों की तलाश में रहता है जो हर तरह से मदद करें।
   develop-title: विकास करना।


### PR DESCRIPTION
Fixes #1124 
## Changes: 
Corrected translation of creative common use & code of conduct message in hindi version of website.

## Screenshots of the change: 

<img width="944" alt="Screenshot 2022-02-01 050438" src="https://user-images.githubusercontent.com/76220055/151960687-ebdc0f0d-708e-43f2-9ac3-8edc500da63b.png">

