### PR TITLE
Formatted indentation with 2 spaces on examples/simulate-springs page

### DIFF
--- a/src/data/examples/en/09_Simulate/09_Springs.js
+++ b/src/data/examples/en/09_Simulate/09_Springs.js
@@ -23,8 +23,8 @@ function draw() {
   background(51);
 
   for (let i = 0; i < num; i++) {
-	springs[i].update();
-	springs[i].display();
+    springs[i].update();
+    springs[i].display();
   }
 }
 
@@ -36,7 +36,7 @@ function mousePressed() {
 
 function mouseReleased() {
   for (let i = 0; i < num; i++) {
-	springs[i].released();
+    springs[i].released();
   }
 }
 
@@ -55,94 +55,94 @@ function Spring (_x, _y, _s, _d, _m, _k_in, _others, _id) {
   this.over = false;
   this.move = false;
 
-	// Spring simulation constants
+  // Spring simulation constants
   this.mass = _m;       // Mass
-  this.k = 0.2;    // Spring constant
+  this.k = 0.2;         // Spring constant
   this.k = _k_in;
   this.damp = _d;       // Damping
   this.rest_posx = _x;  // Rest position X
   this.rest_posy = _y;  // Rest position Y
 
   // Spring simulation variables
-  //float pos = 20.0; // Position
-  this.velx = 0.0;   // X Velocity
-  this.vely = 0.0;   // Y Velocity
-  this.accel = 0;    // Acceleration
-  this.force = 0;    // Force
+  //float pos = 20.0;   // Position
+  this.velx = 0.0;      // X Velocity
+  this.vely = 0.0;      // Y Velocity
+  this.accel = 0;       // Acceleration
+  this.force = 0;       // Force
 
   this.friends = _others;
   this.id = _id;
 
   this.update = function() {
 
-	if (this.move) {
-	  this.rest_posy = mouseY;
-	  this.rest_posx = mouseX;
-	}
+    if (this.move) {
+      this.rest_posy = mouseY;
+      this.rest_posx = mouseX;
+    }
 
-	this.force = -this.k * (this.y_pos - this.rest_posy);  // f=-ky
-	this.accel = this.force / this.mass;                 // Set the acceleration, f=ma == a=f/m
-	this.vely = this.damp * (this.vely + this.accel);         // Set the velocity
-	this.y_pos = this.y_pos + this.vely;           // Updated position
-
-
-	this.force = -this.k * (this.x_pos - this.rest_posx);  // f=-ky
-	this.accel = this.force / this.mass;                 // Set the acceleration, f=ma == a=f/m
-	this.velx = this.damp * (this.velx + this.accel);         // Set the velocity
-	this.x_pos = this.x_pos + this.velx;           // Updated position
+    this.force = -this.k * (this.y_pos - this.rest_posy); // f=-ky
+    this.accel = this.force / this.mass;                  // Set the acceleration, f=ma == a=f/m
+    this.vely = this.damp * (this.vely + this.accel);     // Set the velocity
+    this.y_pos = this.y_pos + this.vely;                  // Updated position
 
 
-	if ((this.overEvent() || this.move) && !(this.otherOver()) ) {
-	  this.over = true;
-	} else {
-	    this.over = false;
-	  }
+    this.force = -this.k * (this.x_pos - this.rest_posx); // f=-ky
+    this.accel = this.force / this.mass;                  // Set the acceleration, f=ma == a=f/m
+    this.velx = this.damp * (this.velx + this.accel);     // Set the velocity
+    this.x_pos = this.x_pos + this.velx;                  // Updated position
+
+
+    if ((this.overEvent() || this.move) && !(this.otherOver()) ) {
+      this.over = true;
+    } else {
+      this.over = false;
+    }
   }
 
   // Test to see if mouse is over this spring
   this.overEvent = function() {
-	let disX = this.x_pos - mouseX;
-	let disY = this.y_pos - mouseY;
-	let dis = createVector(disX, disY);
-	if (dis.mag() < this.size / 2 ) {
-	  return true;
-	} else {
-		return false;
-	  }
+    let disX = this.x_pos - mouseX;
+    let disY = this.y_pos - mouseY;
+    let dis = createVector(disX, disY);
+    if (dis.mag() < this.size / 2 ) {
+      return true;
+    } else {
+      return false;
+    }
   }
 
   // Make sure no other springs are active
   this.otherOver = function() {
-	for (let i = 0; i < num; i++) {
-	  if (i != this.id) {
-		if (this.friends[i].over == true) {
-		  return true;
-		}
-	  }
-	}
-	return false;
+    for (let i = 0; i < num; i++) {
+      if (i != this.id) {
+        if (this.friends[i].over == true) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   this.display = function() {
-	if (this.over) {
-	  fill(153);
-	} else {
-	    fill(255);
-	  }
-	ellipse(this.x_pos, this.y_pos, this.size, this.size);
+    if (this.over) {
+      fill(153);
+    } else {
+      fill(255);
+    }
+    ellipse(this.x_pos, this.y_pos, this.size, this.size);
   }
 
   this.pressed = function() {
-	if (this.over) {
-	  this.move = true;
-	} else {
-	  this.move = false;
-	}
+    if (this.over) {
+      this.move = true;
+    } else {
+      this.move = false;
+    }
   }
 
   this.released = function() {
-	this.move = false;
-	this.rest_posx = this.y_pos;
-	this.rest_posy = this.y_pos;
+    this.move = false;
+    this.rest_posx = this.y_pos;
+    this.rest_posy = this.y_pos;
   }
 };


### PR DESCRIPTION
Fix: Inconsistent indentation (mixed Tab or Spaces)
https://p5js.org/examples/simulate-springs.html

Changes: 
- Change Indentation with 2 spaces.

 Screenshots of the change: 
 e.g.
<img width="640" alt="e.g." src="https://user-images.githubusercontent.com/958471/232874553-484a2c7d-bcd1-475c-8229-cb7a42312b9e.png">
