### PR TITLE
#1362 - Fix typo in tagline for the Spanish translation

### DIFF
--- a/src/data/es.yml
+++ b/src/data/es.yml
@@ -30,7 +30,7 @@ tagline2: la simplicidad de Processing x la flexibilidad de JavaScript
 tagline3: la intuición de Processing x el poder de JavaScript
 tagline4: la creatividad de Processing x el dinamismo de JavaScript
 tagline5: la comunidad de Processing x la comunidad de JavaScript
-tagline6: la comunidad de Processing x la comunidad de JavaScript
+tagline6: lo poder de procesamiento de Processing x el alcance de JavaScript
 tagline7: La comunidad de p5.jS se solidariza con Black Lives Matter.
 home:
   start-creating: ¡Empieza a crear con el Editor de p5!

--- a/src/data/es.yml
+++ b/src/data/es.yml
@@ -30,7 +30,7 @@ tagline2: la simplicidad de Processing x la flexibilidad de JavaScript
 tagline3: la intuición de Processing x el poder de JavaScript
 tagline4: la creatividad de Processing x el dinamismo de JavaScript
 tagline5: la comunidad de Processing x la comunidad de JavaScript
-tagline6: lo poder de procesamiento de Processing x el alcance de JavaScript
+tagline6: el poder de procesamiento de Processing x el alcance de JavaScript
 tagline7: La comunidad de p5.jS se solidariza con Black Lives Matter.
 home:
   start-creating: ¡Empieza a crear con el Editor de p5!


### PR DESCRIPTION
Fixes #1362

 Changes: 
Fixed the tagline6 that was replicated with tagline5 in the Spanish translation.