### PR TITLE
Added a white space between text and link in donate page

### DIFF
--- a/src/data/en.yml
+++ b/src/data/en.yml
@@ -261,7 +261,7 @@ download:
   support-1: >-
     We need your help! p5.js is free, open-source software. We want to make our community as open
     and inclusive as possible. You can support this work by making a donation to
-    the
+    the 
   support-2: >-
     , the organization that supports p5.js.
     Your donation supports software development for p5.js, education resources

--- a/src/data/en.yml
+++ b/src/data/en.yml
@@ -258,10 +258,10 @@ download:
   supported-browsers: 'Supported browsers '
   support-title: Support p5.js!
   support-options: Support Options
-  support-1: >-
-    We need your help! p5.js is free, open-source software. We want to make our community as open
+  support-1:
+    'We need your help! p5.js is free, open-source software. We want to make our community as open
     and inclusive as possible. You can support this work by making a donation to
-    the 
+    the '
   support-2: >-
     , the organization that supports p5.js.
     Your donation supports software development for p5.js, education resources


### PR DESCRIPTION
Fixes #1186 

 Changes: 

I have added the white space between 'the processing foundation' in English language and it will not affect the other languages. 

