### PR TITLE
Adjusting frame rate for Game of Life example 

### DIFF
--- a/src/data/examples/en/09_Simulate/04_GameOfLife.js
+++ b/src/data/examples/en/09_Simulate/04_GameOfLife.js
@@ -10,8 +10,12 @@ let columns;
 let rows;
 let board;
 let next;
+let framerate;
 
 function setup() {
+  // Set simulation framerate to 10 to avoid flickering
+  framerate = 10;
+  frameRate(framerate);
   createCanvas(720, 400);
   w = 20;
   // Calculate columns and rows

--- a/src/data/examples/en/09_Simulate/04_GameOfLife.js
+++ b/src/data/examples/en/09_Simulate/04_GameOfLife.js
@@ -10,12 +10,10 @@ let columns;
 let rows;
 let board;
 let next;
-let framerate;
 
 function setup() {
   // Set simulation framerate to 10 to avoid flickering
-  framerate = 10;
-  frameRate(framerate);
+  frameRate(10);
   createCanvas(720, 400);
   w = 20;
   // Calculate columns and rows


### PR DESCRIPTION
Fixes #1283

 Changes: 
Added framerate variable, then used `frameRate()` function to set frame rate to 10. This avoids the flickering effect when displaying the Game of Life example.


 Screenshots of the change: 
<img width="704" alt="Screen Shot 2022-10-19 at 9 54 04 am" src="https://user-images.githubusercontent.com/103348212/196560329-9bc7d99e-0c5b-4c9b-a60e-a9c20a649463.png">
