### PR TITLE
Resolves issue #1316: corrected asset filepath in WebGL Learn page tutorials

### DIFF
--- a/src/templates/pages/learn/getting-started-in-webgl-appearance.hbs
+++ b/src/templates/pages/learn/getting-started-in-webgl-appearance.hbs
@@ -63,13 +63,13 @@ slug: learn/
       <p>{{#i18n "getting-started-in-webgl-appearance-p1x1"}}{{/i18n}} <a class="code" href="{{root}}/reference/#/p5/perspective">perspective()</a> {{#i18n "getting-started-in-webgl-appearance-p1x2"}}{{/i18n}} <a
       class="code" href="{{root}}/reference/#/p5/ortho">ortho()</a>.</p>
 
-      <img style="padding:60px;" src='{{assets}}/learn/basic3D/images/cameraTypeIllustration.png'
+      <img style="padding:60px;" src='{{assets}}/learn/basic3d/images/cameraTypeIllustration.png'
         alt="an illustration showing the difference between perspective and orthographic camera types">
 
       <p>{{#i18n "getting-started-in-webgl-appearance-p2x1"}}{{/i18n}}</p>
 
       {{!-- sketch illustrating 3D camera --}}
-      <iframe src="{{assets}}/learn/basic3D/cameraExample.html" width="720" height="350">
+      <iframe src="{{assets}}/learn/basic3d/cameraExample.html" width="720" height="350">
       </iframe>
 
       <p>{{#i18n "getting-started-in-webgl-appearance-p3x1"}}{{/i18n}}</p>
@@ -77,7 +77,7 @@ slug: learn/
       <p>{{#i18n "getting-started-in-webgl-appearance-p4x1"}}{{/i18n}}</p>
 
       <div style="display:flex; align-items:center; justify-content: center;">
-      <img style="width:50%;" src='{{assets}}/learn/basic3D/images/frustum_example.png'
+      <img style="width:50%;" src='{{assets}}/learn/basic3d/images/frustum_example.png'
         alt="an illustration showing the the camera frustum in purple, the near plane represented by a 
         yellow rectangle near the camera, and far plane as a green rectangle on the opposite end of the frustum volume.">
       </div>
@@ -158,7 +158,7 @@ function draw() {
       </p>
 
       {{!-- sketch illustrating lighting of geometry --}}
-      <iframe src="{{assets}}/learn/basic3D/lightingExample.html" width="720" height="350">
+      <iframe src="{{assets}}/learn/basic3d/lightingExample.html" width="720" height="350">
       </iframe>
 
       <p>{{#i18n "getting-started-in-webgl-appearance-p9x1"}}{{/i18n}}</p>
@@ -220,7 +220,7 @@ function draw() {
       <p>{{#i18n "getting-started-in-webgl-appearance-p11x1"}}{{/i18n}}</p>
 
       {{!-- sketch illustrating materials --}}
-      <iframe src="{{assets}}/learn/basic3D/materialsExample.html" width="720" height="350">
+      <iframe src="{{assets}}/learn/basic3d/materialsExample.html" width="720" height="350">
       </iframe>
 
       <p>{{#i18n "getting-started-in-webgl-appearance-p12x1"}}{{/i18n}}</p>
@@ -269,7 +269,7 @@ function draw() {
 let myTexture;
 
 function preload() {
-  myTexture = loadImage("{{assets}}/learn/basic3D/images/simpleTexture.png");
+  myTexture = loadImage("{{assets}}/learn/basic3d/images/simpleTexture.png");
   // map textures between 0 and 1 to match geometry uvs
   textureMode(NORMAL);
 }

--- a/src/templates/pages/learn/getting-started-in-webgl-coords-and-transform.hbs
+++ b/src/templates/pages/learn/getting-started-in-webgl-coords-and-transform.hbs
@@ -43,7 +43,7 @@ slug: learn/
       <script src="//toolness.github.io/p5.js-widget/p5-widget.js"></script>
 
       {{!-- large title sketch --}}
-      <iframe src="{{assets}}/learn/basic3D/titleExample.html" width="720" height="350">
+      <iframe src="{{assets}}/learn/basic3d/titleExample.html" width="720" height="350">
       </iframe>
 
       <h1>{{#i18n "getting-started-in-webgl-coords-and-transform-title"}}{{/i18n}}</h1>
@@ -98,7 +98,7 @@ slug: learn/
 
       <p>{{#i18n "getting-started-in-webgl-coords-and-transform-p6x1"}}{{/i18n}}</p>
 
-      <img style="padding:60px;" src='{{assets}}/learn/basic3D/images/2d3d_coordinates.png'
+      <img style="padding:60px;" src='{{assets}}/learn/basic3d/images/2d3d_coordinates.png'
         alt="an illustration showing a 2D coordinate system on the left, showing an origin of (0,0) and a 3D coordinate system on the right, showing an origin of (0,0,0)">
 
       <h2 id="transformations">{{#i18n "getting-started-in-webgl-coords-and-transform-heading3"}}{{/i18n}}</h2>
@@ -113,7 +113,7 @@ slug: learn/
       <h3>{{#i18n "getting-started-in-webgl-coords-and-transform-subheading1"}}{{/i18n}}</h3>
 
       {{!-- sketch illustrating translation of geometry --}}
-      <iframe src="{{assets}}/learn/basic3D/translateExample.html" width="720" height="350">
+      <iframe src="{{assets}}/learn/basic3d/translateExample.html" width="720" height="350">
       </iframe>
 
       <p><a class="code" href="{{root}}/reference/#/p5/translate">translate()</a> {{#i18n
@@ -130,7 +130,7 @@ slug: learn/
       <h3>{{#i18n "getting-started-in-webgl-coords-and-transform-subheading2"}}{{/i18n}}</h3>
 
       {{!-- sketch illustrating rotation of geometry --}}
-      <iframe src="{{assets}}/learn/basic3D/rotateExample.html" width="720" height="350">
+      <iframe src="{{assets}}/learn/basic3d/rotateExample.html" width="720" height="350">
       </iframe>
 
       <p><a class="code" href="{{root}}/reference/#/p5/rotate">rotate()</a> {{#i18n
@@ -176,7 +176,7 @@ slug: learn/
       <h3>{{#i18n "getting-started-in-webgl-coords-and-transform-subheading3"}}{{/i18n}}</h3>
 
       {{!-- sketch illustrating scaling of geometry --}}
-      <iframe src="{{assets}}/learn/basic3D/scaleExample.html" width="720" height="350">
+      <iframe src="{{assets}}/learn/basic3d/scaleExample.html" width="720" height="350">
       </iframe>
 
       <p><a class="code" href="{{root}}/reference/#/p5/scale">scale()</a> {{#i18n
@@ -280,7 +280,7 @@ function draw() {
 
       <p>{{#i18n "getting-started-in-webgl-coords-and-transform-p19x1"}}{{/i18n}}</p>
 
-      <img style="padding:60px;" src='{{assets}}/learn/basic3D/images/primitives_example.png'
+      <img style="padding:60px;" src='{{assets}}/learn/basic3d/images/primitives_example.png'
         alt="an illustration showing each of the available primitives in p5.js">
 
       <p>{{#i18n "getting-started-in-webgl-coords-and-transform-p20x1"}}{{/i18n}}<a class="code"

--- a/src/templates/pages/learn/getting-started-in-webgl-custom-geometry.hbs
+++ b/src/templates/pages/learn/getting-started-in-webgl-custom-geometry.hbs
@@ -72,7 +72,7 @@ slug: learn/
 let teapotModel;
 
 function preload() {
-  teapotModel = loadModel('{{assets}}/learn/basic3D/models/teapot.obj', true);
+  teapotModel = loadModel('{{assets}}/learn/basic3d/models/teapot.obj', true);
 }
 
 function setup() {
@@ -143,7 +143,7 @@ function draw(){
       {{!-- <div style="display: flex; align-items: center; justify-content: center;">
         <p>{{#i18n "getting-started-in-webgl-custom-geometry-p6x2"}}{{/i18n}}</p>
 
-        <img style="padding:30px; width:50%;" src='{{assets}}/learn/basic3D/images/normals_face_example.png'
+        <img style="padding:30px; width:50%;" src='{{assets}}/learn/basic3d/images/normals_face_example.png'
           alt="an illustration a collection of three points, constituting a face, and an arrow extending perpendicular to it, the normal" />
       </div> --}}
 
@@ -151,7 +151,7 @@ function draw(){
       <p>{{#i18n "getting-started-in-webgl-custom-geometry-p6x2"}}{{/i18n}}</p>
 
       <div style="display: flex; align-items: center; justify-content: center;">
-        <img style="padding:30px; width:60%;" src='{{assets}}/learn/basic3D/images/normals_face_example.png'
+        <img style="padding:30px; width:60%;" src='{{assets}}/learn/basic3d/images/normals_face_example.png'
           alt="an illustration a collection of three points, constituting a face, and an arrow extending perpendicular to it, the normal" />
       </div>
 

--- a/src/templates/pages/learn/getting-started-in-webgl-shaders.hbs
+++ b/src/templates/pages/learn/getting-started-in-webgl-shaders.hbs
@@ -222,7 +222,7 @@ void main() {
   gl_FragColor = vec4(uv,1.0,1.0);
 }
 </code></pre>
-        <img style="padding:30px;width:30%;" src='{{assets}}/learn/basic3D/images/uv_example.png'
+        <img style="padding:30px;width:30%;" src='{{assets}}/learn/basic3d/images/uv_example.png'
           alt="an illustration showing UV coordinates, the x axis in red, and the y axis in blue.">
       </div>
 


### PR DESCRIPTION
Fixes #1316

Fixed the incorrect case in asset url in each WebGL tutorial on the Learn page ('basic3D' -> 'basic3d')

@kjhollen 