### PR TITLE
Prevent points from overflowing view area if width > height in mouse signals example

### DIFF
--- a/src/data/examples/es/21_Input/08_Mouse_Signals.js
+++ b/src/data/examples/es/21_Input/08_Mouse_Signals.js
@@ -38,7 +38,7 @@ function draw() {
 
   for (let i = 1; i < width; i++) {
     stroke(255);
-    point(i, xvals[i] / 3);
+    point(i, xvals[i] * height/width / 3);
     stroke(0);
     point(i, height / 3 + yvals[i] / 3);
     stroke(255);


### PR DESCRIPTION
Before changes the mouse input example would overflow the display area if the width was > the height (notice how the top line goes below its bottom axis in the image).

<img width="735" alt="image" src="https://github.com/processing/p5.js-website/assets/30676292/83adb0f4-bfd0-47ec-8464-e5a8783d4639">

After the changes they get scaled correctly.

<img width="737" alt="image" src="https://github.com/processing/p5.js-website/assets/30676292/a790e820-dc0e-46fb-b055-2a7d8aa35354">