### PR TITLE
translated bezierDetail reference page

### DIFF
--- a/src/data/reference/es.json
+++ b/src/data/reference/es.json
@@ -538,11 +538,11 @@
     },
     "bezierDetail": {
       "description": [
-        "Sets the resolution at which Bezier's curve is displayed. The default value is 20.",
-        "Note, This function is only useful when using the WEBGL renderer as the default canvas renderer does not use this information."
+        "Ajusta la resolución a la que se muestran las curvas de Bezier. Su valor por defecto es 20.",
+        "Nota: esta función sólo tiene efecto cuando se usa el renderizador WEBGL debido a que el renderizador por defecto no utiliza esta información."
       ],
       "params": {
-        "detail": "Number: resolution of the curves"
+        "detail": "Número: resolución de las curvas"
       }
     },
     "bezierPoint": {


### PR DESCRIPTION
Address #1216

 Changes: 
Translated Description and Parameters text in bezierDetail reference.


 Screenshots of the change: 
![140223-1544](https://user-images.githubusercontent.com/64996634/218871563-4123e696-6e87-43fe-939e-cbf7959b4004.png)
