### PR TITLE
docs: fixed URL in get-started page

### DIFF
--- a/src/data/en.yml
+++ b/src/data/en.yml
@@ -143,7 +143,7 @@ get started:
     file manager or type:
   environment12: 'file:///the/file/path/to/your/html'
   environment14: ' (or '
-  environment15: 'http://localhost:{your-port-num}/empty-example'
+  environment15: 'http://localhost:{your-port-num}/index.html'
   environment16: ' if you are using a local server)'
   environment13: ' in the address bar to view your sketch.'
   your-first-sketch-title: Your First Sketch


### PR DESCRIPTION
Fixes #1459

**


Changes:** 
```
http://localhost:{your-port-num}/empty-example -> http://localhost:{your-port-num}/index.html

```

**Working**
![Screenshot from 2023-12-02 13-16-47](https://github.com/processing/p5.js-website/assets/98346896/66d932f7-523f-4a25-8340-6b81d2f11fbb)

**Not Working**
![Screenshot from 2023-12-02 13-16-52](https://github.com/processing/p5.js-website/assets/98346896/01275f39-99a2-487c-96e3-1acf2b3ec93f)