### PR TITLE
Added CSS styling for Language button focus state

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -157,7 +157,7 @@ textarea {
 
 #logo_image {
     position: absolute;
-    top: 0;
+    top: 0;         
 }
 
 #menu.top_menu,
@@ -2288,7 +2288,8 @@ p + img {
 }
 
 #lockup a:focus {
-    outline: 0;
+    outline: active;
+    outline-style: dotted;
 }
 
 .logo {

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -324,6 +324,7 @@ textarea {
     font-size: 25px;
     padding: 5px;
     opacity: 0;
+    cursor: default;
 }
 
 #skip-to-content:focus {

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -2899,6 +2899,13 @@ iframe {
     z-index: 5;
 }
 
+#i18n-btn a:focus {
+    color: #ed225d;
+    outline: active;
+    outline-style: dotted;
+}
+
+
 #i18n-btn a:hover {
     color: #ed225d;
 }

--- a/src/templates/layouts/default.hbs
+++ b/src/templates/layouts/default.hbs
@@ -27,7 +27,6 @@
   </head>
   <body>
 
-    <a href="#content" class="sr-only">{{#i18n "Skip-To-Content"}}{{/i18n}}</a>
     {{>i18n}}
     <!-- .container -->
     <div class="container">

--- a/src/templates/pages/index.hbs
+++ b/src/templates/pages/index.hbs
@@ -10,7 +10,7 @@ slug: /
       <form id="search" method="get" action="https://www.google.com/search">
         <input type="hidden" name="as_sitesearch" value="p5js.org">
         <input id="search_button" type="submit" aria-label="Search" class='sr-only'>
-        <input tabindex="2" id='search_field' type="text" size="20" placeholder="Search p5js.org" name="q">
+        <input id='search_field' type="text" size="20" placeholder="Search p5js.org" name="q">
         <label class="sr-only" for="search_field">Search p5js.org</label>
       </form>
 


### PR DESCRIPTION
Fixes #1372

Changes: 
The Language buttons do not have any applied focus state styling, which makes it seem like there are four or so "lost tabs" after passing the "Skip to Main Content" button. 

- I added some focus state styling to the buttons so that keyboard-navigating users can properly see where their "tab" is. 
- Added focus state to Logo img so that users understand their tab is focusing on the image.
- Removed search index from home page to mirror tabbing sequence on other pages (where Search appears later in the tabbing sequence).
- Removed the duplicate skip-to-content class in the body template.
- Added a default cursor style to "Skip to main content" button so that mouse users don't "see" the button when hovering in top left corner of page.