### PR TITLE
Add space between link and text in copyright.html

### DIFF
--- a/i18n-tracking.yml
+++ b/i18n-tracking.yml
@@ -1,5 +1,6 @@
 es:
   src/data/en.yml:
+    line 85: '    under the terms of the '
     line 26: footer6
     line 25: footer2
     line 27: footer4
@@ -304,7 +305,6 @@ es:
     line 23: footer2
     line 65: '  color-rgb-p1x1'
     line 72: '  color-rgb-p2x1'
-    line 85: '  color-custom-ranges-p4x1'
     line 81: '  color-transparency-p1x1'
     line 90: '  color-custom-ranges-p4x1'
     line 153: '  project-a-4-7-casey-louise'
@@ -1846,8 +1846,10 @@ hi:
     line 30: footer7
     line 31: footer8
     line 32: footer9
+    line 85: '    under the terms of the '
 ko:
   src/data/en.yml:
+    line 85: '    under the terms of the '
     line 26: footer6
     line 25: footer2
     line 27: footer4
@@ -2152,7 +2154,6 @@ ko:
     line 23: footer2
     line 65: '  color-rgb-p1x1'
     line 72: '  color-rgb-p2x1'
-    line 85: '  color-custom-ranges-p4x1'
     line 81: '  color-transparency-p1x1'
     line 90: '  color-custom-ranges-p4x1'
     line 153: '  project-a-4-7-casey-louise'
@@ -3686,6 +3687,7 @@ ko:
     line 433: '    presentations. I used'
 zh-Hans:
   src/data/en.yml:
+    line 85: '    under the terms of the '
     line 26: footer6
     line 25: footer2
     line 27: footer4
@@ -3989,7 +3991,6 @@ zh-Hans:
     line 23: footer2
     line 65: '  color-rgb-p1x1'
     line 72: '  color-rgb-p2x1'
-    line 85: '  color-custom-ranges-p4x1'
     line 81: '  color-transparency-p1x1'
     line 90: '  color-custom-ranges-p4x1'
     line 153: '  project-a-4-7-casey-louise'

--- a/src/data/en.yml
+++ b/src/data/en.yml
@@ -80,8 +80,8 @@ home:
 copyright:
   copyright-title: Copyright Information
   copyright1: >-
-    The p5.js library is free software; you can redistribute it and/or modify it
-    under the terms of the 
+    'The p5.js library is free software; you can redistribute it and/or modify it
+    under the terms of the '
   copyright2: ' as published by the Free Software Foundation, version 2.1.'
   copyright3: 'The Reference for the language is under a '
   copyright4: ' license which makes it possible to reuse this content for non-commercial purposes if it is credited.'

--- a/src/data/en.yml
+++ b/src/data/en.yml
@@ -81,7 +81,7 @@ copyright:
   copyright-title: Copyright Information
   copyright1: >-
     The p5.js library is free software; you can redistribute it and/or modify it
-    under the terms of the
+    under the terms of the 
   copyright2: ' as published by the Free Software Foundation, version 2.1.'
   copyright3: 'The Reference for the language is under a '
   copyright4: ' license which makes it possible to reuse this content for non-commercial purposes if it is credited.'


### PR DESCRIPTION
Fixes #1155

**Previous behaviour **

"ms of the[GNU Lesser General Public License](https://github.com/processing/p5.js/blob/main/license.txt) as publish"
![image](https://user-images.githubusercontent.com/34364128/156125358-ceb2ac39-ccaa-4e98-9c40-8f5aedbe4c79.png)


 **Changed behaviour**

"of the [GNU Lesser General Public License](https://github.com/processing/p5.js/blob/main/license.txt) as p"
![image](https://user-images.githubusercontent.com/34364128/156125290-f800d0f4-a6c7-4801-a4a6-ac333f703c8e.png)

 **Steps to reproduce it**
Visit https://p5js.org/copyright.html

There were two changes made by grunt that I didn't stage.
- package-lock.json - I think my npm version was higher causing it to update
- src/assets/js/reference.js was changed adding `\r` to the `\n`s

The pre-commit hook updated i18n-tracking.