### PR TITLE
Fix examples with broken 

### DIFF
--- a/src/data/examples/en/20_3D/05_ray_casting.js
+++ b/src/data/examples/en/20_3D/05_ray_casting.js
@@ -10,7 +10,7 @@ let eyeZ;
 function setup() {
   createCanvas(710, 400, WEBGL);
 
-  eyeZ = height / 2 / tan((30 * PI) / 180); // The default distance the camera is away from the origin.
+  eyeZ = 800; // The default distance the camera is away from the origin.
 
   objects.push(new IntersectPlane(1, 0, 0, -100, 0, 0)); // Left wall
   objects.push(new IntersectPlane(1, 0, 0, 100, 0, 0)); // Right wall

--- a/src/data/examples/en/20_3D/07_orbit_control.js
+++ b/src/data/examples/en/20_3D/07_orbit_control.js
@@ -3,8 +3,11 @@
  * @arialabel Users can click on the screen and drag to move themselves around a 3D space. It consists of a white background with columns of purple cubes and green pyramids arched in curves. 
  * @description Orbit control allows you to drag and move around the world.
  */
+let cam;
 function setup() {
   createCanvas(710, 400, WEBGL);
+  cam = createCamera();
+  cam.setPosition(0, 0, 0);
 }
 
 function draw() {
@@ -15,7 +18,6 @@ function draw() {
   orbitControl();
 
   normalMaterial();
-  translate(0, 0, -600);
   for (let i = 0; i <= 12; i++) {
     for (let j = 0; j <= 12; j++) {
       push();

--- a/src/data/examples/es/20_3D/05_ray_casting.js
+++ b/src/data/examples/es/20_3D/05_ray_casting.js
@@ -9,7 +9,7 @@ let eyeZ;
 function setup() {
   createCanvas(710, 400, WEBGL);
 
-  eyeZ = height / 2 / tan((30 * PI) / 180); // The default distance the camera is away from the origin.
+  eyeZ = 800; // The default distance the camera is away from the origin.
 
   objects.push(new IntersectPlane(1, 0, 0, -100, 0, 0)); // Left wall
   objects.push(new IntersectPlane(1, 0, 0, 100, 0, 0)); // Right wall

--- a/src/data/examples/es/20_3D/07_orbit_control.js
+++ b/src/data/examples/es/20_3D/07_orbit_control.js
@@ -2,8 +2,11 @@
  * @name Control de órbita
  * @description El control de órbita te permite arrastrar y mover alrededor del mundo.
  */
+let cam;
 function setup() {
   createCanvas(710, 400, WEBGL);
+  cam = createCamera();
+  cam.setPosition(0, 0, 0);
 }
 
 function draw() {
@@ -14,7 +17,6 @@ function draw() {
   orbitControl();
 
   normalMaterial();
-  translate(0, 0, -600);
   for (let i = 0; i <= 12; i++) {
     for (let j = 0; j <= 12; j++) {
       push();

--- a/src/data/examples/hi/20_3D/05_ray_casting.js
+++ b/src/data/examples/hi/20_3D/05_ray_casting.js
@@ -9,7 +9,7 @@ let eyeZ;
 function setup() {
   createCanvas(710, 400, WEBGL);
 
-  eyeZ = height / 2 / tan((30 * PI) / 180); // डिफ़ॉल्ट दूरी कैमरा मूल से दूर है।
+  eyeZ = 800; // डिफ़ॉल्ट दूरी कैमरा मूल से दूर है।
 
   objects.push(new IntersectPlane(1, 0, 0, -100, 0, 0)); // बाईं दीवार
   objects.push(new IntersectPlane(1, 0, 0, 100, 0, 0)); // दाहिनी दीवार

--- a/src/data/examples/hi/20_3D/07_orbit_control.js
+++ b/src/data/examples/hi/20_3D/07_orbit_control.js
@@ -2,8 +2,11 @@
   * @name कक्षा नियंत्रण
   * @description कक्षा नियंत्रण आपको दुनिया भर में खींचने और स्थानांतरित करने की अनुमति देता है।
   */
+let cam;
 function setup() {
   createCanvas(710, 400, WEBGL);
+  cam = createCamera();
+  cam.setPosition(0, 0, 0);
 }
 
 function draw() {
@@ -14,7 +17,6 @@ function draw() {
   orbitControl();
 
   normalMaterial();
-  translate(0, 0, -600);
   for (let i = 0; i <= 12; i++) {
     for (let j = 0; j <= 12; j++) {
       push();

--- a/src/data/examples/ko/20_3D/05_ray_casting.js
+++ b/src/data/examples/ko/20_3D/05_ray_casting.js
@@ -9,7 +9,7 @@ let eyeZ;
 function setup() {
   createCanvas(710, 400, WEBGL);
 
-  eyeZ = height / 2 / tan((30 * PI) / 180); // 카메라가 원점에서 떨어진 기본 위치
+  eyeZ = 800; // 카메라가 원점에서 떨어진 기본 위치
 
   objects.push(new IntersectPlane(1, 0, 0, -100, 0, 0)); // 왼쪽 벽
   objects.push(new IntersectPlane(1, 0, 0, 100, 0, 0)); // 오른쪽 벽

--- a/src/data/examples/ko/20_3D/07_orbit_control.js
+++ b/src/data/examples/ko/20_3D/07_orbit_control.js
@@ -2,8 +2,11 @@
  * @name 궤도 제어
  * @description 궤도 제어(Orbit Control)를 사용해 월드를 드래그하거나 움직일 수 있습니다.
  */
+let cam;
 function setup() {
   createCanvas(710, 400, WEBGL);
+  cam = createCamera();
+  cam.setPosition(0, 0, 0);
 }
 
 function draw() {
@@ -14,7 +17,6 @@ function draw() {
   orbitControl();
 
   normalMaterial();
-  translate(0, 0, -600);
   for (let i = 0; i <= 12; i++) {
     for (let j = 0; j <= 12; j++) {
       push();

--- a/src/data/examples/zh-Hans/20_3D/05_ray_casting.js
+++ b/src/data/examples/zh-Hans/20_3D/05_ray_casting.js
@@ -9,7 +9,7 @@ let eyeZ;
 function setup() {
   createCanvas(710, 400, WEBGL);
 
-  eyeZ = height / 2 / tan((30 * PI) / 180); // The default distance the camera is away from the origin.
+  eyeZ = 800; // The default distance the camera is away from the origin.
 
   objects.push(new IntersectPlane(1, 0, 0, -100, 0, 0)); // Left wall
   objects.push(new IntersectPlane(1, 0, 0, 100, 0, 0)); // Right wall

--- a/src/data/examples/zh-Hans/20_3D/07_orbit_control.js
+++ b/src/data/examples/zh-Hans/20_3D/07_orbit_control.js
@@ -2,8 +2,11 @@
  * @name Orbit Control
  * @description Orbit control allows you to drag and move around the world.
  */
+let cam;
 function setup() {
   createCanvas(710, 400, WEBGL);
+  cam = createCamera();
+  cam.setPosition(0, 0, 0);
 }
 
 function draw() {
@@ -14,7 +17,6 @@ function draw() {
   orbitControl();
 
   normalMaterial();
-  translate(0, 0, -600);
   for (let i = 0; i <= 12; i++) {
     for (let j = 0; j <= 12; j++) {
       push();


### PR DESCRIPTION
Fixes https://github.com/processing/p5.js-website/issues/1505

Changes: 
- For orbit control, removes the `translate()` call, and uses a camera to place the view at the origin
- For raycasting, updates the distance from the camera to 800, the new default


Screenshots of the change: 
- Live version of the updated orbit control example: https://editor.p5js.org/davepagurek/sketches/naHUikQFf
- Live version of the updated raycasting example: https://editor.p5js.org/davepagurek/sketches/N1Z4JnGQp