### PR TITLE
Correction of Issue Template label

### DIFF
--- a/.github/ISSUE_TEMPLATE/discussion.yml
+++ b/.github/ISSUE_TEMPLATE/discussion.yml
@@ -1,10 +1,10 @@
 name: 💭 Discussion
 description: This template is for starting a discussion.
-labels: [discussion]
+labels: [ Discussion ]
 body:
-- type: textarea
-  attributes:
-    label: Topic
-    description: What do you want to discuss with the group?
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Topic
+      description: What do you want to discuss with the group?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,6 @@
 name: 🌱 New Feature Request
 description: Request a new feature be added.
-labels: [feature request]
+labels: [ Feature Request ]
 body:
   - type: textarea
     attributes:
@@ -27,7 +27,7 @@ body:
         - Showcase
         - Other (specify if possible)
     validations:
-        required: true
+      required: true
 
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/found-a-bug.yml
+++ b/.github/ISSUE_TEMPLATE/found-a-bug.yml
@@ -1,6 +1,6 @@
 name: "🐛 Found a Bug"
 description: Report p5.js website bugs (broken or incorrect behaviour).
-labels: [ bug ]
+labels: [ Bug ]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/improve-translation.yml
+++ b/.github/ISSUE_TEMPLATE/improve-translation.yml
@@ -1,6 +1,6 @@
 name: "🌐 Improve Translation"
 description: Make a suggestion or report a problem about the translation of p5.js website.
-labels: [ translation ]
+labels: [ Translation ]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
 ## Changes 

I have confirmed that the label names in the Issue Template do not match, so they are not automatically labeled.

- The label name was capitalized, so corrected.
- Formatting was not consistent, so reformatted.


## Screenshots of the change
<!-- Add screenshots depicting the changes. -->

|These two should be automatically labeled as `Bug`|
|:---:|
|![image](https://user-images.githubusercontent.com/69892552/180423204-d4d380e9-9e49-4bf1-8ada-0b1c086def4e.png)|
