### PR TITLE
'Getting Stated in WebGL' section translated to hindi

### DIFF
--- a/src/data/hi.yml
+++ b/src/data/hi.yml
@@ -651,10 +651,10 @@ learn:
   getting-started-in-webgl-other-tutorials-tut3: Styling and Appearance
   getting-started-in-webgl-other-tutorials-tut4: Introduction to Shaders
   getting-started-in-webgl-other-tutorials-you-are-here: (you are here)
-  getting-started-in-webgl-title: Getting Started in WebGL
+  getting-started-in-webgl-title: WebGL में शुरूवाती कदम
   getting-started-in-webgl-glossary-title: Glossary
   getting-started-in-webgl-coords-and-transform-title: Coordinates and Transformations
-  getting-started-in-webgl-coords-and-transform: 'Basics of 3D setup, coordinates, and transformations'
+  getting-started-in-webgl-coords-and-transform: '3डी सेटअप, निर्देशांक और परिवर्तन की मूल बातें'
   getting-started-in-webgl-coords-and-transform-p1x1: >-
     p5.js is a powerful tool for creating 2D graphics but it's also capable of
     3D graphics. To get started in 3D there are some new concepts to learn and
@@ -873,8 +873,8 @@ learn:
   getting-started-in-webgl-coords-and-transform-glossary-term6-definition: 'A point in 3D space, with an x, y, z position.'
   getting-started-in-webgl-coords-and-transform-glossary-term7-title: Face
   getting-started-in-webgl-coords-and-transform-glossary-term7-definition: A collection of three points that create a solid surface.
-  getting-started-in-webgl-custom-geometry-title: Creating Custom Geometry in WebGL
-  getting-started-in-webgl-custom-geometry: Creating custom geometry in WebGL
+  getting-started-in-webgl-custom-geometry-title: WebGL में कस्टम ज्योमेट्री बनाना
+  getting-started-in-webgl-custom-geometry: WebGL में कस्टम ज्योमेट्री बनाना
   getting-started-in-webgl-custom-geometry-p1x1: >-
     p5.js has a number of basic shapes, like <a class="code">box()</a> or <a
     class="code">sphere()</a>, but p5.js is also capable of rendering complex
@@ -983,8 +983,8 @@ learn:
     calculating lighting or using materials.
   getting-started-in-webgl-custom-geometry-glossary-term7-title: Normalization
   getting-started-in-webgl-custom-geometry-glossary-term7-definition: Changing something so that it fits within a standard range.
-  getting-started-in-webgl-appearance-title: Styling and Appearance
-  getting-started-in-webgl-appearance: The basics of materials and lighting in WebGL
+  getting-started-in-webgl-appearance-title: स्टाइल और दिखावट
+  getting-started-in-webgl-appearance: WebGL में मटीरियल और लाईटिंग की मूल बातें
   getting-started-in-webgl-appearance-p0x1: >-
     Creating in 3D is about more than just geometry. Cameras, lights, and
     materials are an important part of creating a visually interesting 3D scene.
@@ -1129,8 +1129,8 @@ learn:
   getting-started-in-webgl-appearance-glossary-term7-definition: >-
     Selectively showing some geometry and not others, such as when geometry
     falls outside of the camera frustum.
-  getting-started-in-webgl-shaders-title: Introduction to Shaders
-  getting-started-in-webgl-shaders: The basics of creating shaders within p5js using WebGL
+  getting-started-in-webgl-shaders-title: शेडर्स से परिचय
+  getting-started-in-webgl-shaders: WebGL का उपयोग करके p5js के भीतर शेडर बनाने की मूल बातें
   getting-started-in-webgl-shaders-p0x1: >-
     Shaders are special programs that run on the graphics processing unit, or
     GPU, that can do some incredible things. They take advantage of the GPU to
@@ -1313,7 +1313,7 @@ learn:
   getting-started-in-webgl-shaders-glossary-term12-definition: >-
     The part of a shader program that is responsible for the color and
     appearance of each pixel output by the shader.
-  getting-started-in-webgl-framebuffers-title: Layered Rendering with Framebuffers
+  getting-started-in-webgl-framebuffers-title: फ्रेमबफर के साथ लेयरड रेन्डरिंग
   getting-started-in-webgl-framebuffers: >-
     Setting up sketches that draw in multiple stages or access 3D depth
     information.

--- a/src/data/hi.yml
+++ b/src/data/hi.yml
@@ -651,9 +651,9 @@ learn:
   getting-started-in-webgl-other-tutorials-tut3: Styling and Appearance
   getting-started-in-webgl-other-tutorials-tut4: Introduction to Shaders
   getting-started-in-webgl-other-tutorials-you-are-here: (you are here)
