### PR TITLE
Idea: p5.min.js version query updater for example.html

### DIFF
--- a/src/data/examples/build_examples/build.js
+++ b/src/data/examples/build_examples/build.js
@@ -13,6 +13,22 @@ var outputRoot = process.argv.slice(2)[0];
 
 var spaceReg = new RegExp(' ', 'g');
 
+// update p5.min.js version query in example.html
+(function () {
+  const version = (() => {
+    const data = fs.readFileSync(path.joinSafe(__dirname, '/../../../assets/js/p5.min.js'), 'utf8');
+    const versionMatch = data.match(/\/\*! p5.js v([\d.]+) /);
+    return versionMatch[1];
+  })();
+  // console.log(`p5.min.js version: ${version}`);
+  
+  const data = fs.readFileSync(path.joinSafe(__dirname, '/../example.html'), 'utf8');
+  const updated = data.replace(/p5\.min\.js\?v=[0-9]+\.[0-9]+\.[0-9]+/g, 'p5.min.js?v=' + version);
+  // console.log(updated);
+
+  fs.writeFileSync(path.joinSafe(__dirname, '/../example.html'), updated);
+})();
+
 // build the templates
 var example_template = ejs.compile(
   fs.readFileSync(path.joinSafe(__dirname, '/example_template.ejs'), 'utf8')

--- a/src/data/examples/example.html
+++ b/src/data/examples/example.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
   <head>
-    <script type='text/javascript' src='/assets/js/p5.min.js'></script>
+    <script type='text/javascript' src='/assets/js/p5.min.js?v=1.7.0'></script>
     <script type='text/javascript' src='/assets/js/p5.sound.min.js'></script>
     <style>
       html, body {


### PR DESCRIPTION
Fixes #1391

Idea:
I have created code to update the p5.min.js version specification in example.html at build time.
The version is taken from /src/assets/js/p5.min.js.

I believe this would solve the problem of p5.min.js being cached by CloudFlare.

However, this only applies to example.html.
I have specified assets/js/p5.min.js in several other learn pages, but it will not work for those.