### PR TITLE
Fix broken example in Korean docs

### DIFF
--- a/src/data/examples/ko/17_Drawing/00_Continuous_Lines.js
+++ b/src/data/examples/ko/17_Drawing/00_Continuous_Lines.js
@@ -4,7 +4,7 @@
  */
 function setup() {
   createCanvas(710, 400);
-  background(102);ㅌ
+  background(102);
 }
 
 function draw() {


### PR DESCRIPTION

 Changes: 
Fix broken example in Korean docs - drawing-continuous-lines
Example is not working.

https://p5js.org/ko/examples/drawing-continuous-lines.html


 Screenshots of the change: 
<img width="901" alt="image" src="https://user-images.githubusercontent.com/41318449/153750148-de68ee19-2126-4b26-8be6-b6494ea2e92e.png">
