### PR TITLE
Fix: Non-English reference pages will not be translated when the lang file is delayed in loading.

### DIFF
--- a/src/templates/pages/reference/index.hbs
+++ b/src/templates/pages/reference/index.hbs
@@ -42,13 +42,21 @@ slug: reference/
       var routes = window.location.pathname.split('/');
       var lang = routes[1];
       if (langs.indexOf(lang) != -1) {
+
+        var didReferenceRendered = false
+        window.addEventListener('reference-rendered', function() {
+          console.log("rendered");
+          didReferenceRendered = true
+          if (translations) {
+            updateLanguage();
+          }
+        }, false);
+
         $.getJSON('/assets/reference/'+lang+'.json', function(data) {
           translations = data;
-
-          window.addEventListener('reference-rendered', function() {
-            console.log("rendered");
+          if (didReferenceRendered) {
             updateLanguage();
-          }, false);
+          }
         });
       }
     });


### PR DESCRIPTION
Fixes: #1366

Changes:
Added "didReferenceRendered" flag.
Translation is now done correctly regardless of whether the "reference-rendered event" or the "after language file is loaded" event occurs first.
