### PR TITLE
Updated outdated link in libraries.json

### DIFF
--- a/src/data/libraries/libraries.json
+++ b/src/data/libraries/libraries.json
@@ -4,9 +4,9 @@
       "name": "p5.sound",
       "url": "{{root}}/reference/#/libraries/p5.sound",
       "authors": [
-        { 
+        {
           "name": "Jason Sigal",
-          "url": "https://www.jasonsigal.cc/" 
+          "url": "https://www.jasonsigal.cc/"
         }
       ]
     }
@@ -16,9 +16,9 @@
       "name": "asciiart",
       "url": "https://tetoki.eu/asciiart",
       "authors": [
-        { 
+        {
           "name": "Pawel Janicki",
-          "url": "https://paweljanicki.jp" 
+          "url": "https://paweljanicki.jp"
         }
       ]
     },
@@ -26,9 +26,9 @@
       "name": "c2.js",
       "url": "https://c2js.org/",
       "authors": [
-        { 
+        {
           "name": "Ren Yuan",
-          "url": "https://renyuan.io/" 
+          "url": "https://renyuan.io/"
         }
       ]
     },
@@ -36,9 +36,9 @@
       "name": "CO2Budget.js",
       "url": "https://github.com/OlafVal/CO2Budget.js",
       "authors": [
-        { 
+        {
           "name": "Olaf Val",
-          "url": "http://projects.olafval.de/p5-co2budget-js/" 
+          "url": "http://projects.olafval.de/p5-co2budget-js/"
         }
       ]
     },
@@ -46,9 +46,9 @@
       "name": "Concave Hull",
       "url": "https://github.com/markroland/concaveHullJS",
       "authors": [
-        { 
+        {
           "name": "Mark Roland",
-          "url": "https://markroland.com" 
+          "url": "https://markroland.com"
         }
       ]
     },
@@ -56,9 +56,9 @@
       "name": "grafica.js",
       "url": "https://github.com/jagracar/grafica.js",
       "authors": [
-        { 
+        {
           "name": "Javier Graciá Carpio",
-          "url": "https://jagracar.com/p5jsSketches.php" 
+          "url": "https://jagracar.com/p5jsSketches.php"
         }
       ]
     },
@@ -66,9 +66,9 @@
       "name": "I_AM_UI",
       "url": "https://github.com/zturtledog/I_AM_UI/blob/main/I_AM_UI.js",
       "authors": [
-        { 
+        {
           "name": "sam oakes",
-          "url": "https://github.com/zturtledog" 
+          "url": "https://github.com/zturtledog"
         }
       ]
     },
@@ -76,9 +76,9 @@
       "name": "mappa",
       "url": "https://github.com/cvalenzuela/Mappa",
       "authors": [
-        { 
+        {
           "name": "Cristóbal Valenzuela",
-          "url": "https://github.com/cvalenzuela/" 
+          "url": "https://github.com/cvalenzuela/"
         }
       ]
     },
@@ -86,9 +86,9 @@
       "name": "marching",
       "url": "https://github.com/jtnimoy/marching",
       "authors": [
-        { 
+        {
           "name": "JT Nimoy",
-          "url": "https://jtnimoy.cc/" 
+          "url": "https://jtnimoy.cc/"
         }
       ]
     },
@@ -96,9 +96,9 @@
       "name": "ml5.js",
       "url": "https://ml5js.org/",
       "authors": [
-        { 
+        {
           "name": "NYU ITP/IMA and contributors",
-          "url": "https://ml5js.org/" 
+          "url": "https://ml5js.org/"
         }
       ]
     },
@@ -106,9 +106,9 @@
       "name": "numero",
       "url": "https://github.com/nickmcintyre/numero",
       "authors": [
-        { 
+        {
           "name": "Nick McIntyre",
-          "url": "https://mcintyre.io" 
+          "url": "https://mcintyre.io"
         }
       ]
     },
@@ -116,9 +116,9 @@
       "name": "p5LiveMedia",
       "url": "https://github.com/vanevery/p5LiveMedia",
       "authors": [
-        { 
+        {
           "name": "Shawn Van Every",
-          "url": "http://www.walking-productions.com/notslop/" 
+          "url": "http://www.walking-productions.com/notslop/"
         }
       ]
     },
