### PR TITLE
Replace grunt-html with htmlhint

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -342,8 +342,22 @@ module.exports = function(grunt) {
         dest: 'p5-reference/'
       }
     },
-    htmllint: {
-      all: {
+
+    htmlhint: {
+      html1: {
+        options: {
+          'attr-value-double-quotes': false,
+          'alt-require': true,
+          'doctype-first': true,
+          'title-require': true,
+          'attr-no-duplication': true,
+          'input-requires-label': true,
+          'tags-check': true,
+          'tagname-lowercase': true,
+          'tagname-specialchars': true,
+          'empty-tag-not-self-closed': true,
+          'id-unique': true
+        },
         src: [
           '<%= config.dist %>/**/*.html',
           '!<%= config.dist %>/**/CHANGES.html',
@@ -352,17 +366,10 @@ module.exports = function(grunt) {
           '!<%= config.dist %>/**/learn/*.html',
           '!<%= config.dist %>/**/examples/*.html',
           '!<%= config.dist %>/**/reference/assets/index.html'
-        ],
-        options: {
-          ignore: [
-            /^This document appears to be written in English/,
-            /^Bad value “https:/,
-            /^Consider adding a “lang” attribute to the “html”/,
-            /^Attribute “paypalexpress” not allowed on element “script” at this point./
-          ]
-        }
+        ]
       }
     },
+
     shell: {
       generate_dataJSON: {
         command: `git checkout ${grunt.option('target')} && npm ci && npm run grunt yui build`,
@@ -402,7 +409,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-file-append');
   grunt.loadNpmTasks('grunt-contrib-compress');
   grunt.loadNpmTasks('grunt-contrib-requirejs');
-  grunt.loadNpmTasks('grunt-html');
+  grunt.loadNpmTasks('grunt-htmlhint');
 
   // i18n tracking task
   grunt.registerTask('i18n', function() {
@@ -495,7 +502,7 @@ module.exports = function(grunt) {
     'file_append',
     'compress',
     'i18n',
-    'htmllint'
+    'htmlhint'
   ]);
 
   // runs with just grunt command

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Other Language Steward(s):
 
 ## Setup
 
-0. Ensure Java is installed. Not installed?  Head over to [Java](https://www.oracle.com/java/technologies/downloads/) for installation.
 1. Install [node.js](https://nodejs.org/en/download/).
 2. Clone this repo by typing ```git clone https://github.com/processing/p5.js-website/``` in terminal.
 3. Navigate to the `p5.js-website` directory in the terminal and type `npm install`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3294,6 +3294,44 @@
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
     },
+    "cli": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+      "integrity": "sha512-4H6IzYk78R+VBeJ3fH3VQejcQRkGPR+kMjA9n30srEN+YVMPJLHfoQDtLquIzcLnfrlUrVA8qSQRB9fdgWpUBw==",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "~ 3.2.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
+          "dev": true,
+          "requires": {
+            "inherits": "2",
+            "minimatch": "0.3"
+          }
+        },
+        "lru-cache": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+          "integrity": "sha512-WpibWJ60c3AgAz8a2iYErDrcT2C7OmKnsWhIcHOjkUHFjkXncJhtLxNSqUmxRxRunpb5I8Vprd7aNSd2NtksJQ==",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
+          }
+        }
+      }
+    },
     "cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
@@ -3943,6 +3981,15 @@
       "integrity": "sha512-3R0kMOdL7CjJpU66fzAkCe6HNtd3AavCS4m+uW4KtJjrdGPT0SQEZieAYd+cm+lJoBznNQ4lqipYWkhBMgk00g==",
       "dev": true
     },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha512-duS7VP5pvfsNLDvL1O4VOEbw37AI3A4ZUQYemvDlnpGrNu9tprR7BYWpDYwC0Xia0Zxz5ZupdiIrUp0GH1aXfg==",
+      "dev": true,
+      "requires": {
+        "date-now": "^0.1.4"
+      }
+    },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -4184,6 +4231,15 @@
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
+    },
+    "csslint": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/csslint/-/csslint-0.10.0.tgz",
+      "integrity": "sha512-mlD1oDw0juzD4dOthyAytPC4NsXqVZeIYAScIbgoYGY+Q7vcrhOQrH7js4JVZXcrOyKxi8ytC42ENMwO9CdnMQ==",
+      "dev": true,
+      "requires": {
+        "parserlib": "~0.2.2"
+      }
     },
     "cssnano": {
       "version": "4.1.11",
@@ -4667,6 +4723,12 @@
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
       "dev": true
     },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha512-AsElvov3LoNB7tf5k37H2jYSB+ZZPMT5sG2QjJCcdlV5chIv6htBUBUui2IKRjgtKAKtCBN7Zbwa+MtwLjSeNw==",
