### PR TITLE
UI consistency (secondary buttons, Reference code instructional text, Community email input)

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -704,6 +704,7 @@ div.reference-subgroup {
     flex-direction: row-reverse;
     position: relative;
     pointer-events: none;
+    color: #333; 
 }
 
 .example-content .edit_space ul li button {

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -3072,6 +3072,16 @@ iframe {
     width: 13em;
 }
 
+.email-octopus-email-address:focus {
+    color: #ed225d;
+    text-decoration: none;
+    padding-bottom: 0.11em;
+    outline: none;
+    border: 0.11em dashed;
+    border-color: #ed225d;
+    transition: border 30ms linear;
+}
+
 .email-octopus-form-row-hp {
     position: absolute;
     left: -5000px;

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -729,6 +729,10 @@ div.reference-subgroup {
     border-color: rgba(45, 123, 182, 0.25);
 }
 
+.example-content .edit_space ul li button:hover{
+    background:white;
+}
+
 .example-content .edit_space .edit_area {
     position: absolute;
     top: 0.5em;


### PR DESCRIPTION
Fixes #1372 

 Changes: 
_This PR does not change any of the brand colors, even though this was of question in the linked issue._ 
- Made the secondary buttons across the Reference, Example, and Learn pages have consistent UI styling.
- Darkened instructional text in Reference page code blocks.
- Added focus state to Community email input.