### PR TITLE
Fixed layout collapse on Examples

### DIFF
--- a/src/data/examples/en/00_Structure/00_Statements_and_Comments.js
+++ b/src/data/examples/en/00_Structure/00_Statements_and_Comments.js
@@ -1,7 +1,10 @@
 /*
  * @name Comments and Statements
  * @arialabel Mustard yellow background
- * @description Statements are the elements that make up programs. The ";" (semi-colon) symbol is used to end statements. It is called the "statement terminator". Comments are used for making notes to help people better understand programs. A comment begins with two forward slashes ("//"). (ported from https://processing.org/examples/statementscomments.html)
+ * @description Statements are the elements that make up programs. The ";" (semi-colon) symbol is used to end statements.
+ * It is called the "statement terminator". Comments are used for making notes to help people better understand programs. A comment begins with two forward slashes ("//").
+ * <br><br><span class="small"><em>This example is ported from the <a href="https://processing.org/examples/statementscomments.html">Statements and Comments example</a>
+ * on the Processing website</em></span>
  */
 // The createCanvas function is a statement that tells the computer 
 // how large to make the window.

--- a/src/data/examples/en/00_Structure/00_Statements_and_Comments.js
+++ b/src/data/examples/en/00_Structure/00_Statements_and_Comments.js
@@ -3,8 +3,8 @@
  * @arialabel Mustard yellow background
  * @description Statements are the elements that make up programs. The ";" (semi-colon) symbol is used to end statements.
  * It is called the "statement terminator". Comments are used for making notes to help people better understand programs. A comment begins with two forward slashes ("//").
- * <br><br><span class="small"><em>This example is ported from the <a href="https://processing.org/examples/statementscomments.html">Statements and Comments example</a>
- * on the Processing website</em></span>
+ * <br><br><small><em>This example is ported from the <a href="https://processing.org/examples/statementscomments.html">Statements and Comments example</a>
+ * on the Processing website</em></small>
  */
 // The createCanvas function is a statement that tells the computer 
 // how large to make the window.

--- a/src/data/examples/en/08_Math/18_randomGaussian.js
+++ b/src/data/examples/en/08_Math/18_randomGaussian.js
@@ -3,7 +3,8 @@
  * @arialabel Translucent white circles are drawn in a line left and right multiple times until they overlap to form a white streak
  * @frame 720,400
  * @description This sketch draws ellipses with x and y locations tied to a gaussian distribution of random numbers.
