### PR TITLE
Reference page keyboard accessibility code block fix

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -653,7 +653,7 @@ div.reference-subgroup {
     position: relative;
     left: 1em;
     padding-top: 0;
-    margin-top: 1rem;
+    margin-top: 3rem;
     border: none;
     width: 30.5em;
     max-width: 100%;
@@ -679,6 +679,7 @@ div.reference-subgroup {
 
 .example-content .edit_space ul {
     display: flex;
+    flex-wrap: wrap-reverse;
     flex-direction: row-reverse;
     position: relative;
     pointer-events: none;
@@ -700,6 +701,12 @@ div.reference-subgroup {
     border-color: rgba(45, 123, 182, 0.25);
 }
 
+.example-content .edit_space ul li button:focus {
+    color: #2d7bb6;
+    border: 2px dotted;
+    border-color: rgba(45, 123, 182, 0.25);
+}
+
 .example-content .edit_space .edit_area {
     position: absolute;
     top: 0.5em;
@@ -711,7 +718,6 @@ div.reference-subgroup {
     padding: 1.5em 0.5em 0.5em 0.5em;
     font-size: 15pt;
 }
-
 .display_button {
     margin-bottom: 2em;
     font-family: 'Montserrat', sans-serif;
@@ -720,6 +726,17 @@ div.reference-subgroup {
     border: 1px solid rgba(45, 123, 182, 0.25);
     background: transparent;
     outline: none;
+}
+
+.sketchTabInstructions {
+    flex-grow: 1;
+    font-family: 'Montserrat', sans-serif;
+    color: #CCC;
+    font-size: 1em;
+    font-style: italic;
+    margin-left: 120px;
+    margin-right: 1em;
+    margin-top: .25em;
 }
 
 .example-content .example_container {

--- a/src/assets/js/render.js
+++ b/src/assets/js/render.js
@@ -18,8 +18,8 @@ var renderCode = function(exampleName) {
 
   function enableTab(el) {
     el.onkeydown = function(e) {
-      if (e.keyCode === 9) {
-        // tab was pressed
+      if (e.keyCode === 32 && e.shiftKey) {
+        // shift + space pressed
         // get caret position/selection
         var val = this.value,
           start = this.selectionStart,
@@ -85,9 +85,12 @@ var renderCode = function(exampleName) {
       edit_space.appendChild(edit_area);
       enableTab(edit_area);
 
-      //add buttons
+      //add buttons and tab instructions
       let button_space = document.createElement('ul');
       edit_space.appendChild(button_space);
+
+      let sketch_tab_instructions = button_space.appendChild(document.createElement('li'));
+      sketch_tab_instructions.innerHTML = 'Press shift + space to insert tab.';
 
       let copy_button = document.createElement('button');
       copy_button.value = 'copy';
@@ -133,6 +136,7 @@ var renderCode = function(exampleName) {
       };
       let edit_li = button_space.appendChild(document.createElement('li'));
       edit_li.appendChild(edit_button);
+
 
       function setMode(sketch, m) {
         if (m === 'edit') {

--- a/src/assets/js/render.js
+++ b/src/assets/js/render.js
@@ -85,12 +85,9 @@ var renderCode = function(exampleName) {
       edit_space.appendChild(edit_area);
       enableTab(edit_area);
 
-      //add buttons and tab instructions
+      //add buttons and instructions
       let button_space = document.createElement('ul');
       edit_space.appendChild(button_space);
-
-      let sketch_tab_instructions = button_space.appendChild(document.createElement('li'));
-      sketch_tab_instructions.innerHTML = 'Press shift + space to insert tab.';
 
       let copy_button = document.createElement('button');
       copy_button.value = 'copy';
@@ -137,6 +134,9 @@ var renderCode = function(exampleName) {
       let edit_li = button_space.appendChild(document.createElement('li'));
       edit_li.appendChild(edit_button);
 
+      let sketch_tab_instructions = button_space.appendChild(document.createElement('li'));
+      sketch_tab_instructions.innerHTML = 'Press Shift-Space to insert tab.';
+      sketch_tab_instructions.className = 'sketchTabInstructions';
 
       function setMode(sketch, m) {
         if (m === 'edit') {


### PR DESCRIPTION
Fixes #1372 

 Changes: 
- Changed the targeted keys for tabbing within the Reference code block examples from 'tab' to 'shift+space,' in order to allow people navigating through the page via keyboard to pass through the code blocks without getting trapped
- Added visible focus state for the edit/reset/copy buttons
- Added instructional text inside button ul for the new keys to tab

*This PR is only to fix the code examples on the Reference page-- the revisions for the Example page code samples are still under development.*