### PR TITLE
Adjust Input and Set anchor tags for editor and showcase in side-bar to target blank

### DIFF
--- a/offline-reference/extra/css/all.css
+++ b/offline-reference/extra/css/all.css
@@ -2946,6 +2946,17 @@ footer {
   width: 1px;
 }
 
+.small-search {
+  size: 20;
+}
+
+
+@media (min-width: 780px) {
+  .small-search {
+    transform: scale(0.8);
+  }
+}
+
 /*
  * Extends the .visuallyhidden class to allow the element to be focusable
  * when navigated to via the keyboard: h5bp.com/p

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -2204,7 +2204,15 @@ footer {
 /*
  * Hide only visually, but have it available for screenreaders: h5bp.com/v
  */
+.small-search {
+  size: 20
+}
 
+@media (min-width: 780px) {
+  .small-search {
+    transform: scale(0.8);
+  }
+}
 .sr-only {
   border: 0;
   clip: rect(0 0 0 0);

--- a/src/templates/pages/index.hbs
+++ b/src/templates/pages/index.hbs
@@ -10,7 +10,7 @@ slug: /
       <form id="search" method="get" action="https://www.google.com/search">
         <input type="hidden" name="as_sitesearch" value="p5js.org">
         <input id="search_button" type="submit" aria-label="Search" class='sr-only'>
-        <input tabindex="2" id='search_field' type="text" size="20" placeholder="Search p5js.org" name="q">
+        <input tabindex="2" id='search_field' type="text" class='small-search' placeholder="Search p5js.org" name="q">
         <label class="sr-only" for="search_field">Search p5js.org</label>
       </form>
 

--- a/src/templates/partials/sidebar.hbs
+++ b/src/templates/partials/sidebar.hbs
@@ -9,7 +9,7 @@ slug: sidebar
     <label class="sidebar-menu-icon" for="sidebar-menu-btn"><span class="sidebar-nav-icon"></span></label>
     <ul id="menu" class="sidebar-menu" aria-labelledby="menu-title">
       <li><a href="{{root}}/">{{#i18n "Home"}}{{/i18n}}</a></li>
-      <li><a href="https://editor.p5js.org">{{#i18n "Editor"}}{{/i18n}}</a></li>
+      <li><a href="https://editor.p5js.org" target=_blank class="other-link">{{#i18n "Editor"}}{{/i18n}}</a></li>
       <li><a href="{{root}}/download/">{{#i18n "Download"}}{{/i18n}}</a></li>
       <li><a href="{{root}}/download/support.html">{{#i18n "Donate"}}{{/i18n}}</a></li>
       <li><a href="{{root}}/get-started/">{{#i18n "Start"}}{{/i18n}}</a></li>
@@ -20,7 +20,7 @@ slug: sidebar
       <li><a href="{{root}}/examples/">{{#i18n "Examples"}}{{/i18n}}</a></li>
       <li><a href="{{root}}/books/">{{#i18n "Books"}}{{/i18n}}</a></li>
       <li><a href="{{root}}/community/">{{#i18n "Community"}}{{/i18n}}</a></li>
-      <li><a href="https://showcase.p5js.org">{{#i18n "Showcase"}}{{/i18n}}</a></li>
+      <li><a href="https://showcase.p5js.org" target=_blank class="other-link">{{#i18n "Showcase"}}{{/i18n}}</a></li>
       <li><a href="https://discourse.processing.org/c/p5js" target=_blank class="other-link">{{#i18n "Forum"}}{{/i18n}}</a></li>
       <li><a href="http://github.com/processing/p5.js" target=_blank class="other-link">GitHub</a></li>
       <li><a href="http://twitter.com/p5xjs" target=_blank class="other-link">Twitter</a></li>


### PR DESCRIPTION
 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->


 Screenshots of the change: 
<!-- Add screenshots depicting the changes. -->

At breakpoint (viewport width) of 1380px and above

![image](https://user-images.githubusercontent.com/59202075/159138991-88fe5e21-1424-40b1-8b6d-a6a3cf85dfdd.png)

instead of

![image](https://user-images.githubusercontent.com/59202075/159139006-e47f35ad-960e-4971-8d05-abede1477fb1.png)