- *  (ported from https://processing.org/examples/randomgaussian.html)
+ * <br><br><span class="small"><em>This example is ported from the <a href="https://processing.org/examples/randomgaussian.html">Random Gaussian example</a>
+ * on the Processing website</em></span>
  */
 
   function setup() {

--- a/src/data/examples/en/08_Math/18_randomGaussian.js
+++ b/src/data/examples/en/08_Math/18_randomGaussian.js
@@ -3,8 +3,8 @@
  * @arialabel Translucent white circles are drawn in a line left and right multiple times until they overlap to form a white streak
  * @frame 720,400
  * @description This sketch draws ellipses with x and y locations tied to a gaussian distribution of random numbers.
- * <br><br><span class="small"><em>This example is ported from the <a href="https://processing.org/examples/randomgaussian.html">Random Gaussian example</a>
- * on the Processing website</em></span>
+ * <br><br><small><em>This example is ported from the <a href="https://processing.org/examples/randomgaussian.html">Random Gaussian example</a>
+ * on the Processing website</em></small>
  */
 
   function setup() {

--- a/src/data/examples/en/09_Simulate/09_Springs.js
+++ b/src/data/examples/en/09_Simulate/09_Springs.js
@@ -5,7 +5,7 @@
  * @description Move the mouse over one of the circles and click to re-position.
  * When you release the mouse, it will snap back into position.
  * Each circle has a slightly different behavior.
- * (ported from https://processing.org/examples/springs.html)
+ * <br><br><span class="small"><em>This example is ported from the Processing website</em></span>
  */
 let num = 3;
 let springs = [];

--- a/src/data/examples/en/09_Simulate/09_Springs.js
+++ b/src/data/examples/en/09_Simulate/09_Springs.js
@@ -5,7 +5,7 @@
  * @description Move the mouse over one of the circles and click to re-position.
  * When you release the mouse, it will snap back into position.
  * Each circle has a slightly different behavior.
- * <br><br><span class="small"><em>This example is ported from the Processing website</em></span>
+ * <br><br><small><em>This example is ported from the <a href="https://processing.org/examples/">Processing website</a></em></small>
  */
 let num = 3;
 let springs = [];

--- a/src/data/examples/en/09_Simulate/13_Chain.js
+++ b/src/data/examples/en/09_Simulate/13_Chain.js
@@ -2,7 +2,7 @@
  * @name Chain
  * @arialabel Two slightly opaque white circles connected by a white line. The user’s mouse moves the top of the string and the circles follow but are also affected by gravity.
  * @description One mass is attached to the mouse position and the other is attached the position of the other mass. The gravity in the environment pulls down on both.
- * Ported from the Processing Examples page.
+ * <br><br><span class="small"><em>This example is ported from the Processing website</em></span>
  */
 let s1, s2;
 let gravity = 9.0;

--- a/src/data/examples/en/09_Simulate/13_Chain.js
+++ b/src/data/examples/en/09_Simulate/13_Chain.js
@@ -2,7 +2,7 @@
  * @name Chain
  * @arialabel Two slightly opaque white circles connected by a white line. The user’s mouse moves the top of the string and the circles follow but are also affected by gravity.
  * @description One mass is attached to the mouse position and the other is attached the position of the other mass. The gravity in the environment pulls down on both.
- * <br><br><span class="small"><em>This example is ported from the Processing website</em></span>
+ * <br><br><small><em>This example is ported from the <a href="https://processing.org/examples/">Processing website</a></em></small>
  */
 let s1, s2;
 let gravity = 9.0;

--- a/src/data/examples/en/13_Motion/05_Brownian.js
+++ b/src/data/examples/en/13_Motion/05_Brownian.js
@@ -2,7 +2,8 @@
  * @name Brownian Motion
  * @arialabel A continuous white line draws squiggles on a grey background, forming a random pattern
  * @description Recording random movement as a continuous line.
- *  (ported from https://processing.org/examples/brownian.html)
+ * <br><br><span class="small"><em>This example is ported from the <a href="https://processing.org/examples/brownian.html">Brownian motion example</a>
+ * on the Processing website</em></span>
  */
 
 let num = 2000;

--- a/src/data/examples/en/13_Motion/05_Brownian.js
+++ b/src/data/examples/en/13_Motion/05_Brownian.js
@@ -2,8 +2,8 @@
  * @name Brownian Motion
  * @arialabel A continuous white line draws squiggles on a grey background, forming a random pattern
  * @description Recording random movement as a continuous line.
- * <br><br><span class="small"><em>This example is ported from the <a href="https://processing.org/examples/brownian.html">Brownian motion example</a>
- * on the Processing website</em></span>
+ * <br><br><small><em>This example is ported from the <a href="https://processing.org/examples/brownian.html">Brownian motion example</a>
+ * on the Processing website</em></small>
  */
 
 let num = 2000;

--- a/src/data/examples/en/19_Typography/02_Text_Rotation.js
+++ b/src/data/examples/en/19_Typography/02_Text_Rotation.js
@@ -2,7 +2,8 @@
  * @name Text Rotation
  * @arialabel Three white lines on a black screen. One at 45 degrees, one at 270 degrees, and one line that turns clockwise and the degree label changes as the line turns.
  * @description Draws letters to the screen and rotates them at different angles.
- *  (ported from https://processing.org/examples/textrotation.html) 
+ * <br><br><span class="small"><em>This example is ported from the <a href="https://processing.org/examples/textrotation.html">Text Rotation example</a>
+ * on the Processing website</em></span>
  */
 
 let font,

--- a/src/data/examples/en/19_Typography/02_Text_Rotation.js
+++ b/src/data/examples/en/19_Typography/02_Text_Rotation.js
@@ -2,8 +2,8 @@
  * @name Text Rotation
  * @arialabel Three white lines on a black screen. One at 45 degrees, one at 270 degrees, and one line that turns clockwise and the degree label changes as the line turns.
  * @description Draws letters to the screen and rotates them at different angles.
- * <br><br><span class="small"><em>This example is ported from the <a href="https://processing.org/examples/textrotation.html">Text Rotation example</a>
- * on the Processing website</em></span>
+ * <br><br><small><em>This example is ported from the <a href="https://processing.org/examples/textrotation.html">Text Rotation example</a>
+ * on the Processing website</em></small>
  */
 
 let font,

--- a/src/data/examples/en/21_Input/04_Milliseconds.js
+++ b/src/data/examples/en/21_Input/04_Milliseconds.js
@@ -1,10 +1,10 @@
 /*
  * @name Milliseconds
  * @arialabel Background broken down in bars of various shades of grey. The fill of some of the bars randomly changes every millisecond to other shades of grey.
- * @description A millisecond is 1/1000 of a second. Processing keeps track of the number of milliseconds a 
+ * @description A millisecond is 1/1000 of a second. Processing keeps track of the number of milliseconds a
  * program has run. By modifying this number with the modulo(%) operator, different patterns in time are created.
- * <br><br><span class="small"><em>This example is ported from the <a href="https://processing.org/examples/milliseconds.html">Milliseconds example</a>
- * on the Processing website</em></span>
+ * <br><br><small><em>This example is ported from the <a href="https://processing.org/examples/milliseconds.html">Milliseconds example</a>
+ * on the Processing website</em></small>
  */
 
 let scale;

--- a/src/data/examples/en/21_Input/04_Milliseconds.js
+++ b/src/data/examples/en/21_Input/04_Milliseconds.js
@@ -2,7 +2,9 @@
  * @name Milliseconds
  * @arialabel Background broken down in bars of various shades of grey. The fill of some of the bars randomly changes every millisecond to other shades of grey.
  * @description A millisecond is 1/1000 of a second. Processing keeps track of the number of milliseconds a 
- * program has run. By modifying this number with the modulo(%) operator, different patterns in time are created. (ported from https://processing.org/examples/milliseconds.html)
+ * program has run. By modifying this number with the modulo(%) operator, different patterns in time are created.
+ * <br><br><span class="small"><em>This example is ported from the <a href="https://processing.org/examples/milliseconds.html">Milliseconds example</a>
+ * on the Processing website</em></span>
  */
 
 let scale;

--- a/src/data/examples/es/00_Structure/00_Statements_and_Comments.js
+++ b/src/data/examples/es/00_Structure/00_Statements_and_Comments.js
@@ -2,8 +2,8 @@
  * @name Comments and Statements
  * @description Statements are the elements that make up programs. The ";" (semi-colon) symbol is used to end statements.
  * It is called the "statement terminator". Comments are used for making notes to help people better understand programs. A comment begins with two forward slashes ("//").
- * <br><br><span class="small"><em>This example is ported from the <a href="https://processing.org/examples/statementscomments.html">Statements and Comments example</a>
- * on the Processing website</em></span>
+ * <br><br><small><em>This example is ported from the <a href="https://processing.org/examples/statementscomments.html">Statements and Comments example</a>
+ * on the Processing website</em></small>
  */
 // The createCanvas function is a statement that tells the computer 
 // how large to make the window.

--- a/src/data/examples/es/00_Structure/00_Statements_and_Comments.js
+++ b/src/data/examples/es/00_Structure/00_Statements_and_Comments.js
@@ -1,6 +1,9 @@
 /*
  * @name Comments and Statements
- * @description Statements are the elements that make up programs. The ";" (semi-colon) symbol is used to end statements. It is called the "statement  * terminator". Comments are used for making notes to help people better understand programs. A comment begins with two forward slashes ("//"). (ported from https://processing.org/examples/statementscomments.html)
+ * @description Statements are the elements that make up programs. The ";" (semi-colon) symbol is used to end statements.
+ * It is called the "statement terminator". Comments are used for making notes to help people better understand programs. A comment begins with two forward slashes ("//").
+ * <br><br><span class="small"><em>This example is ported from the <a href="https://processing.org/examples/statementscomments.html">Statements and Comments example</a>
+ * on the Processing website</em></span>
  */
 // The createCanvas function is a statement that tells the computer 
 // how large to make the window.

--- a/src/data/examples/es/19_Typography/02_Text_Rotation.js
+++ b/src/data/examples/es/19_Typography/02_Text_Rotation.js
@@ -1,8 +1,8 @@
 /*
  * @name Text Rotation
  * @description Draws letters to the screen and rotates them at different angles.
- * <br><br><span class="small"><em>This example is ported from the <a href="https://processing.org/examples/textrotation.html">Text Rotation example</a>
- * on the Processing website</em></span>
+ * <br><br><small><em>This example is ported from the <a href="https://processing.org/examples/textrotation.html">Text Rotation example</a>
+ * on the Processing website</em></small>
  */
 
 let font,

--- a/src/data/examples/es/19_Typography/02_Text_Rotation.js
+++ b/src/data/examples/es/19_Typography/02_Text_Rotation.js
@@ -1,7 +1,8 @@
 /*
  * @name Text Rotation
  * @description Draws letters to the screen and rotates them at different angles.
- *  (ported from https://processing.org/examples/textrotation.html) 
+ * <br><br><span class="small"><em>This example is ported from the <a href="https://processing.org/examples/textrotation.html">Text Rotation example</a>
+ * on the Processing website</em></span>
  */
 
 let font,

--- a/src/data/examples/zh-Hans/00_Structure/00_Statements_and_Comments.js
+++ b/src/data/examples/zh-Hans/00_Structure/00_Statements_and_Comments.js
@@ -2,8 +2,8 @@
  * @name Comments and Statements
  * @description Statements are the elements that make up programs. The ";" (semi-colon) symbol is used to end statements.
  * It is called the "statement terminator". Comments are used for making notes to help people better understand programs. A comment begins with two forward slashes ("//").
- * <br><br><span class="small"><em>This example is ported from the <a href="https://processing.org/examples/statementscomments.html">Statements and Comments example</a>
- * on the Processing website</em></span>
+ * <br><br><small><em>This example is ported from the <a href="https://processing.org/examples/statementscomments.html">Statements and Comments example</a>
+ * on the Processing website</em></small>
  */
 // The createCanvas function is a statement that tells the computer 
 // how large to make the window.

--- a/src/data/examples/zh-Hans/00_Structure/00_Statements_and_Comments.js
+++ b/src/data/examples/zh-Hans/00_Structure/00_Statements_and_Comments.js
@@ -1,6 +1,9 @@
 /*
  * @name Comments and Statements
- * @description Statements are the elements that make up programs. The ";" (semi-colon) symbol is used to end statements. It is called the "statement  * terminator". Comments are used for making notes to help people better understand programs. A comment begins with two forward slashes ("//"). (ported from https://processing.org/examples/statementscomments.html)
+ * @description Statements are the elements that make up programs. The ";" (semi-colon) symbol is used to end statements.
+ * It is called the "statement terminator". Comments are used for making notes to help people better understand programs. A comment begins with two forward slashes ("//").
+ * <br><br><span class="small"><em>This example is ported from the <a href="https://processing.org/examples/statementscomments.html">Statements and Comments example</a>
+ * on the Processing website</em></span>
  */
 // The createCanvas function is a statement that tells the computer 
 // how large to make the window.

--- a/src/data/examples/zh-Hans/09_Simulate/09_Springs.js
+++ b/src/data/examples/zh-Hans/09_Simulate/09_Springs.js
@@ -4,7 +4,7 @@
  * @description Move the mouse over one of the circles and click to re-position.
  * When you release the mouse, it will snap back into position.
  * Each circle has a slightly different behavior.
- * <br><br><span class="small"><em>This example is ported from the Processing website</em></span>
+ * <br><br><small><em>This example is ported from the <a href="https://processing.org/examples/">Processing website</a></em></small>
  */
 let num = 3;
 let springs = [];

--- a/src/data/examples/zh-Hans/09_Simulate/09_Springs.js
+++ b/src/data/examples/zh-Hans/09_Simulate/09_Springs.js
@@ -4,7 +4,7 @@
  * @description Move the mouse over one of the circles and click to re-position.
  * When you release the mouse, it will snap back into position.
  * Each circle has a slightly different behavior.
- * (ported from https://processing.org/examples/springs.html)
+ * <br><br><span class="small"><em>This example is ported from the Processing website</em></span>
  */
 let num = 3;
 let springs = [];

--- a/src/data/examples/zh-Hans/09_Simulate/13_Chain.js
+++ b/src/data/examples/zh-Hans/09_Simulate/13_Chain.js
@@ -1,7 +1,7 @@
 /*
  * @name Chain
  * @description One mass is attached to the mouse position and the other is attached the position of the other mass. The gravity in the environment pulls down on both.
- * <br><br><span class="small"><em>This example is ported from the Processing website</em></span>
+ * <br><br><small><em>This example is ported from the Processing website</em></small>
  */
 let s1, s2;
 let gravity = 9.0;

--- a/src/data/examples/zh-Hans/09_Simulate/13_Chain.js
+++ b/src/data/examples/zh-Hans/09_Simulate/13_Chain.js
@@ -1,7 +1,7 @@
 /*
  * @name Chain
  * @description One mass is attached to the mouse position and the other is attached the position of the other mass. The gravity in the environment pulls down on both.
- * Ported from the Processing Examples page.
+ * <br><br><span class="small"><em>This example is ported from the Processing website</em></span>
  */
 let s1, s2;
 let gravity = 9.0;

--- a/src/data/examples/zh-Hans/19_Typography/02_Text_Rotation.js
+++ b/src/data/examples/zh-Hans/19_Typography/02_Text_Rotation.js
@@ -1,8 +1,8 @@
 /*
  * @name Text Rotation
  * @description Draws letters to the screen and rotates them at different angles.
- * <br><br><span class="small"><em>This example is ported from the <a href="https://processing.org/examples/textrotation.html">Text Rotation example</a>
- * on the Processing website</em></span>
+ * <br><br><small><em>This example is ported from the <a href="https://processing.org/examples/textrotation.html">Text Rotation example</a>
+ * on the Processing website</em></small>
  */
 
 let font,

--- a/src/data/examples/zh-Hans/19_Typography/02_Text_Rotation.js
+++ b/src/data/examples/zh-Hans/19_Typography/02_Text_Rotation.js
@@ -1,7 +1,8 @@
 /*
  * @name Text Rotation
  * @description Draws letters to the screen and rotates them at different angles.
- *  (ported from https://processing.org/examples/textrotation.html) 
+ * <br><br><span class="small"><em>This example is ported from the <a href="https://processing.org/examples/textrotation.html">Text Rotation example</a>
+ * on the Processing website</em></span>
  */
 
 let font,


### PR DESCRIPTION
Fixes #1159

### Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->

- Replace directly written URLs with A tags.
- I have replaced the URL if the link could not be found.

Modified [Examples](https://p5js.org/examples/)

- [Comments and Statements](https://p5js.org/examples/structure-comments-and-statements.html)
- [Text Rotation](https://p5js.org/examples/typography-text-rotation.html)
- [Chain](https://p5js.org/examples/simulate-chain.html)
- [Brownian Motion](https://p5js.org/examples/motion-brownian-motion.html)
- [Springs](https://p5js.org/examples/simulate-springs.html)
- [Random Gaussian](https://p5js.org/examples/math-random-gaussian.html)


 ### Screenshots of the change: 
<!-- Add screenshots depicting the changes. -->

|Before|After|
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/69892552/157684600-f0eb3d8f-10ae-4d57-9a78-9255d31e4d2a.png)|![image](https://user-images.githubusercontent.com/69892552/157684679-967e0806-5534-4d64-9c7c-4fcf5a41374c.png)|
|![img](https://i.gyazo.com/43d4d5d74fbb45fc6265f909c52a4489.png)|![img](https://i.gyazo.com/1a382e582c7e284376bd61499b89193d.png)
|![image](https://user-images.githubusercontent.com/69892552/157687779-e50ce5d3-4b2f-4564-b012-e179ce212fe5.png)|![img](https://i.gyazo.com/a46a3d42a95b5ac082f6f70200e57aa3.png)|
|![img](https://i.gyazo.com/0eef7960effb2e14f845cb87ba5a3428.png)|![img](https://i.gyazo.com/030a089c37dbba00dad0996dd2bc0ce4.png)|
|![img](https://i.gyazo.com/ac884b5a1c8ac7c1ba82e499c5ba6c46.png)|![img](https://i.gyazo.com/fc0a0e493d4ff46fdf0269e4757c0dc3.png)|
|![img](https://i.gyazo.com/3285e9e4d7e12ef8ec75e6881048c04e.png)|![img](https://i.gyazo.com/af8a1a4541220b6f748688252112a49c.png)|


---

### After merged
Since I can't read Korean, I have not modified it in this PR. I will create an issue asking someone to correct the examples listed above.