### PR TITLE
Fixes #1411: Bezier reference for the Spanish translation

### DIFF
--- a/src/data/reference/es.json
+++ b/src/data/reference/es.json
@@ -526,16 +526,16 @@
       "params": {
         "x1": "Número: coordenada x del primer punto ancla",
         "y1": "Número: coordenada y del primer punto ancla",
-        "x2": "Número: coordenada y del primer punto de control",
-        "y2": "Número: coordenada x del segundo punto de control",
-        "x3": "Número: coordenada x del segundo punto ancla",
-        "y3": "Número: coordenada y del segundo punto ancla",
-        "x4": "Número: coordenada z del primer punto de control",
-        "y4": "Número: coordenada z del segundo punto ancla",
-        "z1": "Número: coordenada x del primer punto de control",
-        "z2": "Número: coordenada y del segundo punto de control",
-        "z3": "Número: coordenada z del primer punto ancla",
-        "z4": "Número: coordenada z del segundo punto de control"
+        "x2": "Número: coordenada x del primer punto de control",
+        "y2": "Número: coordenada y del primer punto de control",
+        "x3": "Número: coordenada x del segundo punto de control",
+        "y3": "Número: coordenada y del segundo punto de control",
+        "x4": "Número: coordenada x del segundo punto ancla",
+        "y4": "Número: coordenada y del segundo punto ancla",
+        "z1": "Número: coordenada z del primer punto ancla",
+        "z2": "Número: coordenada z del primer punto de control",
+        "z3": "Número: coordenada z del segundo punto de control",
+        "z4": "Número: coordenada z del segundo punto ancla"
       }
     },
     "bezierDetail": {


### PR DESCRIPTION
Fixes #1411

 Changes: 
Fixed the references for the x, y and z values based on the original English version

 Screenshots of the change: 
N/A