### PR TITLE
Added the Missing Links

### DIFF
--- a/src/data/examples/en/09_Simulate/15_penrose_tiles.js
+++ b/src/data/examples/en/09_Simulate/15_penrose_tiles.js
@@ -2,7 +2,7 @@
  * @name Penrose Tiles
  * @arialabel A penrose tile pattern is created by white rhombi being drawn on a black background
  * @frame 710,400
- * @description This is a port by David Blitz of the "Penrose Tile" example from <pre><a href="https://processing.org/examples/">processing.org/examples</a></pre>
+ * @description This is a port by David Blitz of the "Penrose Tile" example from <a href="https://processing.org/examples/">processing.org/examples</a>
  */
 
 let ds;

--- a/src/data/examples/en/09_Simulate/15_penrose_tiles.js
+++ b/src/data/examples/en/09_Simulate/15_penrose_tiles.js
@@ -2,7 +2,7 @@
  * @name Penrose Tiles
  * @arialabel A penrose tile pattern is created by white rhombi being drawn on a black background
  * @frame 710,400
- * @description This is a port by David Blitz of the "Penrose Tile" example from processing.org/examples
+ * @description This is a port by David Blitz of the "Penrose Tile" example from <pre><a href="https://processing.org/examples/">processing.org/examples</a></pre>
  */
 
 let ds;

--- a/src/data/examples/en/10_Interaction/28_ArduinoSensor.js
+++ b/src/data/examples/en/10_Interaction/28_ArduinoSensor.js
@@ -3,17 +3,17 @@
  * @description WebJack is a way to read data from an Arduino (and other sources)
  * using audio -- it basically turns your Arduino into an audio modem.
  * 
- * <pre><a href = "https://github.com/publiclab/webjack">https://github.com/publiclab/webjack</a><pre>
+ * <pre><a href = "https://github.com/publiclab/webjack">https://github.com/publiclab/webjack</a></pre>
  * 
  * Note: WebJack and p5-webjack libraries must be added to your index.html as follows:
  * <pre><code class="language-markup">&lt;script src="https://webjack.io/dist/webjack.js">&lt;/script></code></pre>
  * <pre><code class="language-markup">&lt;script src="https://jywarren.github.io/p5-webjack/lib.js">&lt;/script></code></pre>
  * 
- * Working example: https://editor.p5js.org/jywarren/sketches/rkztwSt8M
+ * Working example: <pre><a href = "https://editor.p5js.org/jywarren/sketches/rkztwSt8M">https://editor.p5js.org/jywarren/sketches/rkztwSt8M</a></pre>
  * 
- * Testing audio: https://www.youtube.com/watch?v=GtJW1Dlt3cg
+ * Testing audio: <pre><a href="https://www.youtube.com/watch?v=GtJW1Dlt3cg">https://www.youtube.com/watch?v=GtJW1Dlt3cg</a></pre>
  * Load this sketch onto an Arduino: 
- * https://create.arduino.cc/editor/jywarren/023158d8-be51-4c78-99ff-36c63126b554/preview
+ * <pre><a href="https://create.arduino.cc/editor/jywarren/023158d8-be51-4c78-99ff-36c63126b554/preview">https://create.arduino.cc/editor/jywarren/023158d8-be51-4c78-99ff-36c63126b554/preview</a></pre>
  * Arduino will output audio from pin 3 + ground. Use microphone or an audio cable.
  */
 

--- a/src/data/examples/en/10_Interaction/28_ArduinoSensor.js
+++ b/src/data/examples/en/10_Interaction/28_ArduinoSensor.js
@@ -3,17 +3,17 @@
  * @description WebJack is a way to read data from an Arduino (and other sources)
  * using audio -- it basically turns your Arduino into an audio modem.
  * 
- * <pre><a href = "https://github.com/publiclab/webjack">https://github.com/publiclab/webjack</a></pre>
+ * <a href = "https://github.com/publiclab/webjack">https://github.com/publiclab/webjack</a>
  * 
  * Note: WebJack and p5-webjack libraries must be added to your index.html as follows:
  * <pre><code class="language-markup">&lt;script src="https://webjack.io/dist/webjack.js">&lt;/script></code></pre>
  * <pre><code class="language-markup">&lt;script src="https://jywarren.github.io/p5-webjack/lib.js">&lt;/script></code></pre>
  * 
- * Working example: <pre><a href = "https://editor.p5js.org/jywarren/sketches/rkztwSt8M">https://editor.p5js.org/jywarren/sketches/rkztwSt8M</a></pre>
+ * Working example: <a href = "https://editor.p5js.org/jywarren/sketches/rkztwSt8M">https://editor.p5js.org/jywarren/sketches/rkztwSt8M</a>
  * 
- * Testing audio: <pre><a href="https://www.youtube.com/watch?v=GtJW1Dlt3cg">https://www.youtube.com/watch?v=GtJW1Dlt3cg</a></pre>
+ * Testing audio: <a href="https://www.youtube.com/watch?v=GtJW1Dlt3cg">https://www.youtube.com/watch?v=GtJW1Dlt3cg</a>
  * Load this sketch onto an Arduino: 
- * <pre><a href="https://create.arduino.cc/editor/jywarren/023158d8-be51-4c78-99ff-36c63126b554/preview">https://create.arduino.cc/editor/jywarren/023158d8-be51-4c78-99ff-36c63126b554/preview</a></pre>
+ * <a href="https://create.arduino.cc/editor/jywarren/023158d8-be51-4c78-99ff-36c63126b554/preview">https://create.arduino.cc/editor/jywarren/023158d8-be51-4c78-99ff-36c63126b554/preview</a>
  * Arduino will output audio from pin 3 + ground. Use microphone or an audio cable.
  */
 

--- a/src/data/examples/en/10_Interaction/28_ArduinoSensor.js
+++ b/src/data/examples/en/10_Interaction/28_ArduinoSensor.js
@@ -3,7 +3,7 @@
  * @description WebJack is a way to read data from an Arduino (and other sources)
  * using audio -- it basically turns your Arduino into an audio modem.
  * 
- * https://github.com/publiclab/webjack
+ * <pre><a href = "https://github.com/publiclab/webjack">https://github.com/publiclab/webjack</a><pre>
  * 
  * Note: WebJack and p5-webjack libraries must be added to your index.html as follows:
  * <pre><code class="language-markup">&lt;script src="https://webjack.io/dist/webjack.js">&lt;/script></code></pre>


### PR DESCRIPTION
Fixes #1468 

 Changes: 
Converted plain text to hyperlinks in https://p5js.org/examples/interaction-arduino-sensor-data-via-webjack.html . I found a similar issue in https://p5js.org/examples/simulate-penrose-tiles.html and fixed that too.


 Screenshots of the change: 
<img width="618" alt="Screenshot 2023-12-20 at 10 12 52 PM" src="https://github.com/processing/p5.js-website/assets/137528221/00321c5e-7797-4857-8683-5862d37dc2e9">
<img width="597" alt="Screenshot 2023-12-20 at 10 13 13 PM" src="https://github.com/processing/p5.js-website/assets/137528221/e6e66aed-4893-4820-8263-d1939603a65a">
