### PR TITLE
Fixed typo in 'webglVersion' description

### DIFF
--- a/src/data/reference/en.json
+++ b/src/data/reference/en.json
@@ -983,7 +983,7 @@
     },
     "webglVersion": {
       "description": [
-        "If the sketch was created in WebGL mode, then <code>weglVersion</code> will indicate which version of WebGL it is using. It will try to create a WebGL2 canvas unless you have requested WebGL1 via <code>setAttributes({ version: 1 })</code>, and will fall back to WebGL1 if WebGL2 is not available.",
+        "If the sketch was created in WebGL mode, then <code>webglVersion</code> will indicate which version of WebGL it is using. It will try to create a WebGL2 canvas unless you have requested WebGL1 via <code>setAttributes({ version: 1 })</code>, and will fall back to WebGL1 if WebGL2 is not available.",
         "<code>webglVersion</code> will always be either <code>WEBGL2</code>, <code>WEBGL</code>, or <code>P2D</code> if not in WebGL mode."
       ]
     },


### PR DESCRIPTION
Fixed typo in 'webglVersion' description

Fixes #1393 

 Changes:  Corrected typo in line 986 from 'weglVersion' to 'webglVersion'.


 Screenshots of the change: 
![image](https://github.com/processing/p5.js-website/assets/137221902/5cdb55f2-990b-49d7-871f-3e9da2173482)