### PR TITLE
Changed em tags to multiplication symbols

### DIFF
--- a/src/data/reference/en.json
+++ b/src/data/reference/en.json
@@ -1306,7 +1306,7 @@
         "<img style=\"max-width: 300px\" src=\"assets/transformation-matrix-4-4.png\" alt=\"The transformation matrix used when applyMatrix is called with 4x4 matrix\"/>"
       ],
       "params": {
-        "arr": "Array: an array of numbers - should be 6 or 16 length (2<em>3 or 4</em>4 matrix values)",
+        "arr": "Array: an array of numbers - should be 6 or 16 length (2×3 or 4×4 matrix values)",
         "a": "Number: numbers which define the 2×3 or 4x4 matrix to be multiplied",
         "b": "Number: numbers which define the 2×3 or 4x4 matrix to be multiplied",
         "c": "Number: numbers which define the 2×3 or 4x4 matrix to be multiplied",


### PR DESCRIPTION
Changes: 
Changed em tags to multiplication symbols in src/data/reference/en.json/p5/applyMatrix/params.

before:
"arr": "Array: an array of numbers - should be 6 or 16 length (2<em>3 or 4</em>4 matrix values)",

after:
"arr": "Array: an array of numbers - should be 6 or 16 length (2×3 or 4×4 matrix values)",