### PR TITLE
Show bullets in unordered lists in reference docs

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -578,6 +578,26 @@ div.reference-subgroup {
     margin-bottom: 1em;
 }
 
+#reference-page #item ul {
+    list-style: initial;
+    margin-left: 1.5em;
+}
+
+#reference-page #item .example_container li,
+#reference-page #item .params li {
+    margin-bottom: 1em;
+}
+
+#reference-page #item .example_container ul,
+#reference-page #item .params ul {
+    list-style: none;
+    margin-left: 0;
+}
+
+#reference-page #item li {
+    margin-bottom: 0.5em;
+}
+
 .description {
     clear: both;
     display: block;


### PR DESCRIPTION
Addresses https://github.com/processing/p5.js/issues/6170

### Changes
- Updates the CSS so that list items in the reference page, only in the main column and not the sidebar, and not in examples or params lists get a visible bullet and more condensed styling

### Screenshots of the change

Before:
<img width="1635" alt="Screen Shot 2023-05-30 at 4 50 20 PM" src="https://github.com/processing/p5.js-website/assets/5315059/9ddc9323-d72a-440a-ae5f-09b1e5d7e0e5">

After:
<img width="1635" alt="Screen Shot 2023-05-30 at 4 50 08 PM" src="https://github.com/processing/p5.js-website/assets/5315059/8737593c-7c3a-4f3f-b1bd-a59ac82698b4">


These other `ul` `li`s are unchanged:
<img width="804" alt="Screen Shot 2023-05-30 at 4 57 21 PM" src="https://github.com/processing/p5.js-website/assets/5315059/c0275d6d-126f-4790-b32f-f13fca7f13ef">

