### PR TITLE
added gitattributes to disable autocrlf, addressing issue #1234

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# prevents git from converting LF to CRLF, which causes issues
+# when assembling example pages on Windows
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+# Set default behaviour to automatically normalize line endings.
+* text=auto
+
 # prevents git from converting LF to CRLF, which causes issues
 # when assembling example pages on Windows
-* text eol=lf
+data/examples/**/*.js eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,13 @@
 # prevents git from converting LF to CRLF, which causes issues
 # when assembling example pages on Windows
 data/examples/**/*.js eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.mov binary
+*.mp3 binary
+*.mp4 binary
+*.gif binary
+*.webm binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,11 +6,19 @@
 data/examples/**/*.js eol=lf
 
 # Denote all files that are truly binary and should not be modified.
-*.png binary
+*.ai binary
+*.gif binary
+*.ico binary
 *.jpg binary
-*.jpeg binary
 *.mov binary
 *.mp3 binary
 *.mp4 binary
-*.gif binary
+*.ogg binary
+*.ogv binary
+*.otf binary
+*.pdf binary
+*.png binary
+*.ttf binary
+*.wav binary
 *.webm binary
+*.zip binary


### PR DESCRIPTION
Fixes/addresses #1234 (also #430)

Changes: 
 
I've added a .gitattributes file that disables git autocrlf on the repository. On Windows, git will convert LF to CRLF on checkout,  [which breaks findName() in the build script.](https://github.com/processing/p5.js-website/issues/430#issuecomment-474461235) Hopefully this will make this problem less likely to come back up for those on Windows.