### PR TITLE
Fix: sample code url failed in the non-English Get Started page.

### DIFF
--- a/src/templates/pages/get-started/index.hbs
+++ b/src/templates/pages/get-started/index.hbs
@@ -197,7 +197,7 @@ function draw() {
       <div>{{#i18n "book1"}}{{/i18n}}</div>
 
       <script>
-        $.getJSON('../download/version.json', function(data) {
+        $.getJSON('/download/version.json', function(data) {
           $('.p5-replace').each(function() {
             var html = $(this).html().replace('[p5_version]', data.version);
             $(this).html(html);


### PR DESCRIPTION
On the non-English Get Started page, the sample code under "Using a hosted version of the p5.js library" was incorrect.
This is a version number conversion bug.

English version: https://cdn.jsdelivr.net/npm/p5@1.6.0/lib/p5.js
Non-English: https://cdn.jsdelivr.net/npm/p5@[p5_version]/lib/p5.js

Changes: 
- The reference to "version.json" should be the path from the document root as in the Download page.
