### PR TITLE
Fix/example 3d framebuffer depth

### DIFF
--- a/src/data/examples/en/20_3D/12_framebuffer_blur.js
+++ b/src/data/examples/en/20_3D/12_framebuffer_blur.js
@@ -39,7 +39,7 @@ function draw() {
   shader(blur);
   blur.setUniform('img', layer.color);
   blur.setUniform('depth', layer.depth);
-  rect(width, height);
+  rect(0, 0, width, height);
 }
 
 function windowResized() {
@@ -54,7 +54,7 @@ varying vec2 vTexCoord;
 void main() {
   vec4 positionVec4 = vec4(aPosition, 1.0);
   positionVec4.xy = positionVec4.xy * 2.0 - 1.0;
-  positionVec4.y *= -1;
+  positionVec4.y *= -1.0;
   gl_Position = positionVec4;
   vTexCoord = aTexCoord;
 }`;

--- a/src/data/examples/es/20_3D/12_framebuffer_blur.js
+++ b/src/data/examples/es/20_3D/12_framebuffer_blur.js
@@ -39,7 +39,7 @@ function draw() {
   shader(blur);
   blur.setUniform('img', layer.color);
   blur.setUniform('depth', layer.depth);
-  rect(width, height);
+  rect(0, 0, width, height);
 }
 
 function windowResized() {
@@ -54,7 +54,7 @@ varying vec2 vTexCoord;
 void main() {
   vec4 positionVec4 = vec4(aPosition, 1.0);
   positionVec4.xy = positionVec4.xy * 2.0 - 1.0;
-  positionVec4.y *= -1;
+  positionVec4.y *= -1.0;
   gl_Position = positionVec4;
   vTexCoord = aTexCoord;
 }`;

--- a/src/data/examples/hi/20_3D/12_framebuffer_blur.js
+++ b/src/data/examples/hi/20_3D/12_framebuffer_blur.js
@@ -39,7 +39,7 @@ function draw() {
   shader(blur);
   blur.setUniform('img', layer.color);
   blur.setUniform('depth', layer.depth);
-  rect(width, height);
+  rect(0, 0, width, height);
 }
 
 function windowResized() {
@@ -54,7 +54,7 @@ varying vec2 vTexCoord;
 void main() {
   vec4 positionVec4 = vec4(aPosition, 1.0);
   positionVec4.xy = positionVec4.xy * 2.0 - 1.0;
-  positionVec4.y *= -1;
+  positionVec4.y *= -1.0;
   gl_Position = positionVec4;
   vTexCoord = aTexCoord;
 }`;

--- a/src/data/examples/ko/20_3D/12_framebuffer_blur.js
+++ b/src/data/examples/ko/20_3D/12_framebuffer_blur.js
@@ -39,7 +39,7 @@ function draw() {
   shader(blur);
   blur.setUniform('img', layer.color);
   blur.setUniform('depth', layer.depth);
-  rect(width, height);
+  rect(0, 0, width, height);
 }
 
 function windowResized() {
@@ -54,7 +54,7 @@ varying vec2 vTexCoord;
 void main() {
   vec4 positionVec4 = vec4(aPosition, 1.0);
   positionVec4.xy = positionVec4.xy * 2.0 - 1.0;
-  positionVec4.y *= -1;
+  positionVec4.y *= -1.0;
   gl_Position = positionVec4;
   vTexCoord = aTexCoord;
 }`;

--- a/src/data/examples/zh-Hans/20_3D/12_framebuffer_blur.js
+++ b/src/data/examples/zh-Hans/20_3D/12_framebuffer_blur.js
@@ -39,7 +39,7 @@ function draw() {
   shader(blur);
   blur.setUniform('img', layer.color);
   blur.setUniform('depth', layer.depth);
-  rect(width, height);
+  rect(0, 0, width, height);
 }
 
 function windowResized() {
@@ -54,7 +54,7 @@ varying vec2 vTexCoord;
 void main() {
   vec4 positionVec4 = vec4(aPosition, 1.0);
   positionVec4.xy = positionVec4.xy * 2.0 - 1.0;
-  positionVec4.y *= -1;
+  positionVec4.y *= -1.0;
   gl_Position = positionVec4;
   vTexCoord = aTexCoord;
 }`;


### PR DESCRIPTION
Fixes #1391
for Cause 2.

 Changes: 
Update: 12_framebuffer_blur.js for all language versions.

 Screenshots of the change: 
![スクリーンショット 2023-07-14 1 07 02](https://github.com/processing/p5.js-website/assets/958471/2533e8a6-ad27-4ba9-9c45-50674599699c)