-  getting-started-in-webgl-title: WebGL में शुरूवाती कदम
+  getting-started-in-webgl-title: वेबजीएल में शुरूवाती कदम
   getting-started-in-webgl-glossary-title: Glossary
-  getting-started-in-webgl-coords-and-transform-title: Coordinates and Transformations
+  getting-started-in-webgl-coords-and-transform-title: कॉर्डिनेटस और र्टांसफौरमेंशन
   getting-started-in-webgl-coords-and-transform: '3डी सेटअप, निर्देशांक और परिवर्तन की मूल बातें'
   getting-started-in-webgl-coords-and-transform-p1x1: >-
     p5.js is a powerful tool for creating 2D graphics but it's also capable of
@@ -873,8 +873,8 @@ learn:
   getting-started-in-webgl-coords-and-transform-glossary-term6-definition: 'A point in 3D space, with an x, y, z position.'
   getting-started-in-webgl-coords-and-transform-glossary-term7-title: Face
   getting-started-in-webgl-coords-and-transform-glossary-term7-definition: A collection of three points that create a solid surface.
-  getting-started-in-webgl-custom-geometry-title: WebGL में कस्टम ज्योमेट्री बनाना
-  getting-started-in-webgl-custom-geometry: WebGL में कस्टम ज्योमेट्री बनाना
+  getting-started-in-webgl-custom-geometry-title: वेबजीएल में कस्टम ज्योमेट्री बनाना
+  getting-started-in-webgl-custom-geometry: वेबजीएल में कस्टम ज्योमेट्री बनाना
   getting-started-in-webgl-custom-geometry-p1x1: >-
     p5.js has a number of basic shapes, like <a class="code">box()</a> or <a
     class="code">sphere()</a>, but p5.js is also capable of rendering complex
@@ -984,7 +984,7 @@ learn:
   getting-started-in-webgl-custom-geometry-glossary-term7-title: Normalization
   getting-started-in-webgl-custom-geometry-glossary-term7-definition: Changing something so that it fits within a standard range.
   getting-started-in-webgl-appearance-title: स्टाइल और दिखावट
-  getting-started-in-webgl-appearance: WebGL में मटीरियल और लाईटिंग की मूल बातें
+  getting-started-in-webgl-appearance: वेबजीएल में मटीरियल और लाईटिंग की मूल बातें
   getting-started-in-webgl-appearance-p0x1: >-
     Creating in 3D is about more than just geometry. Cameras, lights, and
     materials are an important part of creating a visually interesting 3D scene.
@@ -1130,7 +1130,7 @@ learn:
     Selectively showing some geometry and not others, such as when geometry
     falls outside of the camera frustum.
   getting-started-in-webgl-shaders-title: शेडर्स से परिचय
-  getting-started-in-webgl-shaders: WebGL का उपयोग करके p5js के भीतर शेडर बनाने की मूल बातें
+  getting-started-in-webgl-shaders: वेबजीएल का उपयोग करके p5js के भीतर शेडर बनाने की मूल बातें
   getting-started-in-webgl-shaders-p0x1: >-
     Shaders are special programs that run on the graphics processing unit, or
     GPU, that can do some incredible things. They take advantage of the GPU to
@@ -1315,8 +1315,7 @@ learn:
     appearance of each pixel output by the shader.
   getting-started-in-webgl-framebuffers-title: फ्रेमबफर के साथ लेयरड रेन्डरिंग
   getting-started-in-webgl-framebuffers: >-
-    Setting up sketches that draw in multiple stages or access 3D depth
-    information.
+    कई चरणों में सकेचिज़ तैयार करना या 3डी जानकारी तक पहुंच बनाना।
   color-title: रंग
   color: डिजिटल रंग के लिए एक परिचय।
   coordinate-system-and-shapes-title: समन्वय प्रणाली और आकृतियाँ


### PR DESCRIPTION
Fixes #1431 

 Changes: 
I added the Hindi translation to the learn page on the 'Getting started with WebGL' section. The section and its sub-heading were not transalted to hindi.


 Screenshots of the change: 
Before:
<img width="920" alt="Screenshot 2023-11-04 150524" src="https://github.com/processing/p5.js-website/assets/140689703/7a50cbe1-8413-408c-8cc0-de5ba8e496b4">
After Changes:
<img width="857" alt="Screenshot 2023-11-04 150544" src="https://github.com/processing/p5.js-website/assets/140689703/ae504087-3840-4474-be7a-c8439170795f">