+      "dev": true
+    },
     "date-time": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/date-time/-/date-time-1.1.0.tgz",
@@ -5110,6 +5172,15 @@
       "dev": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
+      }
+    },
+    "domhandler": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "integrity": "sha512-q9bUwjfp7Eif8jWxxxPSykdRZAb6GkguBGSgvvCrhI9wB71W2K/Kvv4E61CF/mcCfnVJDeDWx/Vb/uAqbDj6UQ==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -8145,58 +8216,13 @@
       "integrity": "sha1-P376M2lvoFdwsoCU9EUIyvxdLto=",
       "dev": true
     },
-    "grunt-html": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/grunt-html/-/grunt-html-11.1.1.tgz",
-      "integrity": "sha512-YAurPMB/GUsy8UZdNYZ38pTTGYKoXuTxi6CkIYtxSRfxKEJCCK0JSDJn5UbAvA0MK86CMhOsMeO+4qcu9KnPHw==",
+    "grunt-htmlhint": {
+      "version": "0.9.13",
+      "resolved": "https://registry.npmjs.org/grunt-htmlhint/-/grunt-htmlhint-0.9.13.tgz",
+      "integrity": "sha512-RK94yzM8O1pyMWQHaXFyIG9rMD45tL+SzWiOXHyzmS3deSUjsyPoAZIHVVLzahWxX4gFzKu/5/wQW+impmWlkA==",
       "dev": true,
       "requires": {
-        "async": "^3.1.0",
-        "chalk": "^2.4.2",
-        "vnu-jar": "19.9.4"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "async": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "htmlhint": "~0.9.13"
       }
     },
     "grunt-known-options": {
@@ -9085,6 +9111,104 @@
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-1.2.0.tgz",
       "integrity": "sha1-x43mW1Zjqll5id0rerSSANfk25g=",
       "dev": true
+    },
+    "htmlhint": {
+      "version": "0.9.13",
+      "resolved": "https://registry.npmjs.org/htmlhint/-/htmlhint-0.9.13.tgz",
+      "integrity": "sha512-v+MLf9ipmmeFnsOJVceg5chOwPtXszVc1weN0jBFO71Zv9zet6ae4aCpXx95+MwXyyl0FXR57CB9PkjFc0pL0w==",
+      "dev": true,
+      "requires": {
+        "async": "1.4.2",
+        "colors": "1.0.3",
+        "commander": "2.6.0",
+        "csslint": "0.10.0",
+        "glob": "5.0.15",
+        "jshint": "2.8.0",
+        "parse-glob": "3.0.4",
+        "strip-json-comments": "1.0.4",
+        "xml": "1.0.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
+          "integrity": "sha512-O4fvy4JjdS0Q8MYH4jOODxJdXGbZ61eqfXdmfFDloHSnWoggxkn/+xWbh2eQbmQ6pJNliaravcTK1iQMpW9k4Q==",
+          "dev": true
+        },
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
+          "integrity": "sha512-PhbTMT+ilDXZKqH8xbvuUY2ZEQNef0Q7DKxgoEKb4ccytsdvVVJmYqR0sGbi96nxU6oGrwEIQnclpK2NBZuQlg==",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha512-AOPG8EBc5wAikaG1/7uFCNFJwnKOuQwFTpYBdTW6OvWHeZBQBrAA/amefHGrEiOnCPcLFZK6FUPtWVKpQVIRgg==",
+          "dev": true
+        }
+      }
+    },
+    "htmlparser2": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "integrity": "sha512-hBxEg3CYXe+rPIua8ETe7tmG3XDn9B0edOE/e9wH2nLczxzgdu0m0aNHY+5wFZiviLWLdANPJTssa92dMcXQ5Q==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
+      },
+      "dependencies": {
+        "domutils": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+          "integrity": "sha512-gSu5Oi/I+3wDENBsOWBiRK1eoGxcywYSqg3rR960/+EfY0CF4EX1VPkgHOZ3WiS/Jg2DtliF6BhWcHlfpYUcGw==",
+          "dev": true,
+          "requires": {
+            "dom-serializer": "0",
+            "domelementtype": "1"
+          }
+        },
+        "entities": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+          "integrity": "sha512-LbLqfXgJMmy81t+7c14mnulFHJ170cM6E+0vMXR9k/ZiZwgX8i5pNgjTCX3SO4VeUsFLV+8InixoretwU+MjBQ==",
+          "dev": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+          "dev": true
+        }
+      }
     },
     "http-cache-semantics": {
       "version": "3.8.1",
@@ -10669,6 +10793,45 @@
         "whatwg-url": "^6.4.1",
         "ws": "^5.2.0",
         "xml-name-validator": "^3.0.0"
+      }
+    },
+    "jshint": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.8.0.tgz",
+      "integrity": "sha512-IJJlrjPQU0fBkuV2Sgm4OKyHH5cFx2QToQgpkcyJcrF8gjG2AVpVnRqPQ3JrmlTQPiVlp9KAKfGezHk3mr7VJw==",
+      "dev": true,
+      "requires": {
+        "cli": "0.6.x",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "3.7.x",
+        "minimatch": "2.0.x",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+          "integrity": "sha512-73GDDlioRJOCHV8N9gnBEpjdWI34+e9AvMnS4qdqdMfl8/yH/dJP1tfuqUFccZ/deZQlHuJiRSuKXjKIfDwBOg==",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha512-jQo6o1qSVLEWaw3l+bwYA2X0uLuK2KjNh2wjgO7Q/9UJnXr1Q3yQKR8BI0/Bt/rPg75e6SMW4hW/6cBHVTZUjA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha512-AOPG8EBc5wAikaG1/7uFCNFJwnKOuQwFTpYBdTW6OvWHeZBQBrAA/amefHGrEiOnCPcLFZK6FUPtWVKpQVIRgg==",
+          "dev": true
+        }
       }
     },
     "json-buffer": {
@@ -13592,7 +13755,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -13954,6 +14117,12 @@
         "mixin-deep": "^1.2.0",
         "trim-leading-lines": "^0.1.1"
       }