@@ -126,9 +126,9 @@
       "name": "p5snap",
       "url": "https://www.npmjs.com/package/p5snap",
       "authors": [
-        { 
+        {
           "name": "Zach Krall",
-          "url": "https://zachkrall.com" 
+          "url": "https://zachkrall.com"
         }
       ]
     },
@@ -136,9 +136,9 @@
       "name": "p5.3D",
       "url": "https://github.com/FreddieRa/p5.3D",
       "authors": [
-        { 
+        {
           "name": "Freddie Rawlins",
-          "url": "https://freddierawlins.wixsite.com/site" 
+          "url": "https://freddierawlins.wixsite.com/site"
         }
       ]
     },
@@ -146,9 +146,9 @@
       "name": "p5.animS",
       "url": "https://wixette.github.io/p5.animS/",
       "authors": [
-        { 
+        {
           "name": "Yonggang Wang",
-          "url": "https://github.com/wixette" 
+          "url": "https://github.com/wixette"
         }
       ]
     },
@@ -156,9 +156,9 @@
       "name": "p5.bezier",
       "url": "https://github.com/peilingjiang/p5.bezier",
       "authors": [
-        { 
+        {
           "name": "Peiling Jiang",
-          "url": "https://www.jpl.design" 
+          "url": "https://www.jpl.design"
         }
       ]
     },
