### PR TITLE
Add src to path for examples

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,7 @@
 
 # prevents git from converting LF to CRLF, which causes issues
 # when assembling example pages on Windows
-data/examples/**/*.js eol=lf
+src/data/examples/**/*.js eol=lf
 
 # Denote all files that are truly binary and should not be modified.
 *.ai binary


### PR DESCRIPTION
Fixes #1234 

 Changes: 
Adds src to path in .gitattributes file to set eol for examples directory.


 Screenshots of the change: 
<!-- Add screenshots depicting the changes. -->