### PR TITLE
changed canvas size

### DIFF
--- a/src/data/examples/en/09_Simulate/00_Forces.js
+++ b/src/data/examples/en/09_Simulate/00_Forces.js
@@ -16,7 +16,7 @@ let movers = [];
 let liquid;
 
 function setup() {
-  createCanvas(640, 360);
+  createCanvas(740, 360);
   reset();
   // Create liquid object
   liquid = new Liquid(0, height / 2, width, height / 2, 0.1);

--- a/src/data/examples/en/09_Simulate/02_Flocking.js
+++ b/src/data/examples/en/09_Simulate/02_Flocking.js
@@ -12,7 +12,7 @@
 let flock;
 
 function setup() {
-  createCanvas(640, 360);
+  createCanvas(740, 360);
   createP("Drag the mouse to generate new boids.");
 
   flock = new Flock();

--- a/src/data/examples/en/09_Simulate/03_WolframCA.js
+++ b/src/data/examples/en/09_Simulate/03_WolframCA.js
@@ -16,7 +16,7 @@ let generation = 0;
 let ruleset = [0, 1, 0, 1, 1, 0, 1, 0];
 
 function setup() {
-  createCanvas(640, 400);
+  createCanvas(740, 400);
   cells = Array(floor(width / w));
   for (let i = 0; i < cells.length; i++) {
     cells[i] = 0;

--- a/src/data/examples/en/09_Simulate/11_SmokeParticleSystem.js
+++ b/src/data/examples/en/09_Simulate/11_SmokeParticleSystem.js
@@ -18,7 +18,7 @@ function preload() {
 function setup() {
 
   //set the canvas size
-  createCanvas(640, 360);
+  createCanvas(740, 360);
 
   //initialize our particle system
   ps = new ParticleSystem(0, createVector(width / 2, height - 60), particle_texture);

--- a/src/data/examples/es/09_Simulate/00_Forces.js
+++ b/src/data/examples/es/09_Simulate/00_Forces.js
@@ -15,7 +15,7 @@ let movers = [];
 let liquid;
 
 function setup() {
-  createCanvas(640, 360);
+  createCanvas(740, 360);
   reset();
   // Crear objeto líquido
   liquid = new Liquid(0, height / 2, width, height / 2, 0.1);

--- a/src/data/examples/es/09_Simulate/02_Flocking.js
+++ b/src/data/examples/es/09_Simulate/02_Flocking.js
@@ -13,7 +13,7 @@ let flock;
 let text;
 
 function setup() {
-  createCanvas(640, 360);
+  createCanvas(740, 360);
   createP("Drag the mouse to generate new boids.");
 
   flock = new Flock();

--- a/src/data/examples/es/09_Simulate/03_WolframCA.js
+++ b/src/data/examples/es/09_Simulate/03_WolframCA.js
@@ -15,7 +15,7 @@ let generation = 0;
 let ruleset = [0, 1, 0, 1, 1, 0, 1, 0];
 
 function setup() {
-  createCanvas(640, 400);
+  createCanvas(740, 400);
   cells = Array(floor(width / w));
   for (let i = 0; i < cells.length; i++) {
     cells[i] = 0;

--- a/src/data/examples/es/09_Simulate/11_SmokeParticleSystem.js
+++ b/src/data/examples/es/09_Simulate/11_SmokeParticleSystem.js
@@ -16,7 +16,7 @@ function preload() {
 function setup() {
 
     //definir el tamaño del lienzo
-    createCanvas(640, 360);
+    createCanvas(740, 360);
 
     //inicializar nuestro sistema de partículas
     ps = new ParticleSystem(0,createVector(width / 2, height - 60),particle_texture);

--- a/src/data/examples/hi/09_Simulate/00_Forces.js
+++ b/src/data/examples/hi/09_Simulate/00_Forces.js
@@ -15,7 +15,7 @@ let movers = [];
 let liquid;
 
 function setup() {
-  createCanvas(640, 360);
+  createCanvas(740, 360);
   reset();
   // तरल वस्तु बनाएं
   liquid = new Liquid(0, height / 2, width, height / 2, 0.1);

--- a/src/data/examples/hi/09_Simulate/02_Flocking.js
+++ b/src/data/examples/hi/09_Simulate/02_Flocking.js
@@ -11,7 +11,7 @@
 let flock;
 
 function setup() {
-  createCanvas(640, 360);
+  createCanvas(740, 360);
   createP("Drag the mouse to generate new boids.");
 
   flock = new Flock();

--- a/src/data/examples/hi/09_Simulate/03_WolframCA.js
+++ b/src/data/examples/hi/09_Simulate/03_WolframCA.js
@@ -15,7 +15,7 @@ let generation = 0;
 let ruleset = [0, 1, 0, 1, 1, 0, 1, 0];
 
 function setup() {
-  createCanvas(640, 400);
+  createCanvas(740, 400);
   cells = Array(floor(width / w));
   for (let i = 0; i < cells.length; i++) {
     cells[i] = 0;

--- a/src/data/examples/hi/09_Simulate/11_SmokeParticleSystem.js
+++ b/src/data/examples/hi/09_Simulate/11_SmokeParticleSystem.js
@@ -17,7 +17,7 @@ function preload() {
 function setup() {
 
  // कैनवास का आकार निर्धारित करें
-  createCanvas(640, 360);
+  createCanvas(740, 360);
 
   // हमारे कण प्रणाली को इनिशियलाइज़ करें
   ps = new ParticleSystem(0, createVector(width / 2, height - 60), particle_texture);

--- a/src/data/examples/ko/09_Simulate/00_Forces.js
+++ b/src/data/examples/ko/09_Simulate/00_Forces.js
@@ -14,7 +14,7 @@ let movers = [];
 let liquid;
 
 function setup() {
-  createCanvas(640, 360);
+  createCanvas(740, 360);
   reset();
   // liquid(액체) 객체 생성
   liquid = new Liquid(0, height / 2, width, height / 2, 0.1);

--- a/src/data/examples/ko/09_Simulate/02_Flocking.js
+++ b/src/data/examples/ko/09_Simulate/02_Flocking.js
@@ -11,7 +11,7 @@
 let flock;
 
 function setup() {
-  createCanvas(640, 360);
+  createCanvas(740, 360);
   createP("Drag the mouse to generate new boids.");
 
   flock = new Flock();

--- a/src/data/examples/ko/09_Simulate/03_WolframCA.js
+++ b/src/data/examples/ko/09_Simulate/03_WolframCA.js
@@ -15,7 +15,7 @@ let generation = 0;
 let ruleset = [0, 1, 0, 1, 1, 0, 1, 0];
 
 function setup() {
-  createCanvas(640, 400);
+  createCanvas(740, 400);
   cells = Array(floor(width / w));
   for (let i = 0; i < cells.length; i++) {
     cells[i] = 0;

--- a/src/data/examples/ko/09_Simulate/11_SmokeParticleSystem.js
+++ b/src/data/examples/ko/09_Simulate/11_SmokeParticleSystem.js
@@ -18,7 +18,7 @@ function preload() {
 function setup() {
 
   // 캔버스 사이즈 설정
-  createCanvas(640, 360);
+  createCanvas(740, 360);
 
   // 파티클 시스템 초기화
   ps = new ParticleSystem(0, createVector(width / 2, height - 60), particle_texture);

--- a/src/data/examples/zh-Hans/09_Simulate/00_Forces.js
+++ b/src/data/examples/zh-Hans/09_Simulate/00_Forces.js
@@ -15,7 +15,7 @@ let movers = [];
 let liquid;
 
 function setup() {
-  createCanvas(640, 360);
+  createCanvas(740, 360);
   reset();
   // Create liquid object
   liquid = new Liquid(0, height / 2, width, height / 2, 0.1);

--- a/src/data/examples/zh-Hans/09_Simulate/02_Flocking.js
+++ b/src/data/examples/zh-Hans/09_Simulate/02_Flocking.js
@@ -11,7 +11,7 @@
 let flock;
 
 function setup() {
-  createCanvas(640, 360);
+  createCanvas(740, 360);
   createP("Drag the mouse to generate new boids.");
 
   flock = new Flock();

--- a/src/data/examples/zh-Hans/09_Simulate/03_WolframCA.js
+++ b/src/data/examples/zh-Hans/09_Simulate/03_WolframCA.js
@@ -15,7 +15,7 @@ let generation = 0;
 let ruleset = [0, 1, 0, 1, 1, 0, 1, 0];
 
 function setup() {
-  createCanvas(640, 400);
+  createCanvas(740, 400);
   cells = Array(floor(width / w));
   for (let i = 0; i < cells.length; i++) {
     cells[i] = 0;

--- a/src/data/examples/zh-Hans/09_Simulate/11_SmokeParticleSystem.js
+++ b/src/data/examples/zh-Hans/09_Simulate/11_SmokeParticleSystem.js
@@ -17,7 +17,7 @@ function preload() {
 function setup() {
 
   //set the canvas size
-  createCanvas(640, 360);
+  createCanvas(740, 360);
 
   //initialize our particle system
   ps = new ParticleSystem(0, createVector(width / 2, height - 60), particle_texture);


### PR DESCRIPTION
Fixes #1227 

 Changes: 

 Fixed the canvas sizes of
 1. Forces example (https://p5js.org/examples/simulate-forces.html) 
 2. Flocking example (https://p5js.org/examples/simulate-flocking.html) 
 3. Wolfman example CA (https://p5js.org/examples/simulate-wolfram-ca.html) 
 4. SmokeParticles example (https://p5js.org/examples/simulate-smokeparticles.html) 


 Screenshots of the change: 
1. Forces example canvas Before the changes
<img width="554" alt="image" src="https://user-images.githubusercontent.com/85433137/182436995-430bb60b-73e3-4865-864f-cf12c69d28b4.png">

Forces example canvas After the changes

<img width="563" alt="image" src="https://user-images.githubusercontent.com/85433137/182437036-d57bbd34-e6da-4587-8ef5-19a2423a178e.png">

2. Flocking example canvas Before the changes

<img width="554" alt="image" src="https://user-images.githubusercontent.com/85433137/182437738-927c48fb-e2c9-450d-91ad-6c004d8edbdc.png">

Flocking example canvas After the changes

<img width="567" alt="image" src="https://user-images.githubusercontent.com/85433137/182438522-b725ea0f-6290-408e-8c63-4557f2acc13b.png">

3. Wolfman CA example canvas Before the changes

<img width="552" alt="image" src="https://user-images.githubusercontent.com/85433137/182438712-7acbc84f-ede1-472f-a6c5-12358e390d47.png">

Wolfman CA example canvas After the changes


<img width="566" alt="image" src="https://user-images.githubusercontent.com/85433137/182438930-37e66ef5-a9e2-47ec-a0bb-c6700ddea373.png">

4. SmokeParticles example canvas Before the changes

<img width="558" alt="image" src="https://user-images.githubusercontent.com/85433137/182439230-8178d7f2-af4a-4cca-9713-8a045b669cf3.png">

SmokeParticles example canvas After the changes

<img width="562" alt="image" src="https://user-images.githubusercontent.com/85433137/182439625-eb233849-2bce-42c5-9aa6-4cdf67b52d8d.png">