+    },
+    "parserlib": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/parserlib/-/parserlib-0.2.5.tgz",
+      "integrity": "sha512-SNu7MNq2Lp5aHXM1HZLyXEHpSAVpHU1y3pvPpxnq6jVK/5WIpKv9aA11PyMeiW9Y+EORem2J7XhiEIaOKizUHA==",
+      "dev": true
     },
     "parseurl": {
       "version": "1.3.3",
@@ -18039,6 +18208,12 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shelljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+      "integrity": "sha512-Ny0KN4dyT8ZSCE0frtcbAJGoM/HTArpyPkeli1/00aYfm0sbD/Gk/4x7N2DP9QKGpBsiQH7n6rpm1L79RtviEQ==",
+      "dev": true
+    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -20461,12 +20636,6 @@
         }
       }
     },
-    "vnu-jar": {
-      "version": "19.9.4",
-      "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-19.9.4.tgz",
-      "integrity": "sha512-x91WyaNr1oPJaYZkbyMElRyV60BUaxPuhm3zXXjlFOpW3E2KavPWlyohX0LTf6gX7/tujIMgLE5UGc0jn7o4XQ==",
-      "dev": true
-    },
     "void-elements": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
@@ -20678,6 +20847,12 @@
       "requires": {
         "async-limiter": "~1.0.0"
       }
+    },
+    "xml": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.0.tgz",
+      "integrity": "sha512-NpTtJIGjrofxyTNuc497ZTI/LfhWMSTWbCnAQ8w7DZLgIwn7pWjHNcOhghCEPgzdrwXSZJNxh/dHjunId2jhNQ==",
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "grunt-contrib-watch": "^1.1.0",
     "grunt-exec": "^1.0.1",
     "grunt-file-append": "0.0.7",
-    "grunt-html": "^11.1.1",
+    "grunt-htmlhint": "^0.9.13",
     "grunt-newer": "^1.3.0",
     "grunt-postcss": "^0.9.0",
     "grunt-serve": "^0.1.6",


### PR DESCRIPTION
Fixes #1260

 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Replaced `htmllint` task from `grunt-html` with `htmlhint` from `grunt-htmlhint` which also remove the Java dependency requirement. There is no guarantee the rules in place for `htmlhint` matches the previous rules as I cannot find a good source for what the rules for `grunt-html` are, but a reasonable default is set for now.