### PR TITLE
Fix reference translation for curves (Spanish)

### DIFF
--- a/src/data/reference/es.json
+++ b/src/data/reference/es.json
@@ -573,20 +573,20 @@
     },
     "curve": {
       "description": [
-        "Dibuja una línea curva en la pantalla entre dos puntos, dados como los cuatro parámetros centrales. Los dos primeros puntos son un punto de control, como si la curva viniera desde este punto, aunque no sea dibujado. Los dos últimos parámetros de forma similar describen el otro punto de control. SE pueden cerar curvas más largas, por medio del posicionamiento de varias funciones curve() juntas o usando curveVertex(). Una función adicional llamada curveTightness() provee control de la calidad visual de la curva. La función curve() es una implementación de la Catmull-Rom spline."
+        "Dibuja una línea curva en la pantalla entre dos puntos, dados como los cuatro parámetros centrales. Los dos primeros puntos son un punto de control, como si la curva viniera desde este punto, aunque no sea dibujado. Los dos últimos parámetros de forma similar describen el otro punto de control. Se pueden crear curvas más largas, por medio del posicionamiento de varias funciones curve() juntas o usando curveVertex(). Una función adicional llamada curveTightness() provee control de la calidad visual de la curva. La función curve() es una implementación de la Catmull-Rom spline."
       ],
       "params": {
         "x1": "Número: coordenada x del punto de control inicial",
         "y1": "Número: coordenada y del punto de control inicial",
-        "x2": "Número: coordenada y del primer punto",
-        "y2": "Número: coordenada x del segundo punto",
-        "x3": "Número: coordenada x del punto de control final",
-        "y3": "Número: coordenada y del punto de control final",
-        "x4": "Número: coordenada z del primer punto",
-        "y4": "Número: coordenada z del segundo punto",
-        "z1": "Número: coordenada x del primer punto",
-        "z2": "Número: coordenada y del segundo punto",
-        "z3": "Número: coordenada z del punto de control inicial",
+        "x2": "Número: coordenada x del primer punto",
+        "y2": "Número: coordenada y del primer punto",
+        "x3": "Número: coordenada x del segundo punto",
+        "y3": "Número: coordenada y del segundo punto",
+        "x4": "Número: coordenada x del punto de control final",
+        "y4": "Número: coordenada y del punto de control final",
+        "z1": "Número: coordenada z del punto de control inicial",
+        "z2": "Número: coordenada z del primer punto",
+        "z3": "Número: coordenada z del segundo punto",
         "z4": "Número: coordenada z del punto de control final"
       }
     },


### PR DESCRIPTION
Fixes part of #1225

 Changes: 
Fix parameter order descriptions. 
Fix 2 typos : 
 - SE -> Se
 - cerar -> crear

 Screenshots of the change: 
<img width="1246" alt="image" src="https://user-images.githubusercontent.com/26748227/213936283-65c8f960-5df0-48ff-a0b1-14cbcd5d97d1.png">

