### PR TITLE
Update links to "Writing accessible canvas descriptions"

### DIFF
--- a/src/data/reference/en.json
+++ b/src/data/reference/en.json
@@ -78,7 +78,7 @@
         "Creates a screen reader-accessible description for the canvas.",
         "The first parameter, <code>text</code>, is the description of the canvas.",
         "The second parameter, <code>display</code>, is optional. It determines how the description is displayed. If <code>LABEL</code> is passed, as in <code>describe('A description.', LABEL)</code>, the description will be visible in a div element next to the canvas. If <code>FALLBACK</code> is passed, as in <code>describe('A description.', FALLBACK)</code>, the description will only be visible to screen readers. This is the default mode.",
-        "Read <a href=\"/learn/labeling-canvases.html\">How to label your p5.js code</a> to learn more about making sketches accessible."
+        "Read <a href=\"/learn/accessible-labels.html\">Writing accessible canvas descriptions</a> to learn more about making sketches accessible."
       ],
       "params": {
         "text": "String: description of the canvas.",
@@ -91,7 +91,7 @@
         "The first parameter, <code>name</code>, is the name of the element.",
         "The second parameter, <code>text</code>, is the description of the element.",
         "The third parameter, <code>display</code>, is optional. It determines how the description is displayed. If <code>LABEL</code> is passed, as in <code>describe('A description.', LABEL)</code>, the description will be visible in a div element next to the canvas. Using <code>LABEL</code> creates unhelpful duplicates for screen readers. Only use <code>LABEL</code> during development. If <code>FALLBACK</code> is passed, as in <code>describe('A description.', FALLBACK)</code>, the description will only be visible to screen readers. This is the default mode.",
-        "Read <a href=\"/learn/labeling-canvases.html\">How to label your p5.js code</a> to learn more about making sketches accessible."
+        "Read <a href=\"/learn/accessible-labels.html\">Writing accessible canvas descriptions</a> to learn more about making sketches accessible."
       ],
       "params": {
         "name": "String: name of the element.",
@@ -106,7 +106,7 @@
         "A list of shapes follows the general description. The list describes the color, location, and area of each shape. For example, <code>a red circle at middle covering 3% of the canvas</code>. Each shape can be selected to get more details.",
         "<code>textOutput()</code> uses its table of shapes as a list. The table describes the shape, color, location, coordinates and area. For example, <code>red circle location = middle area = 3%</code>. This is different from <a href=\"#/p5/gridOutput\">gridOutput()</a>, which uses its table as a grid.",
         "The <code>display</code> parameter is optional. It determines how the description is displayed. If <code>LABEL</code> is passed, as in <code>textOutput(LABEL)</code>, the description will be visible in a div element next to the canvas. Using <code>LABEL</code> creates unhelpful duplicates for screen readers. Only use <code>LABEL</code> during development. If <code>FALLBACK</code> is passed, as in <code>textOutput(FALLBACK)</code>, the description will only be visible to screen readers. This is the default mode.",
-        "Read <a href=\"/learn/labeling-canvases.html\">How to label your p5.js code</a> to learn more about making sketches accessible."
+        "Read <a href=\"/learn/accessible-labels.html\">Writing accessible canvas descriptions</a> to learn more about making sketches accessible."
       ],
       "params": {
         "display": "Constant: (Optional) either FALLBACK or LABEL."
@@ -119,7 +119,7 @@
         "<code>gridOutput()</code> uses its table of shapes as a grid. Each shape in the grid is placed in a cell whose row and column correspond to the shape's location on the canvas. The grid cells describe the color and type of shape at that location. For example, <code>red circle</code>. These descriptions can be selected individually to get more details. This is different from <a href=\"#/p5/textOutput\">textOutput()</a>, which uses its table as a list.",
         "A list of shapes follows the table. The list describes the color, type, location, and area of each shape. For example, <code>red circle, location = middle, area = 3 %</code>.",
         "The <code>display</code> parameter is optional. It determines how the description is displayed. If <code>LABEL</code> is passed, as in <code>gridOutput(LABEL)</code>, the description will be visible in a div element next to the canvas. Using <code>LABEL</code> creates unhelpful duplicates for screen readers. Only use <code>LABEL</code> during development. If <code>FALLBACK</code> is passed, as in <code>gridOutput(FALLBACK)</code>, the description will only be visible to screen readers. This is the default mode.",
-        "Read <a href=\"/learn/labeling-canvases.html\">How to label your p5.js code</a> to learn more about making sketches accessible."
+        "Read <a href=\"/learn/accessible-labels.html\">Writing accessible canvas descriptions</a> to learn more about making sketches accessible."
       ],
       "params": {
         "display": "Constant: (Optional) either FALLBACK or LABEL."


### PR DESCRIPTION
Fixes #1479

Changes: 
**/src/data/reference/en.json**
update 4 places.

old:
```
        "Read <a href=\"/learn/labeling-canvases.html\">How to label your p5.js code</a> to learn more about making sketches accessible."
```

new:
```
        "Read <a href=\"/learn/accessible-labels.html\">Writing accessible canvas descriptions</a> to learn more about making sketches accessible."
```

 Screenshots of the change: 
 old
![old](https://github.com/processing/p5.js-website/assets/958471/7317740f-a683-41ae-a712-419ff9db4931)

new
![new](https://github.com/processing/p5.js-website/assets/958471/1b6827c6-c6c3-4732-a593-b32866147b59)
