### PR TITLE
Fixes Navbar responsiveness

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -2125,12 +2125,12 @@ h2 {
 }
 
 #family {
-    position: absolute;
+    position: fixed;
     z-index: 9999;
     top: 0;
     left: 0;
     /*padding: 0.5em 2em;*/
-    width: 100%;
+    width: 100% !important;
     /* 96, 100% if fixed*/
     border-bottom: 1px solid;
     overflow: none;
@@ -2139,7 +2139,7 @@ h2 {
     -webkit-box-shadow: 0px 0px 10px #333;
     -moz-box-shadow: 0px 0px 10px #333;
     box-shadow: 0px 0px 10px #333;
-    background-color: rgba(255, 255, 255, 0.85);
+    background-color: rgba(255, 255, 255, 1);
     /* */
 }
 


### PR DESCRIPTION
Fixes #696 

 **Changes:** 
- For tablet view, the navbar had some responsiveness issues like not completely covering the complete screen width. This probably was happening due to `absolute` positioning however, its nearest positioned ancestor changes with changing screen sizes. Fixed the problem with the use of `fixed` navbar and adjusted its opacity so that it does not interfere with the body text. 

 **Screenshot of the problem:** 

![Screenshot from 2023-02-18 18-00-29](https://user-images.githubusercontent.com/99824146/219870929-4536d16a-be17-4516-9b1d-73a6252e3f82.png)

 **Screenshot after making the changes:** 

![Screenshot from 2023-02-18 19-54-10](https://user-images.githubusercontent.com/99824146/219871012-43ad2cf2-000e-4b31-bc4e-61762e832f6c.png)







