### PR TITLE
Update Chinese translation for bezierVertex in zh-Hans.json

### DIFF
--- a/src/data/reference/zh-Hans.json
+++ b/src/data/reference/zh-Hans.json
@@ -660,11 +660,11 @@
         "y2": "数字：第一个控制点的 y 坐标",
         "x3": "数字：第二个控制点的 x 坐标",
         "y3": "数字：第二个控制点的 y 坐标",
-        "x4": "数字：第一个锚点的 x 坐标",
-        "y4": "数字：第二个锚点的 x 坐标",
-        "z2": "Number: z-coordinate for the first control point (for WebGL mode)",
-        "z3": "Number: z-coordinate for the second control point (for WebGL mode)",
-        "z4": "Number: z-coordinate for the anchor point (for WebGL mode)"
+        "x4": "数字：锚点的 x 坐标",
+        "y4": "数字：锚点的 y 坐标",
+        "z2": "数字：第一个控制点的 z 坐标（适用于WebGL模式）",
+        "z3": "数字：第二个控制点的 z 坐标（适用于WebGL模式）",
+        "z4": "数字：锚点的 z 坐标（适用于WebGL模式）"
       }
     },
     "curveVertex": {


### PR DESCRIPTION
Fixes: [A translation issue from p5.js repo](https://github.com/processing/p5.js/issues/6962)

 Changes: 
<!-- Add here what changes were made in this pull request and if possible provide links showcasing the changes. -->
Fix the wrong translation for bezierVertex(), also translate three lines of description of the parameters from English to Chinese.

 Screenshots of the change: 
<!-- Add screenshots depicting the changes. -->
<img width="1096" alt="image" src="https://github.com/processing/p5.js-website/assets/116049361/2efc2d1d-034b-4487-9ac9-c00692373fa4">

