### PR TITLE
Modify inline code style for references

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -664,6 +664,16 @@ div.reference-subgroup {
     color: #ed225d;
 }
 
+/* INLINE CODE IN REF */
+
+.apidocs .description code,
+.apidocs .paramtype code {
+    font-size: 0.7em;
+    background-color: #eee;
+    padding: 0.2em;
+    border-radius: 3px;
+}
+
 /* EXAMPLES IN REF */
 
 .example div {


### PR DESCRIPTION
Fixes #1395 

 Changes: 

I added the following to `src/assets/css/main.css`:

```css
/* INLINE CODE IN REF */

.apidocs .description code,
.apidocs .paramtype code {
    font-size: 0.7em;
    background-color: #eee;
    padding: 0.2em;
    border-radius: 3px;
}
```

 Screenshots of the change: 

<img width="733" alt="inline_code" src="https://github.com/processing/p5.js-website/assets/3719176/d7395096-9957-4105-b908-cfd5ef2fb7b8">