@@ -166,17 +166,17 @@
       "name": "p5.ble",
       "url": "https://itpnyu.github.io/p5ble-website/",
       "authors": [
-        { 
+        {
           "name": "Yining Shi",
-          "url": "https://1023.io" 
+          "url": "https://1023.io"
         },
-        { 
+        {
           "name": "Jingwen Zhu",
-          "url": "https://www.jingwen-zhu.com/" 
+          "url": "https://www.jingwen-zhu.com/"
         },
-        { 
+        {
           "name": "Tom Igoe",
-          "url": "https://tigoe.com/" 
+          "url": "https://tigoe.com/"
         }
       ]
     },
@@ -184,9 +184,9 @@
       "name": "p5.bots",
       "url": "https://github.com/sarahgp/p5bots",
       "authors": [
-        { 
+        {
           "name": "Sarah Groff-Palermo",
-          "url": "http://www.sarahgp.com" 
+          "url": "http://www.sarahgp.com"
         }
       ]
     },
@@ -194,9 +194,9 @@
       "name": "p5.button",
       "url": "https://www.nicoatek.com/js_libraries/p5.button.min.js",
       "authors": [
-        { 
+        {
           "name": "Nicolas ATEK",
-          "url": "https://www.nicoatek.com/p5button" 
+          "url": "https://www.nicoatek.com/p5button"
         }
       ]
     },
@@ -204,9 +204,9 @@
       "name": "p5.buttons",
       "url": "https://github.com/koerismo/p5.buttons",
       "authors": [
-        { 
+        {
           "name": "Jadon L",
-          "url": "https://github.com/koerismo" 
+          "url": "https://github.com/koerismo"
         }
       ]
     },
@@ -214,7 +214,7 @@
       "name": "p5.capture",
       "url": "https://github.com/tapioca24/p5.capture",
       "authors": [
-        { 
+        {
           "name": "tapioca24",
           "url": "https://github.com/tapioca24"
         }
@@ -224,9 +224,9 @@
       "name": "p5.clickable",
       "url": "https://github.com/Lartu/p5.clickable",
       "authors": [
-        { 
+        {
           "name": "Martín del Río",
-          "url": "https://www.lartu.net" 
+          "url": "https://www.lartu.net"
         }
       ]
     },
@@ -234,9 +234,9 @@
       "name": "p5.cmyk.js",
       "url": "https://github.com/jtnimoy/p5.cmyk.js",
       "authors": [
-        { 
+        {
           "name": "JT Nimoy",
-          "url": "https://jtnimoy.cc/" 
+          "url": "https://jtnimoy.cc/"
         }
       ]
     },
@@ -244,9 +244,9 @@
       "name": "p5.collide2D",
       "url": "https://github.com/bmoren/p5.collide2D",
       "authors": [
-        { 
+        {
           "name": "Ben Moren",
-          "url": "https://www.benmoren.com/" 
+          "url": "https://www.benmoren.com/"
         }
       ]
     },
@@ -254,19 +254,19 @@
       "name": "P5.Create",
       "url": "https://github.com/zachmohammed/P5.Create",
       "authors": [
-        { 
+        {
           "name": "Zach Mohammed",
-          "url": "https://github.com/zachmohammed" 
+          "url": "https://github.com/zachmohammed"
         }
       ]
-    }, 
+    },
     {
       "name": "p5.createloop",
       "url": "https://www.npmjs.com/package/p5.createloop",
       "authors": [
-        { 
+        {
           "name": "Peter Hayman",
-          "url": "https://www.piratesjustar.com/" 
+          "url": "https://www.piratesjustar.com/"
         }
       ]
     },
@@ -274,13 +274,13 @@
       "name": "p5.dimensions",
       "url": "https://github.com/Smilebags/p5.dimensions.js",
       "authors": [
-        { 
+        {
           "name": "Smilebags",
-          "url": "https://github.com/Smilebags" 
+          "url": "https://github.com/Smilebags"
         },
-        { 
+        {
           "name": "Max Segal",
-          "url": "https://github.com/max0410" 
+          "url": "https://github.com/max0410"
         }
       ]
     },
@@ -288,9 +288,9 @@
       "name": "p5.EasyCam",
       "url": "https://github.com/freshfork/p5.EasyCam",
       "authors": [
-        { 
+        {
           "name": "jWilliam Dunn",
-          "url": "https://jwilliamdunn.com" 
+          "url": "https://jwilliamdunn.com"
         }
       ]
     },
@@ -298,9 +298,9 @@
       "name": "p5.experience",
       "url": "https://github.com/loneboarder/p5.experience.js",
       "authors": [
-        { 
+        {
           "name": "Felix Meichelböck",
-          "url": "https://github.com/loneboarder" 
+          "url": "https://github.com/loneboarder"
         }
       ]
     },
@@ -308,9 +308,9 @@
       "name": "p5.fab",
       "url": "https://github.com/machineagency/p5.fab",
       "authors": [
-        { 
+        {
           "name": "Blair Subbaraman",
-          "url": "https://blairsubbaraman.com/" 
+          "url": "https://blairsubbaraman.com/"
         }
       ]
     },
@@ -318,9 +318,9 @@
       "name": "p5.Framebuffer",
       "url": "https://github.com/davepagurek/p5.Framebuffer",
       "authors": [
-        { 
+        {
           "name": "Dave Pagurek",
-          "url": "https://www.davepagurek.com/" 
+          "url": "https://www.davepagurek.com/"
         }
       ]
     },
@@ -328,9 +328,9 @@
       "name": "p5.func",
       "url": "https://idmnyu.github.io/p5.js-func",
       "authors": [
-        { 
+        {
           "name": "R. Luke DuBois",
-          "url": "https://lukedubois.com/" 
+          "url": "https://lukedubois.com/"
         }
       ]
     },
@@ -338,9 +338,9 @@
       "name": "p5.geolocation",
       "url": "https://github.com/bmoren/p5.geolocation",
       "authors": [
-        { 
+        {
           "name": "Ben Moren",
-          "url": "https://www.benmoren.com/" 
+          "url": "https://www.benmoren.com/"
         }
       ]
     },
@@ -348,9 +348,9 @@
       "name": "p5.gibber",
       "url": "https://charlie-roberts.com/gibber/p5-gibber/",
       "authors": [
-        { 
+        {
           "name": "Charlie Roberts",
-          "url": "https://charlie-roberts.com" 
+          "url": "https://charlie-roberts.com"
         }
       ]
     },
@@ -358,9 +358,9 @@
       "name": "p5.glitch",
       "url": "https://p5.glitch.me/",
       "authors": [
-        { 
+        {
           "name": "Ted Davis",
-          "url": "https://teddavis.org" 
+          "url": "https://teddavis.org"
         }
       ]
     },
@@ -368,9 +368,9 @@
       "name": "p5.input",
       "url": "https://github.com/Buggem/processing.input/blob/main/p5.input.js",
       "authors": [
-        { 
+        {
           "name": "Max Parry",
-          "url": "https://github.com/Buggem/" 
+          "url": "https://github.com/Buggem/"
         }
       ]
     },
@@ -378,9 +378,9 @@
       "name": "p5.gui",
       "url": "https://github.com/bitcraftlab/p5.gui",
       "authors": [
-        { 
+        {
           "name": "Martin Schneider",
-          "url": "https://www.bitcraftlab.com/" 
+          "url": "https://www.bitcraftlab.com/"
         }
       ]
     },
@@ -388,9 +388,9 @@
       "name": "p5.j5",
       "url": "https://github.com/monteslu/p5.j5",
       "authors": [
-        { 
+        {
           "name": "Luis Montes",
-          "url": "https://twitter.com/monteslu" 
+          "url": "https://twitter.com/monteslu"
         }
       ]
     },
@@ -398,9 +398,9 @@
       "name": "p5.jacdac",
       "url": "https://microsoft.github.io/jacdac-docs/clients/javascript/p5js/ ",
       "authors": [
-        { 
+        {
           "name": "Jonathan de Halleux",
-          "url": "https://twitter.com/pelikhan" 
+          "url": "https://twitter.com/pelikhan"
         }
       ]
     },
@@ -408,9 +408,9 @@
       "name": "p5.joystick",
       "url": "https://github.com/Vamoss/p5.joystick",
       "authors": [
-        { 
+        {
           "name": "Vamoss",
-          "url": "https://vamoss.com.br" 
+          "url": "https://vamoss.com.br"
         }
       ]
     },
@@ -418,9 +418,9 @@
       "name": "p5.localmessage",
       "url": "https://github.com/bmoren/p5.localmessage",
       "authors": [
-        { 
+        {
           "name": "Ben Moren",
-          "url": "https://benmoren.com" 
+          "url": "https://benmoren.com"
         }
       ]
     },
@@ -428,9 +428,9 @@
       "name": "p5.mapper",
       "url": "https://github.com/jdeboi/p5.mapper",
       "authors": [
-        { 
+        {
           "name": "Jenna deBoisblanc",
-          "url": "https://jdeboi.com/" 
+          "url": "https://jdeboi.com/"
         }
       ]
     },
@@ -438,9 +438,9 @@
       "name": "p5.math.js",
       "url": "https://editor.p5js.org/bharathsatheesan7a/sketches/NHvinWyye",
       "authors": [
-        { 
+        {
           "name": "Bharath Satheesan",
-          "url": "https://github.com/bharathsatheesan" 
+          "url": "https://github.com/bharathsatheesan"
         }
       ]
     },
@@ -448,9 +448,9 @@
       "name": "p5.particle",
       "url": "https://github.com/bobcgausa/cook-js",
       "authors": [
-        { 
+        {
           "name": "Robert Cook",
-          "url": "http://professorcook.org/" 
+          "url": "http://professorcook.org/"
         }
       ]
     },
@@ -458,9 +458,9 @@
       "name": "p5.party",
       "url": "https://github.com/jbakse/p5.party",
       "authors": [
-        { 
+        {
           "name": "Justin Bakse",
-          "url": "http://justinbakse.com" 
+          "url": "http://justinbakse.com"
         }
       ]
     },
@@ -468,9 +468,9 @@
       "name": "p5.PatGrad",
       "url": "https://github.com/antiboredom/p5.patgrad",
       "authors": [
-        { 
+        {
           "name": "Sam Lavigne",
-          "url": "https://lav.io" 
+          "url": "https://lav.io"
         }
       ]
     },
@@ -478,19 +478,19 @@
       "name": "p5.pattern",
       "url": "https://github.com/SYM380/p5.pattern",
       "authors": [
-        { 
+        {
           "name": "Taichi Sayama",
-          "url": "https://twitter.com/hyappy717" 
+          "url": "https://twitter.com/hyappy717"
         }
       ]
     },
     {
       "name": "p5.play",
-      "url": "http://p5play.molleindustria.org",
+      "url": "https://p5play.org/",
       "authors": [
-        { 
+        {
           "name": "Paolo Pedercini",
-          "url": "https://www.molleindustria.org/" 
+          "url": "https://www.molleindustria.org/"
         }
       ]
     },
@@ -498,9 +498,9 @@
       "name": "p5.Polar",
       "url": "https://github.com/liz-peng/p5.Polar",
       "authors": [
-        { 
+        {
           "name": "Liz Peng",
-          "url": "https://github.com/liz-peng" 
+          "url": "https://github.com/liz-peng"
         }
       ]
     },
@@ -508,9 +508,9 @@
       "name": "p5.projection",
       "url": "https://osresearch.github.io/p5.projection/",
       "authors": [
-        { 
+        {
           "name": "Trammell Hudson",
-          "url": "https://trmm.net/" 
+          "url": "https://trmm.net/"
         }
       ]
     },
@@ -518,9 +518,9 @@
       "name": "p5.quadrille.js",
       "url": "https://objetos.github.io/p5.quadrille.js/",
       "authors": [
-        { 
+        {
           "name": "Jean Pierre Charalambos",
-          "url": "https://github.com/nakednous" 
+          "url": "https://github.com/nakednous"
         }
       ]
     },
@@ -528,9 +528,9 @@
       "name": "p5.recorder",
       "url": "https://github.com/doriclaudino/p5.recorder",
       "authors": [
-        { 
+        {
           "name": "Dori Claudino",
-          "url": "https://github.com/doriclaudino" 
+          "url": "https://github.com/doriclaudino"
         }
       ]
     },
@@ -538,23 +538,23 @@
       "name": "p5.Riso",
       "url": "https://antiboredom.github.io/p5.riso",
       "authors": [
-        { 
+        {
           "name": "Sam Lavigne",
-          "url": "https://lav.io/" 
+          "url": "https://lav.io/"
         },
-        { 
+        {
           "name": "Tega Brain",
-          "url": "https://tegabrain.com/" 
+          "url": "https://tegabrain.com/"
         }
       ]
-    },    
+    },
     {
       "name": "p5.scenemanager",
       "url": "https://github.com/mveteanu/p5.SceneManager",
       "authors": [
-        { 
+        {
           "name": "Marian Veteanu",
-          "url": "https://github.com/mveteanu/" 
+          "url": "https://github.com/mveteanu/"
         }
       ]
     },
@@ -562,9 +562,9 @@
       "name": "p5.screenPosition",
       "url": "https://github.com/bohnacker/p5js-screenPosition",
       "authors": [
-        { 
+        {
           "name": "Hartmut Bohnacker",
-          "url": "https://hartmut-bohnacker.de/" 
+          "url": "https://hartmut-bohnacker.de/"
         }
       ]
     },
@@ -572,9 +572,9 @@
       "name": "p5.scribble",
       "url": "https://github.com/generative-light/p5.scribble.js",
       "authors": [
-        { 
+        {
           "name": "handy",
-          "url": "https://github.com/gicentre/handy" 
+          "url": "https://github.com/gicentre/handy"
         }
       ]
     },
@@ -582,17 +582,17 @@
       "name": "p5.serialport",
       "url": "https://github.com/vanevery/p5.serialport",
       "authors": [
-        { 
+        {
           "name": "Shawn Van Every",
-          "url": "https://www.walking-productions.com/notslop/abou/" 
+          "url": "https://www.walking-productions.com/notslop/abou/"
         },
-        { 
+        {
           "name": "Jen Kagan",
-          "url": "https://kaganjd.github.io/portfolio/" 
+          "url": "https://kaganjd.github.io/portfolio/"
         },
-        { 
+        {
           "name": "Tom Igoe",
-          "url": "https://tigoe.net/" 
+          "url": "https://tigoe.net/"
         }
       ]
     },
@@ -600,9 +600,9 @@
       "name": "p5.shape.js",
       "url": "https://github.com/gaba5/p5.shape.js",
       "authors": [
-        { 
+        {
           "name": "Sebastien Lorentz",
-          "url": "https://github.com/gaba5" 
+          "url": "https://github.com/gaba5"
         }
       ]
     },
@@ -610,9 +610,9 @@
       "name": "P5.slides",
       "url": "https://github.com/GarrettMFlynn/p5.js-slides",
       "authors": [
-        { 
+        {
           "name": "Garrett Flynn",
-          "url": "http://garrettflynn.com/" 
+          "url": "http://garrettflynn.com/"
         }
       ]
     },
@@ -620,9 +620,9 @@
       "name": "p5.speech",
       "url": "https://idmnyu.github.io/p5.js-speech/",
       "authors": [
-        { 
+        {
           "name": "R. Luke DuBois",
-          "url": "https://lukedubois.com/" 
+          "url": "https://lukedubois.com/"
         }
       ]
     },
@@ -630,9 +630,9 @@
       "name": "p5.start2d.js",
       "url": "https://github.com/eltapir/p5.start2d.js",
       "authors": [
-        { 
+        {
           "name": "Kris HEYSE",
-          "url": "https://github.com/eltapir" 
+          "url": "https://github.com/eltapir"
         }
       ]
     },
@@ -640,9 +640,9 @@
       "name": "p5.teach",
       "url": "https://github.com/two-ticks/p5.teach.js",
       "authors": [
-        { 
+        {
           "name": "Aditya Siddheshwar",
-          "url": "https://www.linkedin.com/in/aditya-siddheshwar/" 
+          "url": "https://www.linkedin.com/in/aditya-siddheshwar/"
         }
       ]
     },
@@ -650,9 +650,9 @@
       "name": "p5.tiledmap",
       "url": "https://github.com/linux-man/p5.tiledmap",
       "authors": [
-        { 
+        {
           "name": "Caldas Lopes",
-          "url": "https://softlab.pt/" 
+          "url": "https://softlab.pt/"
         }
       ]
     },
@@ -660,9 +660,9 @@
       "name": "p5.timer",
       "url": "https://github.com/scottkildall/p5.timer",
       "authors": [
-        { 
+        {
           "name": "Scott Kildall",
-          "url": "https://www.kildall.com" 
+          "url": "https://www.kildall.com"
         }
       ]
     },
@@ -670,9 +670,9 @@
       "name": "p5.touchgui",
       "url": "https://github.com/L05/p5.touchgui",
       "authors": [
-        { 
+        {
           "name": "Carlos L05 Garcia",
-          "url": "https://L05.is" 
+          "url": "https://L05.is"
         }
       ]
     },
@@ -680,9 +680,9 @@
       "name": "p5.tween",
       "url": "https://github.com/Milchreis/p5.tween",
       "authors": [
-        { 
+        {
           "name": "Nick Müller",
-          "url": "https://github.com/Milchreis" 
+          "url": "https://github.com/Milchreis"
         }
       ]
     },
@@ -690,9 +690,9 @@
       "name": "p5.utils",
       "url": "https://github.com/alptugan/p5.utils",
       "authors": [
-        { 
+        {
           "name": "ALP TUĞAN",
-          "url": "https://www.alptugan.com" 
+          "url": "https://www.alptugan.com"
         }
       ]
     },
@@ -700,9 +700,9 @@
       "name": "p5.videorecorder",
       "url": "https://github.com/calebfoss/p5.videorecorder",
       "authors": [
-        { 
+        {
           "name": "Caleb Foss",
-          "url": "https://www.calebfoss.com/" 
+          "url": "https://www.calebfoss.com/"
         }
       ]
     },
@@ -710,9 +710,9 @@
       "name": "p5.voronoi",
       "url": "https://github.com/Dozed12/p5.voronoi",
       "authors": [
-        { 
+        {
           "name": "Francisco Moreira",
-          "url": "https://github.com/Dozed12" 
+          "url": "https://github.com/Dozed12"
         }
       ]
     },
@@ -720,9 +720,9 @@
       "name": "p5.wasm",
       "url": "https://github.com/limzykenneth/p5.wasm",
       "authors": [
-        { 
+        {
           "name": "Kenneth Lim",
-          "url": "https://github.com/limzykenneth" 
+          "url": "https://github.com/limzykenneth"
         }
       ]
     },
@@ -730,9 +730,9 @@
       "name": "p5.wasm.core",
       "url": "https://github.com/ars2062/p5-wasm",
       "authors": [
-        { 
+        {
           "name": "Arshia Moghaddam",
-          "url": "https://github.com/ars2062" 
+          "url": "https://github.com/ars2062"
         }
       ]
     },
@@ -740,9 +740,9 @@
       "name": "p5.webserial",
       "url": "https://github.com/gohai/p5.webserial/",
       "authors": [
-        { 
+        {
           "name": "Gottfried Haider",
-          "url": "https://github.com/gohai/" 
+          "url": "https://github.com/gohai/"
         }
       ]
     },
@@ -750,9 +750,9 @@
       "name": "p5.web-serial",
       "url": "https://github.com/ongzzzzzz/p5.web-serial",
       "authors": [
-        { 
+        {
           "name": "Ong Zhi Zheng",
-          "url": "https://ongzz.ml" 
+          "url": "https://ongzz.ml"
         }
       ]
     },
@@ -760,9 +760,9 @@
       "name": "p5.xr",
       "url": "https://p5xr.org/#/",
       "authors": [
-        { 
+        {
           "name": "Stalgia Grigg",
-          "url": "https://www.stalgiagrigg.name/" 
+          "url": "https://www.stalgiagrigg.name/"
         }
       ]
     },
@@ -770,9 +770,9 @@
       "name": "pdl.library",
       "url": "https://github.com/phywand/pdl-library/",
       "authors": [
-        { 
+        {
           "name": "Ian Lawrence",
-          "url": "https://slowthinkingphysics.net" 
+          "url": "https://slowthinkingphysics.net"
         }
       ]
     },
@@ -780,9 +780,9 @@
       "name": "react-p5",
       "url": "https://github.com/Gherciu/react-p5",
       "authors": [
-        { 
+        {
           "name": "Gherciu Gheorghe",
-          "url": "https://gherciu.github.io/" 
+          "url": "https://gherciu.github.io/"
         }
       ]
     },
@@ -790,9 +790,9 @@
       "name": "rita.js",
       "url": "https://rednoise.org/rita",
       "authors": [
-        { 
+        {
           "name": "Daniel C. Howe",
-          "url": "https://rednoise.org/daniel" 
+          "url": "https://rednoise.org/daniel"
         }
       ]
     },
@@ -800,9 +800,9 @@
       "name": "Rotating knobs",
       "url": "https://codeforartists.com/RotatingKnobMaker",
       "authors": [
-        { 
+        {
           "name": "Miles DeCoster",
-          "url": "https://codeforartists.com" 
+          "url": "https://codeforartists.com"
         }
       ]
     },
@@ -810,19 +810,19 @@
       "name": "Shape5",
       "url": "https://github.com/pfe1223/Shape5js",
       "authors": [
-        { 
+        {
           "name": "Patrick Ester",
-          "url": "https://github.com/pfe1223" 
+          "url": "https://github.com/pfe1223"
         }
       ]
     },
-     {
+    {
       "name": "simple.js",
       "url": "https://github.com/makeyourownalgorithmicart/simple.js/wiki",
       "authors": [
-        { 
+        {
           "name": "Tariq Rashid",
-          "url": "https://github.com/makeyourownalgorithmicart/simple.js/wiki" 
+          "url": "https://github.com/makeyourownalgorithmicart/simple.js/wiki"
         }
       ]
     },
@@ -830,9 +830,9 @@
       "name": "TiledPlay",
       "url": "https://github.com/andrewtacon/p5.tiledplay.js",
       "authors": [
-        { 
+        {
           "name": "Andrew Tacon",
-          "url": "https://github.com/andrewtacon" 
+          "url": "https://github.com/andrewtacon"
         }
       ]
     },
@@ -840,9 +840,9 @@
       "name": "tramontana",
       "url": "https://www.tramontana.xyz",
       "authors": [
-        { 
+        {
           "name": "Pierluigi Dalla Rosa",
-          "url": "https://www.pierdr.com" 
+          "url": "https://www.pierdr.com"
         }
       ]
     },
@@ -850,9 +850,9 @@
       "name": "TurtleGFX",
       "url": "https://github.com/CodeGuppyPrograms/TurtleGFX",
       "authors": [
-        { 
+        {
           "name": "CodeGuppy",
-          "url": "https://codeguppy.com" 
+          "url": "https://codeguppy.com"
         }
       ]
     },
@@ -860,9 +860,9 @@
       "name": "vida",
       "url": "https://tetoki.eu/vida",
       "authors": [
-        { 
+        {
           "name": "Pawel Janicki",
-          "url": "https://paweljanicki.jp" 
+          "url": "https://paweljanicki.jp"
         }
       ]
     },
@@ -870,9 +870,9 @@
       "name": "WEBMIDI.js",
       "url": "https://webmidijs.org/",
       "authors": [
-        { 
+        {
           "name": "Jean-Philippe Côté",
-          "url": "https://djip.co" 
+          "url": "https://djip.co"
         }
       ]
     }


### PR DESCRIPTION
Fixes #1320 

 Changes: 
Updated outdated link in libraries.json
Before: "url": "http://p5play.molleindustria.org",
After: "url": "http://p5play.org",

 Screenshots of the change: 
![issues1320](https://user-images.githubusercontent.com/46962159/218314043-f2b8fa2c-8efb-4a43-a658-6b88b66a64ac.png)

